### PR TITLE
Use less hacky method to force app into portrait

### DIFF
--- a/edXVideoLocker/OEXAppDelegate.m
+++ b/edXVideoLocker/OEXAppDelegate.m
@@ -23,18 +23,6 @@
 #import "OEXGoogleSocial.h"
 #import <SEGAnalytics.h>
 
-@implementation UIViewController (rotate)
--(BOOL)shouldAutorotate {
-    return NO;
-}
-@end
-
-@implementation UINavigationController (rotate)
--(BOOL)shouldAutorotate {
-    return NO;
-}
-@end
-
 typedef void (^completionHandler)();
 
 @interface OEXAppDelegate ()
@@ -83,7 +71,7 @@ typedef void (^completionHandler)();
         [Fabric with:@[CrashlyticsKit]];
     }
 
-        return YES;
+    return YES;
 }
 
 

--- a/edXVideoLocker/edXVideoLocker-Info.plist
+++ b/edXVideoLocker/edXVideoLocker-Info.plist
@@ -100,8 +100,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>


### PR DESCRIPTION
Overriding an existing method through a category isn't guaranteed to work plus iPad support will need to us to do something else anyway.

@rohan-dhamal-clarice @jotiram please take a look
cc @nasthagiri 