### PR TITLE
Prevent crash when no segment io key is found.

### DIFF
--- a/edXVideoLocker.xcodeproj/project.pbxproj
+++ b/edXVideoLocker.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		77B463921A30F6310083453A /* OEXAnnouncementsView.m in Sources */ = {isa = PBXBuildFile; fileRef = 77B4638E1A30F6310083453A /* OEXAnnouncementsView.m */; };
 		77B463971A30F65E0083453A /* OEXStyles.m in Sources */ = {isa = PBXBuildFile; fileRef = 77B463961A30F65E0083453A /* OEXStyles.m */; };
 		77E849B51A82BCFA004E6AA3 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 77E849B41A82BCFA004E6AA3 /* Default-568h@2x.png */; };
+		77FFAB9A1A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 77FFAB991A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.m */; };
 		890D027F1967343A002CE7EC /* OEXCourseInfoCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 890D027E1967343A002CE7EC /* OEXCourseInfoCell.m */; };
 		8F562F881A1F2D2C00320DB3 /* OEXGoogleSocial.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F562F871A1F2D2C00320DB3 /* OEXGoogleSocial.m */; };
 		8F562F8C1A1F44FC00320DB3 /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F562F8B1A1F44FC00320DB3 /* AddressBook.framework */; };
@@ -443,6 +444,9 @@
 		77B463951A30F65E0083453A /* OEXStyles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXStyles.h; sourceTree = "<group>"; };
 		77B463961A30F65E0083453A /* OEXStyles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXStyles.m; sourceTree = "<group>"; };
 		77E849B41A82BCFA004E6AA3 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
+		77FFAB981A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXSegmentAnalyticsTracker.h; sourceTree = "<group>"; };
+		77FFAB991A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXSegmentAnalyticsTracker.m; sourceTree = "<group>"; };
+		77FFAB9B1A8ABDB200F91F08 /* OEXAnalyticsTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXAnalyticsTracker.h; sourceTree = "<group>"; };
 		83FF9986B9067DBE805D8967 /* Pods-edXVideoLocker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-edXVideoLocker.debug.xcconfig"; path = "Pods/Target Support Files/Pods-edXVideoLocker/Pods-edXVideoLocker.debug.xcconfig"; sourceTree = "<group>"; };
 		890D027D1967343A002CE7EC /* OEXCourseInfoCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXCourseInfoCell.h; sourceTree = "<group>"; };
 		890D027E1967343A002CE7EC /* OEXCourseInfoCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXCourseInfoCell.m; sourceTree = "<group>"; };
@@ -801,9 +805,12 @@
 		1972E3B619BF474900085F08 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				77FFAB9B1A8ABDB200F91F08 /* OEXAnalyticsTracker.h */,
 				19DC02011A1E13AA00A874D3 /* OEXAnalyticsData.h */,
 				1940D8C91A230E25000318A3 /* OEXAnalytics.h */,
 				1940D8CA1A230E25000318A3 /* OEXAnalytics.m */,
+				77FFAB981A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.h */,
+				77FFAB991A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.m */,
 			);
 			name = Analytics;
 			sourceTree = "<group>";
@@ -1658,6 +1665,7 @@
 				BECB7B561924CA17009C77F1 /* OEXNetworkManager.m in Sources */,
 				191A002419405B91004F7902 /* OEXUserDetails.m in Sources */,
 				19DC02041A1F226300A874D3 /* OEXFindCourseTableViewCell.m in Sources */,
+				77FFAB9A1A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.m in Sources */,
 				BE45DA8919260604003BD39B /* OEXCustomTabBarViewViewController.m in Sources */,
 				19321F651961698B00B7D75C /* OEXDownloadTableCell.m in Sources */,
 				B49A390B1975919C00850002 /* OEXCustomSlider.m in Sources */,

