### PR TITLE
Reset selected Closed Caption language to fix crash

### DIFF
--- a/edXVideoLocker/CutomePlayer/CLPortraitOptionsView.m
+++ b/edXVideoLocker/CutomePlayer/CLPortraitOptionsView.m
@@ -359,6 +359,8 @@ static CLPortraitOptionsView * _sharedInterface = nil;
     NSString *strLanguage = [[NSString alloc] init];
     strLanguage = [OEXInterface getCCSelectedLanguage];
     
+    _dataInterface.selectedCCIndex= -1;
+    
     for (int i = 0 ; i < [self.arr_Values count]; i++)
     {
         if ([strLanguage isEqualToString: [self.arr_Values objectAtIndex:i]])
@@ -367,6 +369,13 @@ static CLPortraitOptionsView * _sharedInterface = nil;
             _dataInterface.selectedCCIndex = i;
             break;
         }
+    }
+    
+    if(_dataInterface.selectedCCIndex== -1){
+        
+        strLanguage=@"";
+        [OEXInterface setCCSelectedLanguage:@""];
+        
     }
 
     if ([self.selectedCCOption isEqualToString:@"0"])


### PR DESCRIPTION

App was getting crash if selected language in not available for playing video .  I reset selected Closed Caption language to fix crash if it is not available for playing video.

JIRA : https://openedx.atlassian.net/browse/MOB-1347

@aleffert  @nasthagiri  Please review .