### PR TITLE
Remove some global state from OEXInterface

### DIFF
--- a/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.h
+++ b/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.h
@@ -10,6 +10,7 @@
 
 
 @class CLVideoPlayer;
+@class OEXHelperVideoDownload;
 
 typedef enum {
     /** Controls will appear in a bottom bar */
@@ -40,6 +41,8 @@ typedef enum {
 
 
 @interface CLVideoPlayerControls : UIView
+
+@property (strong, nonatomic) OEXHelperVideoDownload* video;
 
 /**
  The style of the controls. Can be changed on the fly.

--- a/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
+++ b/edXVideoLocker/CutomePlayer/CLVideoPlayerControls.m
@@ -399,13 +399,13 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
             // Set the language to persist
             [OEXInterface setCCSelectedLanguage:strValue];
 
-            if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
+            if (self.video.summary.videoID)
             {
-                [[OEXAnalytics sharedAnalytics] trackTranscriptLanguage: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackTranscriptLanguage: self.video.summary.videoID
                                        CurrentTime: [self getMoviePlayerCurrentTime]
                                           Language: strLang
-                                          CourseID: _dataInterface.selectedCourseOnFront.course_id
-                                           UnitURL: _dataInterface.selectedVideoUsedForAnalytics.summary.unitURL];
+                                          CourseID: self.video.course_id
+                                           UnitURL: self.video.summary.unitURL];
                 
             }
         
@@ -442,14 +442,14 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
             
             [self.moviePlayer setCurrentPlaybackRate:_playbackRate];
             
-            if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
+            if (self.video.summary.videoID)
             {
 
                 ELog(@" did select ====== trackVideoSpeed");
-                [[OEXAnalytics sharedAnalytics] trackVideoSpeed: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackVideoSpeed: self.video.summary.videoID
                                CurrentTime: [self getMoviePlayerCurrentTime]
-                                  CourseID: _dataInterface.selectedCourseOnFront.course_id
-                                   UnitURL: _dataInterface.selectedVideoUsedForAnalytics.summary.unitURL
+                                  CourseID: self.video.course_id
+                                   UnitURL: self.video.summary.unitURL
                                   OldSpeed: oldSpeed
                                   NewSpeed: [NSString stringWithFormat:@"%.1f",self.playbackRate]];
             }
@@ -492,10 +492,10 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
         [self.moviePlayer play];
       
         ELog(@" callPortraitSubtitles ====== trackVideoSpeed");
-        [[OEXAnalytics sharedAnalytics] trackVideoSpeed: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+        [[OEXAnalytics sharedAnalytics] trackVideoSpeed: self.video.summary.videoID
                        CurrentTime: [self getMoviePlayerCurrentTime]
-                          CourseID: _dataInterface.selectedCourseOnFront.course_id
-                           UnitURL: _dataInterface.selectedVideoUsedForAnalytics.summary.unitURL
+                          CourseID: self.video.course_id
+                           UnitURL: self.video.summary.unitURL
                           OldSpeed: oldSpeed
                           NewSpeed: [NSString stringWithFormat:@"%.1f",self.playbackRate]];
         
@@ -1376,17 +1376,13 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
     {
         
         
-        if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
+        if (self.video.summary.videoID)
         {
-            // Analytics Orientaion Landscape
-            if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
-            {
-                [[OEXAnalytics sharedAnalytics] trackVideoOrientation: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
-                                        CourseID: _dataInterface.selectedCourseOnFront.course_id
-                                     CurrentTime: [self getMoviePlayerCurrentTime]
-                                            Mode: YES
-                                         UnitURL: _dataInterface.selectedVideoUsedForAnalytics.summary.unitURL];
-            }
+            [[OEXAnalytics sharedAnalytics] trackVideoOrientation: self.video.summary.videoID
+                                       CourseID: self.video.course_id
+                                    CurrentTime: [self getMoviePlayerCurrentTime]
+                                           Mode: YES
+                                        UnitURL: self.video.summary.unitURL];
         }
         
         self.leftSwipeGestureRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(nextBtnClicked:)];
@@ -1400,18 +1396,14 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
     }
     else if (_style == CLVideoPlayerControlsStyleEmbedded || (_style == CLVideoPlayerControlsStyleDefault && !_moviePlayer.isFullscreen))
     {
-        if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
+        if (self.video.summary.videoID)
         {
-            // Analytics Orientaion Portrait
-            if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
-            {
-                [[OEXAnalytics sharedAnalytics] trackVideoOrientation: _dataInterface.selectedVideoUsedForAnalytics.summary.videoID
-                                        CourseID: _dataInterface.selectedCourseOnFront.course_id
-                                     CurrentTime: [self getMoviePlayerCurrentTime]
-                                            Mode: NO
-                                         UnitURL: _dataInterface.selectedVideoUsedForAnalytics.summary.unitURL];
+            [[OEXAnalytics sharedAnalytics] trackVideoOrientation: self.video.summary.videoID
+                                       CourseID: self.video.course_id
+                                    CurrentTime: [self getMoviePlayerCurrentTime]
+                                           Mode: NO
+                                        UnitURL: self.video.summary.unitURL];
 
-            }
         }
         
         
@@ -1640,10 +1632,10 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
 
 -(void)analyticsShowTranscript
 {
-    [[OEXAnalytics sharedAnalytics] trackShowTranscript:_dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+    [[OEXAnalytics sharedAnalytics] trackShowTranscript:self.video.summary.videoID
                        CurrentTime:[self getMoviePlayerCurrentTime]
-                          CourseID:_dataInterface.selectedCourseOnFront.course_id
-                           UnitURL:_dataInterface.selectedVideoUsedForAnalytics.summary.unitURL];
+                          CourseID:self.video.course_id
+                           UnitURL:self.video.summary.unitURL];
 }
 
 #pragma CC methods
@@ -1659,12 +1651,12 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
         // Set the language to blank
         [OEXInterface setCCSelectedLanguage:@""];
         // Analytics HIDE TRANSCRIPT
-        if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
+        if (self.video.summary.videoID)
         {
-            [[OEXAnalytics sharedAnalytics] trackHideTranscript:_dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+            [[OEXAnalytics sharedAnalytics] trackHideTranscript:self.video.summary.videoID
                                CurrentTime:[self getMoviePlayerCurrentTime]
-                                  CourseID:_dataInterface.selectedCourseOnFront.course_id
-                                   UnitURL:_dataInterface.selectedVideoUsedForAnalytics.summary.unitURL];
+                                  CourseID:self.video.course_id
+                                   UnitURL:self.video.summary.unitURL];
             
         }
         _dataInterface.selectedCCIndex = -1;
@@ -1682,7 +1674,7 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
 
 - (void)LMSBtnClicked:(id)sender
 {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:_dataInterface.selectedVideoUsedForAnalytics.summary.unitURL]];
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:self.video.summary.unitURL]];
 
 }
 
@@ -1746,15 +1738,14 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
     self.stopTime = [self getMoviePlayerCurrentTime];
     NSLog(@"self.stopTime : %f",self.stopTime);
 
-    if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
+    if (self.video.summary.videoID)
     {
-        
-        [[OEXAnalytics sharedAnalytics] trackVideoSeekRewind:_dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+        [[OEXAnalytics sharedAnalytics] trackVideoSeekRewind:self.video.summary.videoID
                       RequestedDuration:self.stopTime - self.startTime
                                 OldTime:self.startTime
                                 NewTime:self.stopTime
-                               CourseID:_dataInterface.selectedCourseOnFront.course_id
-                                UnitURL:_dataInterface.selectedVideoUsedForAnalytics.summary.unitURL
+                               CourseID:self.video.course_id
+                                UnitURL:self.video.summary.unitURL
                                SkipType:@"slide"];
         
     }
@@ -1811,14 +1802,14 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
     {
         self.stateBeforeSeek = MPMoviePlaybackStatePaused;
         [self.moviePlayer pause];
-        [_dataInterface sendAnalyticsEvents:OEXVideoStatePause WithCurrentTime:[self getMoviePlayerCurrentTime]];
+        [_dataInterface sendAnalyticsEvents:OEXVideoStatePause withCurrentTime:[self getMoviePlayerCurrentTime] forVideo:self.video];
 
     }
     else
     {
         self.stateBeforeSeek = MPMoviePlaybackStatePlaying;
         [self.moviePlayer play];
-        [_dataInterface sendAnalyticsEvents:OEXVideoStatePlay WithCurrentTime:[self getMoviePlayerCurrentTime]];
+        [_dataInterface sendAnalyticsEvents:OEXVideoStatePlay withCurrentTime:[self getMoviePlayerCurrentTime]forVideo:self.video];
 
     }
     
@@ -1853,15 +1844,14 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
         currentTime=0;
     }
     
-    if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
+    if (self.video.summary.videoID)
     {
-        
-        [[OEXAnalytics sharedAnalytics] trackVideoSeekRewind:_dataInterface.selectedVideoUsedForAnalytics.summary.videoID
+        [[OEXAnalytics sharedAnalytics] trackVideoSeekRewind:self.video.summary.videoID
                       RequestedDuration:CLVideoSkipBackwardsDuration
                                 OldTime:OldTime
                                 NewTime:currentTime
-                               CourseID:_dataInterface.selectedCourseOnFront.course_id
-                                UnitURL:_dataInterface.selectedVideoUsedForAnalytics.summary.unitURL
+                               CourseID:self.video.course_id
+                                UnitURL:self.video.summary.unitURL
                                SkipType:@"skip"];
         
     }
@@ -2153,9 +2143,9 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
         ELog(@" %s Reason: movie finished playing ", __PRETTY_FUNCTION__ );
         
         // Fix semantics - MOB 1232
-        if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
+        if (self.video.summary.videoID)
         {
-            [_dataInterface sendAnalyticsEvents:OEXVideoStateStop WithCurrentTime:[weakSelf getMoviePlayerCurrentTime]];
+            [_dataInterface sendAnalyticsEvents:OEXVideoStateStop withCurrentTime:[weakSelf getMoviePlayerCurrentTime] forVideo:self.video];
         }
         
         
@@ -2190,9 +2180,9 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
                 self.moviePlayer.lastPlayedTime=0;
             }
             
-            if (_dataInterface.selectedVideoUsedForAnalytics.summary.videoID)
+            if (self.video.summary.videoID)
             {
-                [_dataInterface sendAnalyticsEvents:OEXVideoStateLoading WithCurrentTime:0];
+                [_dataInterface sendAnalyticsEvents:OEXVideoStateLoading withCurrentTime:0 forVideo:self.video];
             }
             
             [self showControls:nil];

--- a/edXVideoLocker/OEXCourseVideoDownloadTableViewController.h
+++ b/edXVideoLocker/OEXCourseVideoDownloadTableViewController.h
@@ -22,6 +22,5 @@
 @property (strong,nonatomic)  OEXHelperVideoDownload *lastAccessedVideo;
 @property (nonatomic, strong) NSArray *arr_DownloadProgress;
 @property (strong, nonatomic) NSArray *selectedPath; // OEXVideoPathEntry
-@property (strong, nonatomic) NSURL * currentVideoURL;
 
 @end

--- a/edXVideoLocker/OEXCustomTabBarViewViewController.m
+++ b/edXVideoLocker/OEXCustomTabBarViewViewController.m
@@ -151,7 +151,7 @@
     }
     else
     {
-        if (_dataInterface.selectedCourseOnFront.video_outline)
+        if (self.course.video_outline)
         {
             [self updateCourseWareData];
         }
@@ -281,8 +281,7 @@
     [self addObserver];
     
     self.table_Announcements.hidden=YES;
-    
-    self.lastAccessedVideo=[self.dataInterface lastAccessedSubsectionForCourseID:_dataInterface.selectedCourseOnFront.course_id];
+    self.lastAccessedVideo=[self.dataInterface lastAccessedSubsectionForCourseID:self.course.course_id];
     
     
     [[OEXOpenInBrowserViewController sharedInstance] addViewToContainerSuperview:self.containerView];
@@ -312,7 +311,7 @@
     
     // To get updated from the server.
     dispatch_async(dispatch_get_main_queue(), ^{
-        [_dataInterface getLastVisitedModule];
+        [_dataInterface getLastVisitedModuleForCourseID:self.course.course_id];
     });
 }
 
@@ -366,7 +365,7 @@
     [self.customProgressBar setHidden:YES];
     [self.btn_Downloads setHidden:YES];
     
-    NSData * data = [_dataInterface resourceDataForURLString:_dataInterface.selectedCourseOnFront.video_outline downloadIfNotAvailable:NO];
+    NSData * data = [_dataInterface resourceDataForURLString:self.course.video_outline downloadIfNotAvailable:NO];
     if (data)
     {
         [self.dataInterface processVideoSummaryList:data URLString:self.course.video_outline];
@@ -375,7 +374,7 @@
     }
     else
     {
-        [_dataInterface downloadWithRequestString:_dataInterface.selectedCourseOnFront.video_outline forceUpdate:NO];
+        [_dataInterface downloadWithRequestString:self.course.video_outline forceUpdate:NO];
         [self getCourseOutlineData];
     }
     
@@ -625,7 +624,7 @@
         }
         else if ([URLString isEqualToString:NOTIFICATION_VALUE_URL_LASTACCESSED])
         {
-            self.lastAccessedVideo=[self.dataInterface lastAccessedSubsectionForCourseID:_dataInterface.selectedCourseOnFront.course_id];
+            self.lastAccessedVideo=[self.dataInterface lastAccessedSubsectionForCourseID:self.course.course_id];
             if (self.lastAccessedVideo)
             {
                 [self reloadTableOnMainThread];
@@ -1132,10 +1131,10 @@
         }
     }
     // Analytics Bulk Video Download From Section
-    if (_dataInterface.selectedCourseOnFront.course_id)
+    if (self.course.course_id)
     {
         [[OEXAnalytics sharedAnalytics] trackSectionBulkVideoDownload: chapter.entryID
-                                                             CourseID: _dataInterface.selectedCourseOnFront.course_id
+                                                             CourseID: self.course.course_id
                                                            VideoCount: [validArray count]];
         
         

--- a/edXVideoLocker/OEXFrontCourseViewController.m
+++ b/edXVideoLocker/OEXFrontCourseViewController.m
@@ -58,9 +58,8 @@
 #pragma mark Controller delegate
 -(void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender
 {
-     if([[segue  identifier] isEqualToString:@"LaunchCourseDetailTab"]){
         
-    }else if([[segue  identifier] isEqualToString:@"DownloadControllerSegue"])
+    if([[segue  identifier] isEqualToString:@"DownloadControllerSegue"])
     {
         OEXDownloadViewController *obj_download = (OEXDownloadViewController *)[segue destinationViewController];
         obj_download.isFromFrontViews = YES;
@@ -636,7 +635,6 @@
 - (void)showCourse:(OEXCourse*)course {
     if(course) {
         [[OEXRouter sharedRouter] showCourse:course fromController:self];
-        _dataInterface.selectedCourseOnFront = course;
     }
 }
 

--- a/edXVideoLocker/OEXGenericCourseTableViewController.m
+++ b/edXVideoLocker/OEXGenericCourseTableViewController.m
@@ -368,12 +368,12 @@ if (IS_IOS8)
     
     
     // Analytics Bulk Video Download From SubSection 
-    if (_dataInterface.selectedCourseOnFront.course_id)
+    if (self.course.course_id)
     {
         OEXVideoPathEntry* section = [self.arr_TableCourseData oex_safeObjectAtIndex:tagValue];
         [[OEXAnalytics sharedAnalytics] trackSubSectionBulkVideoDownload: self.selectedChapter.entryID
                                          Subsection: section.entryID
-                                           CourseID: _dataInterface.selectedCourseOnFront.course_id
+                                           CourseID: self.course.course_id
                                          VideoCount: [validArray count]];
         
 

--- a/edXVideoLocker/OEXInterface.h
+++ b/edXVideoLocker/OEXInterface.h
@@ -25,10 +25,6 @@
 @property (nonatomic, assign) NSInteger selectedCCIndex;
 @property (nonatomic, assign) NSInteger selectedVideoSpeedIndex;
 
-// To pass the course and load in the next view
-// Solves the waiting time issue on Course Cell clicked in FrontView
-@property (nonatomic,strong) OEXCourse *selectedCourseOnFront;
-@property (nonatomic,strong) OEXHelperVideoDownload *selectedVideoUsedForAnalytics;
 @property (nonatomic, strong) OEXUserDetails * userdetail;
 @property (nonatomic, strong) NSArray * courses;
 @property (nonatomic, strong) NSMutableDictionary * courseVideos;
@@ -163,16 +159,16 @@
 
 #pragma mark - Update Last Accessed from server
 
-- (void)updateLastVisitedModule:(NSString*)module;
-- (void)getLastVisitedModule;
+- (void)updateLastVisitedModule:(NSString*)module forCourseID:(NSString*)courseID;
+- (void)getLastVisitedModuleForCourseID:(NSString*)courseID;
 
 
--(void)activateIntefaceForUser:(OEXUserDetails *)user;
+-(void)activateInterfaceForUser:(OEXUserDetails *)user;
 
 
 
 #pragma mark - Analytics Call
-- (void)sendAnalyticsEvents:(OEXVideoState)state WithCurrentTime:(NSTimeInterval)currentTime;
+- (void)sendAnalyticsEvents:(OEXVideoState)state withCurrentTime:(NSTimeInterval)currentTime forVideo:(OEXHelperVideoDownload*)video;
 
 
 @end

--- a/edXVideoLocker/OEXInterface.m
+++ b/edXVideoLocker/OEXInterface.m
@@ -1415,7 +1415,7 @@ static OEXInterface * _sharedInterface = nil;
 }
 
 
-- (void)updateLastVisitedModule:(NSString*)module
+- (void)updateLastVisitedModule:(NSString*)module forCourseID:(NSString*)courseID
 {
     if (!module)
         return;
@@ -1423,11 +1423,11 @@ static OEXInterface * _sharedInterface = nil;
     NSString *timestamp = [self getFormattedDate];
 
     // Set to DB first and then depending on the response the DB gets updated
-    [self setLastAccessedDataToDB:module TimeStamp:timestamp];
+    [self setLastAccessedDataToDB:module withTimeStamp:timestamp forCourseID:courseID];
     
     OEXUserDetails *user = [OEXAuthentication getLoggedInUser];
     
-    NSString* path = [NSString stringWithFormat:@"/api/mobile/v0.5/users/%@/course_status_info/%@", user.username , self.selectedCourseOnFront.course_id];
+    NSString* path = [NSString stringWithFormat:@"/api/mobile/v0.5/users/%@/course_status_info/%@", user.username , courseID];
     
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@%@", [OEXConfig sharedConfig].apiHostURL, path]]];
     
@@ -1467,7 +1467,7 @@ static OEXInterface * _sharedInterface = nil;
 
         if (![module isEqualToString:subsectionID])
         {
-            [self setLastAccessedDataToDB:subsectionID TimeStamp:timestamp];
+            [self setLastAccessedDataToDB:subsectionID withTimeStamp:timestamp forCourseID:courseID];
         }
 
 
@@ -1476,20 +1476,20 @@ static OEXInterface * _sharedInterface = nil;
 
 
 
-- (void)setLastAccessedDataToDB:(NSString *)subsectionID TimeStamp:(NSString *)timestamp
+- (void)setLastAccessedDataToDB:(NSString *)subsectionID withTimeStamp:(NSString *)timestamp forCourseID:(NSString*)courseID
 {
     OEXHelperVideoDownload *video = [self getSubsectionNameForSubsectionID:subsectionID];
     
-    [self setLastAccessedSubsectionWith:subsectionID andSubsectionName:video.summary.sectionPathEntry.entryID forCourseID:self.selectedCourseOnFront.course_id OnTimeStamp:timestamp];
+    [self setLastAccessedSubsectionWith:subsectionID andSubsectionName:video.summary.sectionPathEntry.entryID forCourseID:courseID OnTimeStamp:timestamp];
 }
 
 
 
-- (void)getLastVisitedModule
+- (void)getLastVisitedModuleForCourseID:(NSString*)courseID
 {
     OEXUserDetails *user = [OEXAuthentication getLoggedInUser];
     
-    NSString* path = [NSString stringWithFormat:@"/api/mobile/v0.5/users/%@/course_status_info/%@", user.username , self.selectedCourseOnFront.course_id];
+    NSString* path = [NSString stringWithFormat:@"/api/mobile/v0.5/users/%@/course_status_info/%@", user.username , courseID];
     
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@%@", [OEXConfig sharedConfig].apiHostURL, path]]];
     
@@ -1524,7 +1524,7 @@ static OEXInterface * _sharedInterface = nil;
         {
             NSString *timestamp = [self getFormattedDate];
             // Set to DB first and then depending on the response the DB gets updated
-            [self setLastAccessedDataToDB:subsectionID TimeStamp:timestamp];
+            [self setLastAccessedDataToDB:subsectionID withTimeStamp:timestamp forCourseID:courseID];
 
             //Post notification
             [[NSNotificationCenter defaultCenter] postNotificationName:NOTIFICATION_URL_RESPONSE
@@ -1544,7 +1544,7 @@ static OEXInterface * _sharedInterface = nil;
 #pragma mark - Analytics Call
 
 
-- (void)sendAnalyticsEvents:(OEXVideoState)state WithCurrentTime:(NSTimeInterval)currentTime
+- (void)sendAnalyticsEvents:(OEXVideoState)state withCurrentTime:(NSTimeInterval)currentTime forVideo:(OEXHelperVideoDownload*)video
 {
     if (isnan(currentTime))
     {
@@ -1557,11 +1557,11 @@ static OEXInterface * _sharedInterface = nil;
             
             ELog(@"EdxInterface sendAnalyticsEvents ==>> MPMoviePlaybackStateStopped");
             
-            if (self.selectedVideoUsedForAnalytics.summary.videoID)
+            if (video.summary.videoID)
             {
-                [[OEXAnalytics sharedAnalytics] trackVideoLoading:self.selectedVideoUsedForAnalytics.summary.videoID
-                                    CourseID:self.selectedCourseOnFront.course_id
-                                     UnitURL:self.selectedVideoUsedForAnalytics.summary.unitURL];
+                [[OEXAnalytics sharedAnalytics] trackVideoLoading:video.summary.videoID
+                                    CourseID:video.course_id
+                                     UnitURL:video.summary.unitURL];
             }
             
             break;
@@ -1570,12 +1570,12 @@ static OEXInterface * _sharedInterface = nil;
             
             ELog(@"EdxInterface sendAnalyticsEvents ==>> MPMoviePlaybackStateStopped");
             
-            if (self.selectedVideoUsedForAnalytics.summary.videoID)
+            if (video.summary.videoID)
             {
-                [[OEXAnalytics sharedAnalytics] trackVideoStop:self.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackVideoStop:video.summary.videoID
                               CurrentTime:currentTime
-                                 CourseID:self.selectedCourseOnFront.course_id
-                                  UnitURL:self.selectedVideoUsedForAnalytics.summary.unitURL];
+                                 CourseID:video.course_id
+                                  UnitURL:video.summary.unitURL];
             }
             
             break;
@@ -1584,12 +1584,12 @@ static OEXInterface * _sharedInterface = nil;
             
             ELog(@"EdxInterface sendAnalyticsEvents ==>> MPMoviePlaybackStatePlaying");
             
-            if (self.selectedVideoUsedForAnalytics.summary.videoID)
+            if (video.summary.videoID)
             {
-                [[OEXAnalytics sharedAnalytics] trackVideoPlaying:self.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackVideoPlaying:video.summary.videoID
                                  CurrentTime:currentTime
-                                    CourseID:self.selectedCourseOnFront.course_id
-                                     UnitURL:self.selectedVideoUsedForAnalytics.summary.unitURL];
+                                    CourseID:video.course_id
+                                     UnitURL:video.summary.unitURL];
             }
             
             break;
@@ -1598,13 +1598,13 @@ static OEXInterface * _sharedInterface = nil;
         case OEXVideoStatePause:
             
             ELog(@"EdxInterface sendAnalyticsEvents ==>> MPMoviePlaybackStatePaused");
-            if (self.selectedVideoUsedForAnalytics.summary.videoID)
+            if (video.summary.videoID)
             {
                 // MOB - 395
-                [[OEXAnalytics sharedAnalytics] trackVideoPause:self.selectedVideoUsedForAnalytics.summary.videoID
+                [[OEXAnalytics sharedAnalytics] trackVideoPause:video.summary.videoID
                                CurrentTime:currentTime
-                                  CourseID:self.selectedCourseOnFront.course_id
-                                   UnitURL:self.selectedVideoUsedForAnalytics.summary.unitURL];
+                                  CourseID:video.course_id
+                                   UnitURL:video.summary.unitURL];
             }
             
             break;
@@ -1638,8 +1638,6 @@ static OEXInterface * _sharedInterface = nil;
             self.signInPassword = nil;
             self.parser = nil;
             self.numberOfRecentDownloads = 0;
-            self.selectedCourseOnFront = nil;
-            self.selectedVideoUsedForAnalytics = nil;
             [self.videoSummaries removeAllObjects];
             completionHandler();
         }];
@@ -1649,14 +1647,12 @@ static OEXInterface * _sharedInterface = nil;
 
 # pragma  mark activate interface for user
 
--(void)activateIntefaceForUser:(OEXUserDetails *)user{
+-(void)activateInterfaceForUser:(OEXUserDetails *)user{
   
     // Reset Default Settings
     
     _sharedInterface.shownOfflineView=NO;
     // Used for CC
-    _sharedInterface.selectedCourseOnFront = [[OEXCourse alloc] init];
-    _sharedInterface.selectedVideoUsedForAnalytics = [[OEXHelperVideoDownload alloc] init];
     _sharedInterface.selectedCCIndex = -1;
     _sharedInterface.selectedVideoSpeedIndex = -1;
     

--- a/edXVideoLocker/OEXLoginViewController.m
+++ b/edXVideoLocker/OEXLoginViewController.m
@@ -898,7 +898,7 @@
     
     OEXUserDetails *objUser = [OEXAuthentication getLoggedInUser];
     if(objUser){
-        [[OEXInterface sharedInterface] activateIntefaceForUser:objUser];
+        [[OEXInterface sharedInterface] activateInterfaceForUser:objUser];
         [[OEXInterface sharedInterface] loggedInUser:objUser];
         [[OEXAnalytics sharedAnalytics] identifyUser:objUser];
         //Init background downloads

--- a/edXVideoLocker/OEXMyVideosSubSectionViewController.m
+++ b/edXVideoLocker/OEXMyVideosSubSectionViewController.m
@@ -649,9 +649,6 @@ typedef NS_ENUM(NSUInteger, OEXAlertType) {
     NSArray *videos = [self.arr_SubsectionData objectAtIndex:indexPath.section];
     
     OEXHelperVideoDownload *obj = [videos objectAtIndex:indexPath.row];
-    
-    // Assign this for Analytics
-    _dataInterface.selectedVideoUsedForAnalytics = obj;
 
     // Set the path of the downloaded videos
     [_dataInterface downloadTranscripts:obj];
@@ -686,7 +683,7 @@ typedef NS_ENUM(NSUInteger, OEXAlertType) {
     [_videoPlayerInterface playVideoFor:obj];
     
     // Send Analytics
-    [_dataInterface sendAnalyticsEvents:OEXVideoStatePlay WithCurrentTime:self.videoPlayerInterface.moviePlayerController.currentPlaybackTime];
+    [_dataInterface sendAnalyticsEvents:OEXVideoStatePlay withCurrentTime:self.videoPlayerInterface.moviePlayerController.currentPlaybackTime forVideo:self.currentTappedVideo];
     
 }
 

--- a/edXVideoLocker/OEXVideoPlayerInterface.h
+++ b/edXVideoLocker/OEXVideoPlayerInterface.h
@@ -30,8 +30,6 @@
 - (void)updatePlaybackRate:(float)newPlaybackRate;
 //- (void)playVideoFromURL:(NSURL *)URL;
 - (void)playVideoFor:(OEXHelperVideoDownload *)video;
-- (void)playVideoFromURL:(NSURL *)URL withTitle:(NSString *)title;
--(void)playVideoFromURL:(NSURL *)URL withTitle:(NSString *)title timeInterval:(NSTimeInterval)interval;
 -(void)resetPlayer;
 -(void)videoPlayerShouldRotate;
 -(void)setAutoPlaying:(BOOL)playing;

--- a/edXVideoLocker/OEXVideoPlayerInterface.m
+++ b/edXVideoLocker/OEXVideoPlayerInterface.m
@@ -80,15 +80,10 @@
     
 }
 
-- (void)playVideoFromURL:(NSURL *)URL withTitle:(NSString *)title{
-    _moviePlayerController.videoTitle=title;
-    [self playVideoFromURL:URL withTitle:title timeInterval:0];
-}
-
-
 - (void)playVideoFor:(OEXHelperVideoDownload *)video
 {
     _moviePlayerController.videoTitle = video.summary.name;
+    _moviePlayerController.controls.video = video;
     NSURL *url = [NSURL URLWithString:video.summary.videoURL];
     
     NSFileManager *filemgr = [NSFileManager defaultManager];

--- a/edXVideoLockerTests/OEXInterFaceTests.m
+++ b/edXVideoLockerTests/OEXInterFaceTests.m
@@ -59,7 +59,7 @@
     user.userId = [NSNumber numberWithInt:12345];
     
     self.interface = [[OEXInterface alloc] init];
-    [self.interface activateIntefaceForUser:user];
+    [self.interface activateInterfaceForUser:user];
     [self.interface storeVideoList:self.videos forURL:self.outlineURL];
 }
 


### PR DESCRIPTION
In particular, the selectedCourseOnFront and selectedVideoUsedForAnalytics properties were used in a number of places. This patch encapsulates the relevant information into the places where it's used, removing intertwined state from that class, moving us toward a more testable interface local reasoning and write tests.

cc @jotiram @rahul-clarice @rohan-dhamal-clarice please review. thanks.