### PR TITLE
Replace ClosedCaptionTableViewCell with OEXClosedCaptionTableViewCell to fix crash

### DIFF
--- a/edXVideoLocker/CutomePlayer/CLPortraitOptionsView.m
+++ b/edXVideoLocker/CutomePlayer/CLPortraitOptionsView.m
@@ -44,7 +44,7 @@ static CLPortraitOptionsView * _sharedInterface = nil;
 
 - (void)addValueToArray:(NSDictionary *)dictValues
 {
-    [self.table_Values registerNib:[UINib nibWithNibName:@"ClosedCaptionTableViewCell"bundle:nil] forCellReuseIdentifier:@"CustomCell"];
+    [self.table_Values registerNib:[UINib nibWithNibName:@"OEXClosedCaptionTableViewCell"bundle:nil] forCellReuseIdentifier:@"CustomCell"];
 
     [_sharedInterface.arr_Values removeAllObjects];
     
@@ -209,7 +209,7 @@ static CLPortraitOptionsView * _sharedInterface = nil;
     OEXClosedCaptionTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"CustomCell"];
     if(cell == nil)
     {
-        [tableView registerNib:[UINib nibWithNibName:@"ClosedCaptionTableViewCell"bundle:nil] forCellReuseIdentifier:@"CustomCell"];
+        [tableView registerNib:[UINib nibWithNibName:@"OEXClosedCaptionTableViewCell"bundle:nil] forCellReuseIdentifier:@"CustomCell"];
         cell = [tableView dequeueReusableCellWithIdentifier:@"CustomCell"];
         
     }

--- a/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
+++ b/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
@@ -1314,9 +1314,9 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
     [self.view_OptionsInner addSubview:self.table_Values];
     
     
-    [self.table_Options registerNib:[UINib nibWithNibName:@"ClosedCaptionTableViewCell"bundle:nil] forCellReuseIdentifier:@"CustomCell"];
+    [self.table_Options registerNib:[UINib nibWithNibName:@"OEXClosedCaptionTableViewCell" bundle:nil] forCellReuseIdentifier:@"CustomCell"];
     
-    [self.table_Values registerNib:[UINib nibWithNibName:@"ClosedCaptionTableViewCell"bundle:nil] forCellReuseIdentifier:@"CustomCell"];
+    [self.table_Values registerNib:[UINib nibWithNibName:@"OEXClosedCaptionTableViewCell" bundle:nil] forCellReuseIdentifier:@"CustomCell"];
     
     
      self.btnCancel = [UIButton buttonWithType:UIButtonTypeCustom];


### PR DESCRIPTION

App was getting crash because in code at some places new classnames were not reflected. So I have replaced ClosedCaptionTableViewCell with OEXClosedCaptionTableViewCell to fix crash in code 
to fix crash.
JIRA:https://openedx.atlassian.net/browse/MOB-1373
@aleffert  @nasthagiri  Please review .