### PR TITLE
Change default keyboard type for reset password textfield

### DIFF
--- a/edXVideoLocker/OEXLoginViewController.m
+++ b/edXVideoLocker/OEXLoginViewController.m
@@ -548,6 +548,8 @@
                                               otherButtonTitles:NSLocalizedString(@"OK", nil), nil];
         
         alert.alertViewStyle = UIAlertViewStylePlainTextInput;
+        UITextField *textfield=[alert textFieldAtIndex:0];
+        textfield.keyboardType=UIKeyboardTypeEmailAddress;
         
         if ([self.tf_EmailID.text length] > 0)
         {


### PR DESCRIPTION
Change default keyboard type for reset password textfield to UIKeyboardTypeEmailAddress .
JIRA: https://openedx.atlassian.net/browse/MOB-1209
cc @aleffert 