### PR TITLE
Switch format strings to use named parameters.

### DIFF
--- a/edXVideoLocker.xcodeproj/project.pbxproj
+++ b/edXVideoLocker.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		77D76BFD1AA5076D00C51C2C /* OEXLocalizedString.m in Sources */ = {isa = PBXBuildFile; fileRef = 77D76BFC1AA5076D00C51C2C /* OEXLocalizedString.m */; };
 		77E849B51A82BCFA004E6AA3 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 77E849B41A82BCFA004E6AA3 /* Default-568h@2x.png */; };
 		77EC889E1AB787630050F9CF /* OEXAnalyticsData.m in Sources */ = {isa = PBXBuildFile; fileRef = 77EC889D1AB787630050F9CF /* OEXAnalyticsData.m */; };
+		77EC88A01AB878880050F9CF /* NSString+OEXFormattingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77EC889F1AB878880050F9CF /* NSString+OEXFormattingTests.m */; };
 		77FFAB9A1A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 77FFAB991A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.m */; };
 		890D027F1967343A002CE7EC /* OEXCourseInfoCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 890D027E1967343A002CE7EC /* OEXCourseInfoCell.m */; };
 		8F41F4791A834A8F0041B30D /* OEXImageCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 8F41F4781A834A8F0041B30D /* OEXImageCache.m */; };
@@ -546,6 +547,7 @@
 		77D76BFC1AA5076D00C51C2C /* OEXLocalizedString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXLocalizedString.m; sourceTree = "<group>"; };
 		77E849B41A82BCFA004E6AA3 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		77EC889D1AB787630050F9CF /* OEXAnalyticsData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXAnalyticsData.m; sourceTree = "<group>"; };
+		77EC889F1AB878880050F9CF /* NSString+OEXFormattingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+OEXFormattingTests.m"; sourceTree = "<group>"; };
 		77FFAB981A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXSegmentAnalyticsTracker.h; sourceTree = "<group>"; };
 		77FFAB991A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXSegmentAnalyticsTracker.m; sourceTree = "<group>"; };
 		77FFAB9B1A8ABDB200F91F08 /* OEXAnalyticsTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXAnalyticsTracker.h; sourceTree = "<group>"; };
@@ -1615,6 +1617,7 @@
 				77AE2F611ABB71840027E799 /* OEXFileUtilityTests.m */,
 				7778F0941ABA2C3600B4CDA0 /* OEXRegistrationFieldEmailViewTests.m */,
 				7778F0921ABA1F8000B4CDA0 /* OEXStatusMessageViewControllerTests.m */,
+				77EC889F1AB878880050F9CF /* NSString+OEXFormattingTests.m */,
 				194E018F1A54204A00A0CFAE /* OEXDBTests.m */,
 				770A27AB1A702B6500DFC6FF /* OEXDataParserTests.m */,
 				77000A461A77555B007D306C /* OEXDateFormattingTests.m */,
@@ -2193,6 +2196,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9CA725F41A8E1B56009244A6 /* OEXFindCoursesTests.m in Sources */,
+				77EC88A01AB878880050F9CF /* NSString+OEXFormattingTests.m in Sources */,
 				B4B285EA1A9B182900DD603A /* OEXConfigTests.m in Sources */,
 				8F7F6DAD1A795AA60063B9D6 /* OEXSessionTests.m in Sources */,
 				77A340211AB2461800C8E141 /* OEXRegistrationViewControllerTests.m in Sources */,

--- a/edXVideoLocker/NSString+OEXFormatting.h
+++ b/edXVideoLocker/NSString+OEXFormatting.h
@@ -13,4 +13,13 @@
 /// Converts a string to UPPERCASE using the display locale
 - (NSString*)oex_uppercaseStringInCurrentLocale;
 
+/// Performs named string substitution. Subtitutable parts of the string should be in curly braces
+/// and correspond to entries in the parameters dictionary.
+/// For example, if the format string is "{bookcount} books" and parameters is @{"bookcount" : @3}
+/// The resulting string will be "3 books"
+/// If this is a DEBUG build, strings with missing parameters or substitutions without
+/// corresponding parameters will cause an assertion
++ (NSString*)oex_stringWithFormat:(NSString*)format parameters:(NSDictionary*)parameters;
+
+
 @end

