### PR TITLE
Remove assertion if part of the path is missing.

### DIFF
--- a/edXVideoLocker/NSArray+OEXSafeAccess.h
+++ b/edXVideoLocker/NSArray+OEXSafeAccess.h
@@ -11,8 +11,13 @@
 @interface NSArray (OEXSafeGetAccess)
 
 /// Like objectAtIndex: but return nil instead of crashing if the index is out of bounds
-/// Will still assert if the index is out of bounds in DEBUG builds.
+/// Will still assert if the index is out of bounds in DEBUG builds. See oex_objectOrNilAtIndex:
+/// if you want to ignore the nil case entirely.
 - (id)oex_safeObjectAtIndex:(NSUInteger)index;
+
+/// Like objectAtIndex: but return nil instead of crashing if the index is out of bounds
+/// See oex_objectOrNilAtIndex: if you want fail fast behavior for fetching out of bounds
+- (id)oex_safeObjectOrNilAtIndex:(NSUInteger)index;
 
 @end
 
@@ -21,10 +26,10 @@
 
 
 /// Like addObject: but won't crash if object is nil. Will still assert on DEBUG builds
-/// See safeAddObjectOrNil: if you want to ignore the nil case entirely
+/// See oex_addObjectOrNil: if you want to ignore the nil case entirely
 - (void)oex_safeAddObject:(id)object;
 
-/// Like addObject: but won't crash if object is nil. See safeAddObject: if you want fail fast
+/// Like addObject: but won't crash if object is nil. See oex_safeAddObject: if you want fail fast
 /// behavior for setting nil
 - (void)oex_safeAddObjectOrNil:(id)object;
 

--- a/edXVideoLocker/NSArray+OEXSafeAccess.m
+++ b/edXVideoLocker/NSArray+OEXSafeAccess.m
@@ -12,6 +12,10 @@
 
 - (id)oex_safeObjectAtIndex:(NSUInteger)index {
     NSAssert(index < self.count, @"Index out of bounds");
+    return [self oex_safeObjectOrNilAtIndex:index];
+}
+
+- (id)oex_safeObjectOrNilAtIndex:(NSUInteger)index {
     if(index < self.count) {
         return self[index];
     }
@@ -22,7 +26,6 @@
 
 
 @implementation NSMutableArray (OEXSafeSetAccess)
-
 
 - (void)oex_safeAddObject:(id)object {
     NSAssert(object != nil, @"Attempting to add nil to an array");

--- a/edXVideoLocker/OEXVideoSummary.m
+++ b/edXVideoLocker/OEXVideoSummary.m
@@ -107,11 +107,11 @@
 }
 
 - (OEXVideoPathEntry*)chapterPathEntry {
-    return [self.path oex_safeObjectAtIndex:0];
+    return [self.path oex_safeObjectOrNilAtIndex:0];
 }
 
 - (OEXVideoPathEntry*)sectionPathEntry {
-    return [self.path oex_safeObjectAtIndex:1];
+    return [self.path oex_safeObjectOrNilAtIndex:1];
 }
 
 @end


### PR DESCRIPTION
We're expecting some courses to have overly short paths. This was
causing a crash on some courses when doing a DEBUG build. Release builds
were fine.

@nasthagiri 