### PR TITLE
Reset selected Closed Caption language to fix crash if it is not available for playing video.

### DIFF
--- a/edXVideoLocker/CutomePlayer/CLPortraitOptionsView.m
+++ b/edXVideoLocker/CutomePlayer/CLPortraitOptionsView.m
@@ -356,8 +356,7 @@ static CLPortraitOptionsView * _sharedInterface = nil;
 - (void)setPersistedLanguage
 {
     
-    NSString *strLanguage = [[NSString alloc] init];
-    strLanguage = [OEXInterface getCCSelectedLanguage];
+    NSString *strLanguage =[OEXInterface getCCSelectedLanguage];
     
     if(!strLanguage || [strLanguage isEqualToString:@""]){
         return ;

--- a/edXVideoLocker/CutomePlayer/CLPortraitOptionsView.m
+++ b/edXVideoLocker/CutomePlayer/CLPortraitOptionsView.m
@@ -359,12 +359,9 @@ static CLPortraitOptionsView * _sharedInterface = nil;
     NSString *strLanguage = [[NSString alloc] init];
     strLanguage = [OEXInterface getCCSelectedLanguage];
     
-    if(!strLanguage){
+    if(!strLanguage || [strLanguage isEqualToString:@""]){
         return ;
     }
-
-    _dataInterface.selectedCCIndex= -1;
-    
     for (int i = 0 ; i < [self.arr_Values count]; i++)
     {
         if ([strLanguage isEqualToString: [self.arr_Values objectAtIndex:i]])
@@ -373,15 +370,13 @@ static CLPortraitOptionsView * _sharedInterface = nil;
             _dataInterface.selectedCCIndex = i;
             break;
         }
-    }
-    
-    if(_dataInterface.selectedCCIndex== -1){
-        
-        strLanguage=@"";
-        [OEXInterface setCCSelectedLanguage:@""];
-        
+        if(i == [self.arr_Values count]-1){
+            strLanguage=@"";
+            return;
+        }
     }
 
+    
     if ([self.selectedCCOption isEqualToString:@"0"])
     {
         if ([strLanguage isEqualToString:@"Chinese"])

--- a/edXVideoLocker/CutomePlayer/CLPortraitOptionsView.m
+++ b/edXVideoLocker/CutomePlayer/CLPortraitOptionsView.m
@@ -359,6 +359,10 @@ static CLPortraitOptionsView * _sharedInterface = nil;
     NSString *strLanguage = [[NSString alloc] init];
     strLanguage = [OEXInterface getCCSelectedLanguage];
     
+    if(!strLanguage){
+        return ;
+    }
+
     _dataInterface.selectedCCIndex= -1;
     
     for (int i = 0 ; i < [self.arr_Values count]; i++)

--- a/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
+++ b/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
@@ -1033,6 +1033,8 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
         return ;
     }
     
+    _dataInterface.selectedCCIndex= -1;
+    
     for (int i = 0 ; i < [self.arr_Values count]; i++)
     {
         if ([strLanguage isEqualToString: [self.arr_Values objectAtIndex:i]])
@@ -1043,7 +1045,14 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
         }
     }
     
+    if(_dataInterface.selectedCCIndex== -1){
+        
+        strLanguage=@"";
+        [OEXInterface setCCSelectedLanguage:@""];
+        
+    }
     
+
     if ([strLanguage isEqualToString:@"Chinese"])
     {
         [self activateSubTitles:self.objTranscript.ChineseURLFilePath WithFileDownloadURL:self.objTranscript.ChineseDownloadURLString];

--- a/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
+++ b/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
@@ -1029,11 +1029,9 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
     NSString *strLanguage ;
     strLanguage = [OEXInterface getCCSelectedLanguage];
     
-    if(!strLanguage){
+    if(!strLanguage || [strLanguage isEqualToString:@""]){
         return ;
     }
-    
-    _dataInterface.selectedCCIndex= -1;
     
     for (int i = 0 ; i < [self.arr_Values count]; i++)
     {
@@ -1043,15 +1041,11 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
             _dataInterface.selectedCCIndex = i;
             break;
         }
+        if(i == [self.arr_Values count]-1){
+            strLanguage=@"";
+            return;
+        }
     }
-    
-    if(_dataInterface.selectedCCIndex== -1){
-        
-        strLanguage=@"";
-        [OEXInterface setCCSelectedLanguage:@""];
-        
-    }
-    
 
     if ([strLanguage isEqualToString:@"Chinese"])
     {

--- a/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
+++ b/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
@@ -1026,8 +1026,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
 - (void)setPersistedLanguage
 {
     [self addCCTableValues];
-    NSString *strLanguage ;
-    strLanguage = [OEXInterface getCCSelectedLanguage];
+    NSString *strLanguage =[OEXInterface getCCSelectedLanguage];
     
     if(!strLanguage || [strLanguage isEqualToString:@""]){
         return ;


### PR DESCRIPTION
App was getting crash if selected language in not available for playing video . I reset selected Closed Caption language to fix crash if it is not available for playing video.

JIRA : https://openedx.atlassian.net/browse/MOB-1347

@aleffert  @nasthagiri  Please review.