### PR TITLE
Fix vertical appearance of Closed Caption

### DIFF
--- a/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
+++ b/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
@@ -788,7 +788,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
         Y_offset = bottomOffset;
     }
     
-    CGSize size = [self.subtitleLabel sizeThatFits:CGSizeMake(self.bounds.size.width*0.97, CGFLOAT_MAX)];
+    CGSize size = [self.subtitleLabel sizeThatFits:CGSizeMake(self.bounds.size.width-40.0, CGFLOAT_MAX)];
     self.subtitleLabel.bounds = ({
         CGRect bounds = self.subtitleLabel.bounds;
         bounds.size = size;

--- a/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
+++ b/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
@@ -788,7 +788,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
         Y_offset = bottomOffset;
     }
     
-    CGSize size = [self.subtitleLabel sizeThatFits:CGSizeMake(self.subtitleLabel.bounds.size.width, CGFLOAT_MAX)];
+    CGSize size = [self.subtitleLabel sizeThatFits:CGSizeMake(self.bounds.size.width*0.97, CGFLOAT_MAX)];
     self.subtitleLabel.bounds = ({
         CGRect bounds = self.subtitleLabel.bounds;
         bounds.size = size;


### PR DESCRIPTION
The frame of closed caption label on video player has been fixed so that the vertical appearance does not occur.