--- a/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
+++ b/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
@@ -401,7 +401,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
 
             if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
             {
-                [OEXAnalytics trackTranscriptLanguage: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackTranscriptLanguage: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
                                        CurrentTime: [self getMoviePlayerCurrentTime]
                                           Language: strLang
                                           CourseID: _dataInterface.selectedCourseOnFront.course_id
@@ -446,7 +446,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
             {
 
                 ELog(@" did select ====== trackVideoSpeed");
-                [OEXAnalytics trackVideoSpeed: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackVideoSpeed: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
                                CurrentTime: [self getMoviePlayerCurrentTime]
                                   CourseID: _dataInterface.selectedCourseOnFront.course_id
                                    UnitURL: _dataInterface.selectedVideoUsedForAnalytics.summary.unitURL
@@ -492,7 +492,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
         [self.moviePlayer play];
       
         ELog(@" callPortraitSubtitles ====== trackVideoSpeed");
-        [OEXAnalytics trackVideoSpeed: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+        [[OEXAnalytics sharedAnalytics] trackVideoSpeed: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
                        CurrentTime: [self getMoviePlayerCurrentTime]
                           CourseID: _dataInterface.selectedCourseOnFront.course_id
                            UnitURL: _dataInterface.selectedVideoUsedForAnalytics.summary.unitURL
@@ -1375,7 +1375,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
             // Analytics Orientaion Landscape
             if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
             {
-                [OEXAnalytics trackVideoOrientation: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackVideoOrientation: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
                                         CourseID: _dataInterface.selectedCourseOnFront.course_id
                                      CurrentTime: [self getMoviePlayerCurrentTime]
                                             Mode: YES
@@ -1399,7 +1399,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
             // Analytics Orientaion Portrait
             if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
             {
-                [OEXAnalytics trackVideoOrientation: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackVideoOrientation: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
                                         CourseID: _dataInterface.selectedCourseOnFront.course_id
                                      CurrentTime: [self getMoviePlayerCurrentTime]
                                             Mode: NO
@@ -1624,7 +1624,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
 
 -(void)analyticsShowTranscript
 {
-    [OEXAnalytics trackShowTranscript:_dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+    [[OEXAnalytics sharedAnalytics] trackShowTranscript:_dataInterface.selectedVideoUsedForAnalytics.summary.videoID
                        CurrentTime:[self getMoviePlayerCurrentTime]
                           CourseID:_dataInterface.selectedCourseOnFront.course_id
                            UnitURL:_dataInterface.selectedVideoUsedForAnalytics.summary.unitURL];
@@ -1645,7 +1645,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
         // Analytics HIDE TRANSCRIPT
         if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
         {
-            [OEXAnalytics trackHideTranscript:_dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+            [[OEXAnalytics sharedAnalytics] trackHideTranscript:_dataInterface.selectedVideoUsedForAnalytics.summary.videoID
                                CurrentTime:[self getMoviePlayerCurrentTime]
                                   CourseID:_dataInterface.selectedCourseOnFront.course_id
                                    UnitURL:_dataInterface.selectedVideoUsedForAnalytics.summary.unitURL];
@@ -1728,7 +1728,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
     if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
     {
         
-        [OEXAnalytics trackVideoSeekRewind:_dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+        [[OEXAnalytics sharedAnalytics] trackVideoSeekRewind:_dataInterface.selectedVideoUsedForAnalytics.summary.videoID
                       RequestedDuration:self.stopTime - self.startTime
                                 OldTime:self.startTime
                                 NewTime:self.stopTime
@@ -1831,7 +1831,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
     if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
     {
         
-        [OEXAnalytics trackVideoSeekRewind:_dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+        [[OEXAnalytics sharedAnalytics] trackVideoSeekRewind:_dataInterface.selectedVideoUsedForAnalytics.summary.videoID
                       RequestedDuration:CLVideoSkipBackwardsDuration
                                 OldTime:OldTime
                                 NewTime:currentTime

--- a/edXVideoLocker/OEXAnalytics.h
+++ b/edXVideoLocker/OEXAnalytics.h
@@ -8,42 +8,61 @@
 
 #import <Foundation/Foundation.h>
 
+@protocol OEXAnalyticsTracker;
+
+@class OEXUserDetails;
+
+@interface OEXAnalyticsEvent : NSObject
+
+@property (copy, nonatomic) NSString* openInBrowserURL;
+@property (copy, nonatomic) NSString* courseID;
+@property (copy, nonatomic) NSString* name;
+@property (copy, nonatomic) NSString* displayName;
+
+@end
+
+
 @interface OEXAnalytics : NSObject
 
-+ (void)identifyUser:(NSString*)userID
-              Email:(NSString *)email
-           Username:(NSString *)username;
+/// Note that these are not thread safe. The expectation is that these operations only
+/// immediately when the app launches or synchronously at the start of a test.
++ (void)setSharedAnalytics:(OEXAnalytics*)analytics;
++ (instancetype)sharedAnalytics;
+- (void)addTracker:(id <OEXAnalyticsTracker>)tracker;
 
-+ (void)trackVideoLoading:(NSString *)videoId
+
+- (void)identifyUser:(OEXUserDetails*)user;
+
+- (void)trackVideoLoading:(NSString *)videoId
                 CourseID:(NSString *)courseId
                  UnitURL:(NSString *)unitUrl;
 
-+(void)trackVideoPlaying:(NSString *)videoId
+- (void)trackVideoPlaying:(NSString *)videoId
              CurrentTime:(NSTimeInterval)currentTime
                 CourseID:(NSString *)courseId
                  UnitURL:(NSString *)unitUrl;
 
-+(void)trackVideoPause:(NSString *)videoId
+- (void)trackVideoPause:(NSString *)videoId
            CurrentTime:(NSTimeInterval)currentTime
               CourseID:(NSString *)courseId
                UnitURL:(NSString *)unitUrl;
 
-+(void)trackVideoStop:(NSString *)videoId
+- (void)trackVideoStop:(NSString *)videoId
           CurrentTime:(NSTimeInterval)currentTime
              CourseID:(NSString *)courseId
               UnitURL:(NSString *)unitUrl;
 
-+(void)trackShowTranscript:(NSString *)videoId
+- (void)trackShowTranscript:(NSString *)videoId
                CurrentTime:(NSTimeInterval)currentTime
                   CourseID:(NSString *)courseId
                    UnitURL:(NSString *)unitUrl;
 
-+(void)trackHideTranscript:(NSString *)videoId
+- (void)trackHideTranscript:(NSString *)videoId
                CurrentTime:(NSTimeInterval)currentTime
                   CourseID:(NSString *)courseId
                    UnitURL:(NSString *)unitUrl;
 
-+(void)trackVideoSeekRewind:(NSString *)videoId
+- (void)trackVideoSeekRewind:(NSString *)videoId
           RequestedDuration:(NSTimeInterval)requestedDuration
                       OldTime:(NSTimeInterval)oldTime
                       NewTime:(NSTimeInterval)newTime
@@ -51,56 +70,54 @@
                       UnitURL:(NSString *)unitUrl
                    SkipType:(NSString *)skip_value;
 
-+ (void)trackVideoSpeed:(NSString *)videoId
+- (void)trackVideoSpeed:(NSString *)videoId
            CurrentTime:(double)currentTime
               CourseID:(NSString *)courseId
                UnitURL:(NSString *)unitUrl
               OldSpeed:(NSString *)oldSpeed
               NewSpeed:(NSString *)newSpeed;
 
-//NEW added
-
-+ (void)trackTranscriptLanguage:(NSString *)videoID CurrentTime:(NSTimeInterval)currentTime Language:(NSString *)language CourseID:(NSString *)courseid UnitURL:(NSString *)unitURL;
+- (void)trackTranscriptLanguage:(NSString *)videoID CurrentTime:(NSTimeInterval)currentTime Language:(NSString *)language CourseID:(NSString *)courseid UnitURL:(NSString *)unitURL;
 
 
-+ (void)trackDownloadComplete:(NSString *)videoId
+- (void)trackDownloadComplete:(NSString *)videoId
                     CourseID:(NSString *)courseId
                      UnitURL:(NSString *)unitUrl;
 
 
-+ (void)trackSectionBulkVideoDownload:(NSString *)section
+- (void)trackSectionBulkVideoDownload:(NSString *)section
                             CourseID:(NSString *)courseId
                           VideoCount:(long)count;
 
-+ (void)trackSubSectionBulkVideoDownload:(NSString *)section
+- (void)trackSubSectionBulkVideoDownload:(NSString *)section
                              Subsection:(NSString *)subsection
                                CourseID:(NSString *)courseId
                              VideoCount:(long)count;
 
-+ (void)trackSingleVideoDownload:(NSString *)videoID
+- (void)trackSingleVideoDownload:(NSString *)videoID
                        CourseID:(NSString *)courseId
                         UnitURL:(NSString *)unitUrl;
 
 
-+ (void)trackVideoOrientation:(NSString *)videoID
+- (void)trackVideoOrientation:(NSString *)videoID
                     CourseID:(NSString *)courseid
                  CurrentTime:(CGFloat)currentTime
                         Mode:(BOOL)isFullscreen
                      UnitURL:(NSString *)unitUrl;
 
-+ (void)trackUserLogin:(NSString *)method;
+- (void)trackUserLogin:(NSString *)method;
 
-+ (void)trackUserLogout;
+- (void)trackUserLogout;
 
-+ (void)screenViewsTracking:(NSString *)screenName;
+- (void)trackScreenWithName:(NSString *)screenName;
 
-+ (void)trackOpenInBrowser:(NSString *)URL;
+- (void)trackOpenInBrowser:(NSString *)URL;
 
-+ (void)trackUserDoesNotHaveAccount;
+- (void)trackUserDoesNotHaveAccount;
 
-+ (void)trackUserFindsCourses;
+- (void)trackUserFindsCourses;
 
-+ (void)resetIdentifyUser;
+- (void)clearIdentifiedUser;
 
 
 @end

--- a/edXVideoLocker/OEXAnalyticsTracker.h
+++ b/edXVideoLocker/OEXAnalyticsTracker.h
@@ -1,0 +1,23 @@
+//
+//  OEXAnalyticsTracker.h
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 2/10/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class OEXAnalyticsEvent;
+@class OEXUserDetails;
+
+@protocol OEXAnalyticsTracker <NSObject>
+
+- (void)identifyUser:(OEXUserDetails*)user;
+- (void)clearIdentifiedUser;
+
+- (void)trackEvent:(OEXAnalyticsEvent*)event forComponent:(NSString*)component withProperties:(NSDictionary*)properties;
+
+- (void)trackScreenWithName:(NSString*)screenName;
+
+@end

--- a/edXVideoLocker/OEXCourseVideoDownloadTableViewController.m
+++ b/edXVideoLocker/OEXCourseVideoDownloadTableViewController.m
@@ -167,7 +167,7 @@ typedef  enum OEXAlertType {
     }
     
     //Analytics Screen record
-    [OEXAnalytics screenViewsTracking:@"My Courses"];
+    [[OEXAnalytics sharedAnalytics] trackScreenWithName:@"My Courses"];
 
 }
 
@@ -1390,7 +1390,7 @@ typedef  enum OEXAlertType {
     // Analytics Single Video Download
     if (obj.summary.videoID)
     {
-        [OEXAnalytics trackSingleVideoDownload: obj.summary.videoID
+        [[OEXAnalytics sharedAnalytics] trackSingleVideoDownload: obj.summary.videoID
                                    CourseID: _dataInterface.selectedCourseOnFront.course_id
                                     UnitURL: _dataInterface.selectedVideoUsedForAnalytics.summary.unitURL];
     }

--- a/edXVideoLocker/OEXCustomTabBarViewViewController.m
+++ b/edXVideoLocker/OEXCustomTabBarViewViewController.m
@@ -531,7 +531,7 @@
     [self.customProgressBar setProgress:_dataInterface.totalProgress animated:YES];
     
     //Analytics Screen record
-    [OEXAnalytics screenViewsTracking:self.course.name];
+    [[OEXAnalytics sharedAnalytics] trackScreenWithName:self.course.name];
 
 }
 
@@ -757,7 +757,7 @@
             
             
             //Analytics Screen record
-            [OEXAnalytics screenViewsTracking:[NSString stringWithFormat:@"%@ - Courseware", self.course.name]];
+            [[OEXAnalytics sharedAnalytics] trackScreenWithName:[NSString stringWithFormat:@"%@ - Courseware", self.course.name]];
             
             break;
             
@@ -791,7 +791,7 @@
             }
             
             //Analytics Screen record
-            [OEXAnalytics screenViewsTracking:[NSString stringWithFormat:@"%@ - Announcements", self.course.name]];
+            [[OEXAnalytics sharedAnalytics] trackScreenWithName:[NSString stringWithFormat:@"%@ - Announcements", self.course.name]];
 
             break;
             
@@ -809,7 +809,7 @@
             [self showBrowserView:NO];
             
             //Analytics Screen record
-            [OEXAnalytics screenViewsTracking:[NSString stringWithFormat:@"%@ - Handouts", self.course.name]];
+            [[OEXAnalytics sharedAnalytics] trackScreenWithName:[NSString stringWithFormat:@"%@ - Handouts", self.course.name]];
 
             break;
             
@@ -1147,7 +1147,7 @@
     // Analytics Bulk Video Download From Section
     if (_dataInterface.selectedCourseOnFront.course_id)
     {
-        [OEXAnalytics trackSectionBulkVideoDownload: chapter.entryID
+        [[OEXAnalytics sharedAnalytics] trackSectionBulkVideoDownload: chapter.entryID
                                         CourseID: _dataInterface.selectedCourseOnFront.course_id
                                       VideoCount: [validArray count]];
         

--- a/edXVideoLocker/OEXDownloadManager.m
+++ b/edXVideoLocker/OEXDownloadManager.m
@@ -393,7 +393,7 @@ didFinishDownloadingToURL:(NSURL *)location
             
                 NSLog(@"Updating record for Downloaded Video ==>> %@ ",videoData.title);
                 
-                [OEXAnalytics trackDownloadComplete:videoData.video_id CourseID:videoData.enrollment_id UnitURL:videoData.unit_url];
+                [[OEXAnalytics sharedAnalytics] trackDownloadComplete:videoData.video_id CourseID:videoData.enrollment_id UnitURL:videoData.unit_url];
                 [self.storage completedDownloadForVideo:videoData];
             }
             

--- a/edXVideoLocker/OEXEnvironment.m
+++ b/edXVideoLocker/OEXEnvironment.m
@@ -10,11 +10,13 @@
 
 #import "OEXConfig.h"
 #import "OEXRouter.h"
+#import "OEXSegmentAnalyticsTracker.h"
 
 @interface OEXEnvironment ()
 
 @property (strong, nonatomic) OEXConfig*(^configBuilder)(void);
 @property (strong, nonatomic) OEXRouter*(^routerBuilder)(void);
+@property (strong, nonatomic) OEXAnalytics*(^analyticsBuilder)(void);
 
 @end
 
@@ -38,6 +40,14 @@
         self.routerBuilder = ^{
             return [[OEXRouter alloc] init];
         };
+        self.analyticsBuilder = ^{
+            OEXAnalytics* analytics = [[OEXAnalytics alloc] init];
+            
+            if([OEXConfig sharedConfig].segmentIOKey != nil) {
+                [analytics addTracker:[[OEXSegmentAnalyticsTracker alloc] init]];
+            }
+            return analytics;
+        };
     }
     return self;
 }
@@ -45,6 +55,7 @@
 - (void)setupEnvironment {
     [OEXConfig setSharedConfig:self.configBuilder()];
     [OEXRouter setSharedRouter:self.routerBuilder()];
+    [OEXAnalytics setSharedAnalytics:self.analyticsBuilder()];
 }
 
 @end

--- a/edXVideoLocker/OEXFrontCourseViewController.m
+++ b/edXVideoLocker/OEXFrontCourseViewController.m
@@ -132,7 +132,7 @@
 {
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[OEXConfig sharedConfig].courseSearchURL]];
     
-    [OEXAnalytics trackUserFindsCourses];
+    [[OEXAnalytics sharedAnalytics] trackUserFindsCourses];
 }
 
 - (void)hideWebview:(BOOL)hide
@@ -244,7 +244,7 @@
     [self InitializeTableCourseData];
     
     //Analytics Screen record
-    [OEXAnalytics screenViewsTracking:@"My Courses"];
+    [[OEXAnalytics sharedAnalytics] trackScreenWithName:@"My Courses"];
 
     
     [[self.dataInterface progressViews] addObject:self.customProgressBar];

--- a/edXVideoLocker/OEXGenericCourseTableViewController.m
+++ b/edXVideoLocker/OEXGenericCourseTableViewController.m
@@ -371,7 +371,7 @@ if (IS_IOS8)
     if (_dataInterface.selectedCourseOnFront.course_id)
     {
         OEXVideoPathEntry* section = [self.arr_TableCourseData oex_safeObjectAtIndex:tagValue];
-        [OEXAnalytics trackSubSectionBulkVideoDownload: self.selectedChapter.entryID
+        [[OEXAnalytics sharedAnalytics] trackSubSectionBulkVideoDownload: self.selectedChapter.entryID
                                          Subsection: section.entryID
                                            CourseID: _dataInterface.selectedCourseOnFront.course_id
                                          VideoCount: [validArray count]];

--- a/edXVideoLocker/OEXInterface.m
+++ b/edXVideoLocker/OEXInterface.m
@@ -1560,7 +1560,7 @@ static OEXInterface * _sharedInterface = nil;
             
             if (self.selectedVideoUsedForAnalytics.summary.videoID)
             {
-                [OEXAnalytics trackVideoLoading:self.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackVideoLoading:self.selectedVideoUsedForAnalytics.summary.videoID
                                     CourseID:self.selectedCourseOnFront.course_id
                                      UnitURL:self.selectedVideoUsedForAnalytics.summary.unitURL];
             }
@@ -1573,7 +1573,7 @@ static OEXInterface * _sharedInterface = nil;
             
             if (self.selectedVideoUsedForAnalytics.summary.videoID)
             {
-                [OEXAnalytics trackVideoStop:self.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackVideoStop:self.selectedVideoUsedForAnalytics.summary.videoID
                               CurrentTime:currentTime
                                  CourseID:self.selectedCourseOnFront.course_id
                                   UnitURL:self.selectedVideoUsedForAnalytics.summary.unitURL];
@@ -1587,7 +1587,7 @@ static OEXInterface * _sharedInterface = nil;
             
             if (self.selectedVideoUsedForAnalytics.summary.videoID)
             {
-                [OEXAnalytics trackVideoPlaying:self.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackVideoPlaying:self.selectedVideoUsedForAnalytics.summary.videoID
                                  CurrentTime:currentTime
                                     CourseID:self.selectedCourseOnFront.course_id
                                      UnitURL:self.selectedVideoUsedForAnalytics.summary.unitURL];
@@ -1602,7 +1602,7 @@ static OEXInterface * _sharedInterface = nil;
             if (self.selectedVideoUsedForAnalytics.summary.videoID)
             {
                 // MOB - 395
-                [OEXAnalytics trackVideoPause:self.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackVideoPause:self.selectedVideoUsedForAnalytics.summary.videoID
                                CurrentTime:currentTime
                                   CourseID:self.selectedCourseOnFront.course_id
                                    UnitURL:self.selectedVideoUsedForAnalytics.summary.unitURL];

--- a/edXVideoLocker/OEXLoginViewController.m
+++ b/edXVideoLocker/OEXLoginViewController.m
@@ -309,7 +309,7 @@
     [self setExclusiveTouch];
 
     //Analytics Screen record
-    [OEXAnalytics screenViewsTracking:@"Login"];
+    [[OEXAnalytics sharedAnalytics] trackScreenWithName:@"Login"];
 
 }
 
@@ -527,7 +527,7 @@
     [self loadEULA:@"NEW_USER"];
     [self hideEULA:NO];
     
-    [OEXAnalytics trackUserDoesNotHaveAccount];
+    [[OEXAnalytics sharedAnalytics] trackUserDoesNotHaveAccount];
     
 //    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:URL_SIGN_UP]];
 //    [self.view setUserInteractionEnabled:YES];
@@ -825,7 +825,7 @@
             [[NSUserDefaults standardUserDefaults] setObject:_tf_EmailID.text forKey:USER_EMAIL];
             // Analytics User Login
             if(self.strLoggedInWith)
-                [OEXAnalytics trackUserLogin:self.strLoggedInWith];
+                [[OEXAnalytics sharedAnalytics] trackUserLogin:self.strLoggedInWith];
         }
     [self tappedToDismiss];
     [self.activityIndicator stopAnimating];
@@ -840,7 +840,7 @@
     if(objUser){
         [[OEXInterface sharedInterface] activateIntefaceForUser:objUser];
         [[OEXInterface sharedInterface] loggedInUser:objUser];
-        [OEXAnalytics identifyUser:[NSString stringWithFormat:@"%ld",[objUser.userId longValue]] Email:objUser.email Username:objUser.username];
+        [[OEXAnalytics sharedAnalytics] identifyUser:objUser];
         //Init background downloads
         [[OEXInterface sharedInterface] startAllBackgroundDownloads];
         [self performSegueWithIdentifier:@"LaunchReveal" sender:self];

--- a/edXVideoLocker/OEXMyVideosViewController.m
+++ b/edXVideoLocker/OEXMyVideosViewController.m
@@ -365,7 +365,7 @@ typedef  enum OEXAlertType {
     
     [self performSelector:@selector(reloadTable) withObject:self afterDelay:5.0];
     //Analytics Screen record
-    [OEXAnalytics screenViewsTracking: @"My Videos - All Videos"];
+    [[OEXAnalytics sharedAnalytics] trackScreenWithName: @"My Videos - All Videos"];
     
 }
 
@@ -1144,7 +1144,7 @@ typedef  enum OEXAlertType {
             
             
             //Analytics Screen record
-            [OEXAnalytics screenViewsTracking: @"My Videos - All Videos"];
+            [[OEXAnalytics sharedAnalytics] trackScreenWithName: @"My Videos - All Videos"];
             
             break;
             
@@ -1171,7 +1171,7 @@ typedef  enum OEXAlertType {
             
             
             //Analytics Screen record
-            [OEXAnalytics screenViewsTracking: @"My Videos - Recent Videos"];
+            [[OEXAnalytics sharedAnalytics] trackScreenWithName: @"My Videos - Recent Videos"];
             
             break;
             

--- a/edXVideoLocker/OEXOpenInBrowserViewController.m
+++ b/edXVideoLocker/OEXOpenInBrowserViewController.m
@@ -88,7 +88,7 @@ static OEXOpenInBrowserViewController * _sharedInterface = nil;
     
     if ([_str_browserURL length]>0)
     {
-        [OEXAnalytics trackOpenInBrowser:_str_browserURL];
+        [[OEXAnalytics sharedAnalytics] trackOpenInBrowser:_str_browserURL];
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:_str_browserURL]];
     }
     else

--- a/edXVideoLocker/OEXRearTableViewController.m
+++ b/edXVideoLocker/OEXRearTableViewController.m
@@ -180,9 +180,9 @@
 {
 
     // Analytics User Logout
-    [OEXAnalytics trackUserLogout];
+    [[OEXAnalytics sharedAnalytics] trackUserLogout];
     // Analytics tagging
-    [OEXAnalytics resetIdentifyUser];
+    [[OEXAnalytics sharedAnalytics] clearIdentifiedUser];
     UIButton * button = (UIButton *)sender;
     [button setBackgroundImage:[UIImage imageNamed:@"bt_logout_active.png"] forState:UIControlStateNormal];
     // Set the language to blank

--- a/edXVideoLocker/OEXSegmentAnalyticsTracker.h
+++ b/edXVideoLocker/OEXSegmentAnalyticsTracker.h
@@ -1,0 +1,15 @@
+//
+//  OEXSegmentAnalyticsTracker.h
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 2/10/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "OEXAnalyticsTracker.h"
+
+@interface OEXSegmentAnalyticsTracker : NSObject <OEXAnalyticsTracker>
+
+@end

--- a/edXVideoLocker/OEXSegmentAnalyticsTracker.m
+++ b/edXVideoLocker/OEXSegmentAnalyticsTracker.m
@@ -1,0 +1,63 @@
+//
+//  OEXSegmentAnalyticsTracker.m
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 2/10/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import <SEGAnalytics.h>
+
+#import "OEXSegmentAnalyticsTracker.h"
+
+#import "NSMutableDictionary+OEXSafeAccess.h"
+#import "OEXAnalyticsData.h"
+#import "OEXUserDetails.h"
+
+@implementation OEXSegmentAnalyticsTracker
+
+- (void)identifyUser:(OEXUserDetails *)user {
+    
+    if(user.userId) {
+        NSMutableDictionary* traits = [[NSMutableDictionary alloc] init];
+        [traits setObjectOrNil:user.email forKey:key_email];
+        [traits setObjectOrNil:user.username forKey:key_username];
+        [[SEGAnalytics sharedAnalytics] identify:user.userId.description traits:traits];
+    }
+}
+
+- (void)clearIdentifiedUser {
+    [[SEGAnalytics sharedAnalytics] reset];
+}
+
+- (void)trackEvent:(OEXAnalyticsEvent *)event forComponent:(NSString *)component withProperties:(NSDictionary *)properties {
+
+    NSMutableDictionary* context = @{}.mutableCopy;
+    [context safeSetObject:value_app_name forKey:key_app_name];
+
+    // These are optional depending on the event
+    [context setObjectOrNil:component forKey:key_component];
+    [context setObjectOrNil:event.courseID forKey:key_course_id];
+    [context setObjectOrNil:event.openInBrowserURL forKey:key_open_in_browser];
+
+    NSMutableDictionary* data = [[NSMutableDictionary alloc] initWithDictionary:properties];
+
+    NSDictionary* info = @{
+                           key_data : data,
+                           key_context : context,
+                           key_name : event.name
+                           };
+
+    [[SEGAnalytics sharedAnalytics] track:event.displayName properties:info];
+
+}
+
+- (void)trackScreenWithName:(NSString *)screenName {
+    [[SEGAnalytics sharedAnalytics] screen:screenName properties:@{
+                                                                   key_context : @{
+                                                                           key_appname : value_appname
+                                                                           }
+                                                                   }];
+}
+
+@end


### PR DESCRIPTION
This also makes it easier to plug in different analytics providers, for
example, a test analytics provider that creates examinable records.