--- a/edXVideoLocker/NSString+OEXFormatting.m
+++ b/edXVideoLocker/NSString+OEXFormatting.m
@@ -10,10 +10,49 @@
 
 #import "NSBundle+OEXConveniences.h"
 
+/// Determines if parameters has an extra item or is missing something
+BOOL OEXFormatStringIsValid(NSString* string, NSDictionary* parameters) {
+    __block BOOL isValid = YES;
+    __block NSString* current = string;
+
+    // Make sure all the strings are matched
+    [parameters enumerateKeysAndObjectsUsingBlock:^(NSString* key, id value, BOOL *stop) {
+        NSString* token = [NSString stringWithFormat:@"{%@}", key];
+        NSString* replacement = [current stringByReplacingOccurrencesOfString:token withString:@""];
+
+        // No replacement happened so we have an unused parameter
+        if(replacement.length == current.length) {
+            isValid = NO;
+            *stop = YES;
+        }
+        current = replacement;
+    }];
+
+    // We've replaced all the strings so we should have no more format arguments at this point
+    // Try matching the format regex
+    BOOL noReplacement = [current rangeOfString:@"\\{.*\\}" options:NSRegularExpressionSearch].location == NSNotFound;
+    isValid = isValid && noReplacement;
+    
+    return isValid;
+}
+
 @implementation NSString (OEXFormatting)
 
 - (NSString*)oex_uppercaseStringInCurrentLocale {
     return [self uppercaseStringWithLocale:[[NSBundle mainBundle] oex_displayLocale]];
+}
+
+
++ (NSString*)oex_stringWithFormat:(NSString*)format parameters:(NSDictionary*)parameters {
+    NSAssert(OEXFormatStringIsValid(format, parameters), @"Invalid format string: %@, parameters: parameters", format, parameters);
+
+    NSMutableString* result = format.mutableCopy;
+    [parameters enumerateKeysAndObjectsUsingBlock:^(NSString* key, id value, BOOL *stop) {
+        NSRange range = NSMakeRange(0, result.length);
+        NSString* token = [NSString stringWithFormat:@"{%@}", key];
+        [result replaceOccurrencesOfString:token withString:[value description] options:0 range:range];
+    }];
+    return result;
 }
 
 @end

--- a/edXVideoLocker/OEXCourseVideoDownloadTableViewController.m
+++ b/edXVideoLocker/OEXCourseVideoDownloadTableViewController.m
@@ -1291,7 +1291,9 @@ typedef  enum OEXAlertType
 
     [self.table_Videos reloadData];
 
-    NSString* message = [NSString stringWithFormat:OEXLocalizedStringPlural(@"VIDEOS_DELETED", deleteCount, nil), deleteCount];
+    NSString* message = [NSString oex_stringWithFormat:
+                         OEXLocalizedStringPlural(@"VIDEOS_DELETED", deleteCount, nil)
+                                            parameters:@{@"count" : @(deleteCount)}];
     [[OEXStatusMessageViewController sharedInstance] showMessage:message onViewController:self];
 
 //    [self disableDeleteButton];

--- a/edXVideoLocker/OEXCustomTabBarViewViewController.m
+++ b/edXVideoLocker/OEXCustomTabBarViewViewController.m
@@ -116,7 +116,7 @@
 -(NSAttributedString*)msgFutureCourses {
     NSString* strStartDate = [OEXDateFormatting formatAsMonthDayYearString:self.course.start];
     NSString* localizedString = OEXLocalizedString(@"COURSE_WILL_START_AT", nil);
-    NSString* lblCourseMsg = [NSString stringWithFormat:localizedString, strStartDate];
+    NSString* lblCourseMsg = [NSString oex_stringWithFormat:localizedString parameters:@{@"date" : strStartDate}];
     NSMutableAttributedString* msgFutureCourses = [[NSMutableAttributedString alloc] initWithString:lblCourseMsg];
     NSRange range = [lblCourseMsg rangeOfString:strStartDate];
     [msgFutureCourses setAttributes:@{NSFontAttributeName:[UIFont fontWithName:@"OpenSans-Semibold" size:self.lbl_NoCourseware.font.pointSize], NSForegroundColorAttributeName:[UIColor blackColor]} range:range];
@@ -839,7 +839,9 @@
     NSInteger downloadingCount = [_dataInterface downloadMultipleVideosForRequestStrings:validArray];
 
     if(downloadingCount > 0) {
-        NSString* message = [NSString stringWithFormat:OEXLocalizedStringPlural(@"VIDEOS_DOWNLOADING", downloadingCount, nil), downloadingCount];
+        NSString* message = [NSString oex_stringWithFormat:
+                             OEXLocalizedStringPlural(@"VIDEOS_DOWNLOADING", downloadingCount, nil)
+                                                parameters:@{@"count" : @(downloadingCount)}];
         [[OEXStatusMessageViewController sharedInstance] showMessage:message onViewController:self];
     }
     else {

--- a/edXVideoLocker/OEXFindCourseInterstitialViewController.m
+++ b/edXVideoLocker/OEXFindCourseInterstitialViewController.m
@@ -23,12 +23,10 @@
     self.topLabel.text = OEXLocalizedString(@"NO_ENROLLMENT_INTERSTITIAL_TOP_LABEL", nil);
     self.topLabel.font = [UIFont fontWithName:@"OpenSans" size:self.topLabel.font.pointSize];
 
-    NSString* bottomLabelBoldText = OEXLocalizedString(@"NO_ENROLLMENT_INTERSTITIAL_BOTTOM_LABEL_BOLD_PART", nil);
-    NSString* bottomLabelText = [NSString stringWithFormat:OEXLocalizedString(@"NO_ENROLLMENT_INTERSTITIAL_BOTTOM_LABEL", nil), bottomLabelBoldText];
+    NSString* bottomLabelText = OEXLocalizedString(@"NO_ENROLLMENT_INTERSTITIAL_BOTTOM_LABEL", nil);
 
     NSMutableAttributedString* bottomLabelAttributedText = [[NSMutableAttributedString alloc] initWithString:bottomLabelText];
     [bottomLabelAttributedText setAttributes:@{NSFontAttributeName:[UIFont fontWithName:@"OpenSans" size:self.bottomLabel.font.pointSize]} range:[bottomLabelText rangeOfString:bottomLabelText]];
-    [bottomLabelAttributedText setAttributes:@{NSFontAttributeName:[UIFont fontWithName:@"OpenSans-Semibold" size:self.bottomLabel.font.pointSize]} range:[bottomLabelText rangeOfString:bottomLabelBoldText]];
     self.bottomLabel.attributedText = bottomLabelAttributedText;
 }
 

--- a/edXVideoLocker/OEXGenericCourseTableViewController.m
+++ b/edXVideoLocker/OEXGenericCourseTableViewController.m
@@ -11,6 +11,7 @@
 #import "DACircularProgressView.h"
 
 #import "NSArray+OEXSafeAccess.h"
+#import "NSString+OEXFormatting.h"
 
 #import "OEXAppDelegate.h"
 #import "OEXAuthentication.h"
@@ -332,7 +333,9 @@
     NSInteger downloadingCount = [_dataInterface downloadMultipleVideosForRequestStrings:validArray];
 
     if(downloadingCount > 0) {
-        NSString* message = [NSString stringWithFormat:OEXLocalizedStringPlural(@"VIDEOS_DOWNLOADING", downloadingCount, nil), downloadingCount];
+        NSString* message = [NSString oex_stringWithFormat:
+                             OEXLocalizedStringPlural(@"VIDEOS_DOWNLOADING", downloadingCount, nil)
+                                                parameters:@{@"count" : @(downloadingCount)}];
         [[OEXStatusMessageViewController sharedInstance] showMessage:message onViewController:self];
         [self.table_Generic reloadData];
     }

--- a/edXVideoLocker/OEXMyVideosSubSectionViewController.m
+++ b/edXVideoLocker/OEXMyVideosSubSectionViewController.m
@@ -1032,7 +1032,9 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
                 [self performSelector:@selector(pop) withObject:nil afterDelay:1.0];
             }
             else {
-                NSString* message = [NSString stringWithFormat:OEXLocalizedStringPlural(@"VIDEOS_DELETED", deleteCount, nil), deleteCount];
+                NSString* message = [NSString oex_stringWithFormat:
+                                     OEXLocalizedStringPlural(@"VIDEOS_DELETED", deleteCount, nil)
+                                                    parameters:@{@"count" : @(deleteCount)}];
                 [[OEXStatusMessageViewController sharedInstance] showMessage:message onViewController:self];
 
 		// clear all objects form array after deletion.

--- a/edXVideoLocker/OEXMyVideosViewController.m
+++ b/edXVideoLocker/OEXMyVideosViewController.m
@@ -9,6 +9,7 @@
 #import "OEXMyVideosViewController.h"
 
 #import "NSArray+OEXSafeAccess.h"
+#import "NSString+OEXFormatting.h"
 
 #import "CLPortraitOptionsView.h"
 #import "OEXAppDelegate.h"
@@ -1328,7 +1329,9 @@ typedef  enum OEXAlertType
             [self.table_RecentVideos reloadData];
             [self.table_MyVideos reloadData];
 
-            NSString* message = [NSString stringWithFormat:OEXLocalizedStringPlural(@"VIDEOS_DELETED", deleteCount, nil), deleteCount];
+            NSString* message = [NSString oex_stringWithFormat:
+                                 OEXLocalizedStringPlural(@"VIDEOS_DELETED", deleteCount, nil)
+                                                    parameters:@{@"count" : @(deleteCount)}];
             [[OEXStatusMessageViewController sharedInstance] showMessage:message onViewController:self];
 
             // clear all objects form array after deletion.

--- a/edXVideoLocker/OEXRegistrationFieldSelectController.m
+++ b/edXVideoLocker/OEXRegistrationFieldSelectController.m
@@ -45,7 +45,7 @@
     if(self.field.isRequired && ![self hasValue]) {
         if(!self.field.errorMessage.required) {
             NSString* localizedString = OEXLocalizedString(@"REGISTRATION_FIELD_EMPTY_SELECT_ERROR", nil);
-            NSString* error = [NSString stringWithFormat:localizedString, self.field.label];
+            NSString* error = [NSString oex_stringWithFormat:localizedString parameters:@{@"field_name" : self.field.label}];
             [self handleError:error];
         }
         else {

--- a/edXVideoLocker/OEXRegistrationFieldValidator.m
+++ b/edXVideoLocker/OEXRegistrationFieldValidator.m
@@ -16,7 +16,7 @@
     if(field.isRequired && (currentValue == nil || [currentValue isEqualToString:@""])) {
         if(!field.errorMessage.required) {
             NSString* localizedString = OEXLocalizedString(@"REGISTRATION_FIELD_EMPTY_ERROR", nil);
-            errorMessage = [NSString stringWithFormat:localizedString, field.label];
+            errorMessage = [NSString oex_stringWithFormat:localizedString parameters: @{@"field_name" : field.label}];
             return errorMessage;
         }
         else {
@@ -28,7 +28,11 @@
     if(length < field.restriction.minLength) {
         if(!field.errorMessage.minLength) {
             NSString* localizedString = OEXLocalizedString(@"REGISTRATION_FIELD_MIN_LENGTH_ERROR", nil);
-            errorMessage = [NSString stringWithFormat:localizedString, field.label, field.restriction.minLength];
+            errorMessage = [NSString oex_stringWithFormat:localizedString
+                                               parameters:@{
+                                                            @"field_name" : field.label,
+                                                            @"count" : @(field.restriction.minLength)
+                                                            }];
             return errorMessage;
         }
         else {
@@ -38,7 +42,11 @@
     if(length > field.restriction.maxLength && field.restriction.maxLength != 0) {
         if(!field.errorMessage.maxLength) {
             NSString* localizedString = OEXLocalizedString(@"REGISTRATION_FIELD_MAX_LENGTH_ERROR", nil);
-            errorMessage = [NSString stringWithFormat:localizedString, field.label, field.restriction.maxLength];
+            errorMessage = [NSString oex_stringWithFormat:localizedString
+                                               parameters:@{
+                                                            @"field_name" : field.label,
+                                                            @"count" : @(field.restriction.maxLength)
+                                                            }];
             return errorMessage;
         }
         else {

--- a/edXVideoLocker/en.lproj/Localizable.strings
+++ b/edXVideoLocker/en.lproj/Localizable.strings
@@ -38,8 +38,8 @@
 "COURSE_ENDED"="Ended";
 /* Title of tab showing general course information */
 "COURSE_INFO_TAB_TITLE"="Course Info";
-/* Message shown on a course when it hasn't started yet */
-"COURSE_WILL_START_AT"="This course hasn't started yet. Come back on %@ to see your videos.";
+/* Message shown on a course when it hasn't started yet. {date} will be a localized date string */
+"COURSE_WILL_START_AT"="This course hasn't started yet. Come back on {date} to see your videos.";
 /* Alert dialog confirmation button */
 "DELETE"="Delete";
 /* Alert dialog button allowing user to chosing not to allow downloads on cellular */
@@ -114,9 +114,9 @@
 "NETWORK_NOT_AVAILABLE_MESSAGE_TROUBLE"="You are not connected to the Internet. Please check your Internet connection.";
 /* Title of alert dialog shown when attempting an action without an internet connection */
 "NETWORK_NOT_AVAILABLE_TITLE"="Connection Error";
-/* Title of alert dialog shown when attempting an action without an internet connection */
-"NO_ENROLLMENT_INTERSTITIAL_BOTTOM_LABEL" = "In the meantime, %@ - you'll need to log in, enroll, and then return to the app when you're done.";
-"NO_ENROLLMENT_INTERSTITIAL_BOTTOM_LABEL_BOLD_PART" = "you can enroll in courses through our website";
+/* Message shown when tapping on enroll courses when in app course enrollment is disabled */
+"NO_ENROLLMENT_INTERSTITIAL_BOTTOM_LABEL" = "In the meantime, you can enroll in courses through our website - you'll need to log in, enroll, and then return to the app when you're done.";
+/* Message shown when tapping on enroll courses when in app course enrollment is disabled */
 "NO_ENROLLMENT_INTERSTITIAL_TOP_LABEL" = "Our team is currently working hard to let you enroll in courses within the app.";
 /* Message shown when user attempts to download a video over cellular data, but has chosen to only allow video downloads over wifi */
 "NO_WIFI_MESSAGE" = "Your current download settings only allow downloads over Wi-Fi. Please connect to a Wi-Fi network or change your download settings.";
@@ -150,14 +150,14 @@
 "REGISTRATION_CREATE_MY_ACCOUNT"="Create my account";
 /* Text shown while waiting for registration request */
 "REGISTRATION_CREATING_ACCOUNT"="Creating account...";
-/* Error prompt shown during registration to indicate an empty field. Argument is a field name */
-"REGISTRATION_FIELD_EMPTY_ERROR"="Please enter your %@.";
-/* Error prompt shown during registration to indicate a field missing a selection. Argument is a field name */
-"REGISTRATION_FIELD_EMPTY_SELECT_ERROR"="Please select your %@.";
-/* Error prompt shown during registration when a field entry is too long. Arguments are 1) a field name, 2) a number */
-"REGISTRATION_FIELD_MAX_LENGTH_ERROR"="%@ cannot have more than %d characters.";
-/* Error prompt shown during registration when a field entry is too short. Arguments are 1) a field name, 2) a number */
-"REGISTRATION_FIELD_MIN_LENGTH_ERROR"="%@ must have at least %d characters.";
+/* Error prompt shown during registration to indicate an empty field. {field_name} is the name of a registration field like 'password' */
+"REGISTRATION_FIELD_EMPTY_ERROR"="Please enter your {field_name}.";
+/* Error prompt shown during registration to indicate a field missing a selection. {field_name} is the name of a registration field like 'year of birth' */
+"REGISTRATION_FIELD_EMPTY_SELECT_ERROR"="Please select your {field_name}.";
+/* Error prompt shown during registration when a field entry is too long. {field_name} is the name of a registration field like 'password'. {count} is a number of characters */
+"REGISTRATION_FIELD_MAX_LENGTH_ERROR"="{field_name} cannot have more than {count} characters.";
+/* Error prompt shown during registration when a field entry is too short.  {field_name} is the name of a registration field like 'password'. {count} is a number of characters */
+"REGISTRATION_FIELD_MIN_LENGTH_ERROR"="{field_name} must have at least {count} characters.";
 /* Button text allowing user to hide visible optional registration fields */
 "REGISTRATION_HIDE_OPTIONAL_FIELDS"="Hide optional fields";
 /* Button text allowing user to show hidden optional registration fields */
@@ -196,14 +196,14 @@
 "USERNAME_PLACEHOLDER" = "User name or e-mail address";
 /* Error shown when video download fails */
 "VIDEO_CONTENT_NOT_AVAILABLE"="This video is currently unavailable. Check back again later.";
-/* Floating overlay text shown after deleting a video */
-"VIDEOS_DELETED##{one}" = "%ld video deleted";
-/* Floating overlay text shown after deleting a video */
-"VIDEOS_DELETED##{other}" = "%ld videos deleted";
-/* Floating overlay text shown after video download begins */
-"VIDEOS_DOWNLOADING##{one}" = "Downloading %ld video ";
-/* Floating overlay text shown after video download begins */
-"VIDEOS_DOWNLOADING##{other}" = "Downloading %ld videos ";
+/* Floating overlay text shown after deleting a video. {count} is a number of videos */
+"VIDEOS_DELETED##{one}" = "{count} video deleted";
+/* Floating overlay text shown after deleting a video. {count} is a number of videos */
+"VIDEOS_DELETED##{other}" = "{count} videos deleted";
+/* Floating overlay text shown after video download begins. {count} is a number of videos  */
+"VIDEOS_DOWNLOADING##{one}" = "Downloading {count} video";
+/* Floating overlay text shown after video download begins. {count} is a number of videos  */
+"VIDEOS_DOWNLOADING##{other}" = "Downloading {count} videos";
 /* Alert dialog content shown when user attempts to view a video that hasn't been synced  */
 "VIDEO_NOT_AVAILABLE"="This video is not available in offline mode.\nPlease select a video that you've downloaded onto your device.";
 /* Overlay shown after a network request has started, telling the user to wait for the response */

--- a/edXVideoLockerTests/NSString+OEXFormattingTests.m
+++ b/edXVideoLockerTests/NSString+OEXFormattingTests.m
@@ -1,0 +1,64 @@
+//
+//  NSString+OEXFormatting.m
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 3/17/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+#import "NSString+OEXFormatting.h"
+
+@interface NSString_OEXFormattingTests : XCTestCase
+
+@end
+
+@implementation NSString_OEXFormattingTests
+
+- (void)testFormatNoParams {
+    NSString* format = @"some string with { stuff in it";
+    NSString* result = [NSString oex_stringWithFormat:format parameters:nil];
+    // This is an example of a functional test case.
+    XCTAssertEqualObjects(result, format);
+}
+
+- (void)testFormatSingleReplacement {
+    NSString* format = @"{param} string with {param} stuff in it";
+    NSString* result = [NSString oex_stringWithFormat:format parameters:@{@"param" : @"some"}];
+    // This is an example of a functional test case.
+    XCTAssertEqualObjects(result, @"some string with some stuff in it");
+}
+
+- (void)testNumericReplacement {
+    NSString* format = @"{count} strings";
+    NSString* result = [NSString oex_stringWithFormat:format parameters:@{@"count" : @5}];
+    // This is an example of a functional test case.
+    XCTAssertEqualObjects(result, @"5 strings");
+}
+
+- (void)testFormatMultipleReplacement {
+    NSString* format = @"{param} {arg} with {param} {arg} in it";
+    NSString* result = [NSString oex_stringWithFormat:format parameters:@{@"param" : @"some", @"arg" : @"string"}];
+    // This is an example of a functional test case.
+    XCTAssertEqualObjects(result, @"some string with some string in it");
+}
+
+// These tests will only assert on DEBUG builds
+// As validation will fail silently on RELEASE builds
+#if DEBUG
+
+- (void)testMissingArgument {
+    NSString* format = @"{param} {arg} with {param} {arg} in it";
+    XCTAssertThrowsSpecific([NSString oex_stringWithFormat:format parameters:@{@"param" : @"some"}], NSException);
+}
+
+- (void)testExtraParameter {
+    NSString* format = @"{arg} some text";
+    XCTAssertThrowsSpecific([NSString oex_stringWithFormat:format parameters:@{}], NSException);
+}
+
+#endif
+
+@end


### PR DESCRIPTION
This will make it easier for translators to understand what the
arguments mean and prevent them from having to deal with weird format
specifiers.


@sarina is this a better way to deal with the strings?

@hanningni please review. We'll also need to do this on Android.