### PR TITLE
Prevent data from being backed up EVER

### DIFF
--- a/edXVideoLocker.xcodeproj/project.pbxproj
+++ b/edXVideoLocker.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		77A340211AB2461800C8E141 /* OEXRegistrationViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77A340201AB2461800C8E141 /* OEXRegistrationViewControllerTests.m */; };
 		77ACA1CA1A323C2500039AD1 /* Crashlytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77ACA1C81A323C2500039AD1 /* Crashlytics.framework */; };
 		77ACA1CB1A323C2500039AD1 /* Fabric.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77ACA1C91A323C2500039AD1 /* Fabric.framework */; };
+		77AE2F621ABB71840027E799 /* OEXFileUtilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77AE2F611ABB71840027E799 /* OEXFileUtilityTests.m */; };
 		77B4638A1A30F60C0083453A /* handouts-announcements.css in Resources */ = {isa = PBXBuildFile; fileRef = 77B463891A30F60C0083453A /* handouts-announcements.css */; };
 		77B463911A30F6310083453A /* OEXAnnouncement.m in Sources */ = {isa = PBXBuildFile; fileRef = 77B4638C1A30F6310083453A /* OEXAnnouncement.m */; };
 		77B463971A30F65E0083453A /* OEXStyles.m in Sources */ = {isa = PBXBuildFile; fileRef = 77B463961A30F65E0083453A /* OEXStyles.m */; };
@@ -535,6 +536,7 @@
 		77A340201AB2461800C8E141 /* OEXRegistrationViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXRegistrationViewControllerTests.m; sourceTree = "<group>"; };
 		77ACA1C81A323C2500039AD1 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Crashlytics.framework; path = Libraries/Crashlytics.framework; sourceTree = "<group>"; };
 		77ACA1C91A323C2500039AD1 /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fabric.framework; path = Libraries/Fabric.framework; sourceTree = "<group>"; };
+		77AE2F611ABB71840027E799 /* OEXFileUtilityTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXFileUtilityTests.m; sourceTree = "<group>"; };
 		77B463891A30F60C0083453A /* handouts-announcements.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = "handouts-announcements.css"; sourceTree = "<group>"; };
 		77B4638B1A30F6310083453A /* OEXAnnouncement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXAnnouncement.h; sourceTree = "<group>"; };
 		77B4638C1A30F6310083453A /* OEXAnnouncement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXAnnouncement.m; sourceTree = "<group>"; };
@@ -1610,6 +1612,7 @@
 		BECB7B331924C0C3009C77F1 /* edXVideoLockerTests */ = {
 			isa = PBXGroup;
 			children = (
+				77AE2F611ABB71840027E799 /* OEXFileUtilityTests.m */,
 				7778F0941ABA2C3600B4CDA0 /* OEXRegistrationFieldEmailViewTests.m */,
 				7778F0921ABA1F8000B4CDA0 /* OEXStatusMessageViewControllerTests.m */,
 				194E018F1A54204A00A0CFAE /* OEXDBTests.m */,
@@ -2206,6 +2209,7 @@
 				770A27AC1A702B6500DFC6FF /* OEXDataParserTests.m in Sources */,
 				B4B6D6401A952D1C000F44E8 /* OEXRegistrationAgreementView.m in Sources */,
 				194E01921A54204B00A0CFAE /* OEXDBTests.m in Sources */,
+				77AE2F621ABB71840027E799 /* OEXFileUtilityTests.m in Sources */,
 				7778F0951ABA2C3600B4CDA0 /* OEXRegistrationFieldEmailViewTests.m in Sources */,
 				770A27A11A6F172300DFC6FF /* OEXVideoSummaryTests.m in Sources */,
 				77000A4C1A775904007D306C /* NSDate+OEXComparisonsTests.m in Sources */,

--- a/edXVideoLocker.xcodeproj/xcshareddata/xcschemes/edXVideoLocker.xcscheme
+++ b/edXVideoLocker.xcodeproj/xcshareddata/xcschemes/edXVideoLocker.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "C3755C06723335B490C1F41E"
+               BlueprintIdentifier = "7760F537DF5B7788B16F325D"
                BuildableName = "libPods-edXVideoLocker.a"
                BlueprintName = "Pods-edXVideoLocker"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -56,7 +56,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "0F2A6DA2F3F19812BE8555B1"
+               BlueprintIdentifier = "50B5C0B786DE01FFAF8FF881"
                BuildableName = "libPods-edXVideoLocker-Analytics.a"
                BlueprintName = "Pods-edXVideoLocker-Analytics"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -140,7 +140,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BF1161C42CE35DC2F70E0162"
+               BlueprintIdentifier = "905345F1BA9B10B0246E05AE"
                BuildableName = "libPods-edXVideoLocker-GoogleAnalytics-iOS-SDK.a"
                BlueprintName = "Pods-edXVideoLocker-GoogleAnalytics-iOS-SDK"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -210,7 +210,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E704E37F9807E47B09E2D011"
+               BlueprintIdentifier = "5E9E997ED9F7B41B6D121041"
                BuildableName = "libPods-edXVideoLocker-TRVSDictionaryWithCaseInsensitivity.a"
                BlueprintName = "Pods-edXVideoLocker-TRVSDictionaryWithCaseInsensitivity"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -296,7 +296,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BECB7B0A1924C0C3009C77F1"
@@ -314,7 +315,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BECB7B0A1924C0C3009C77F1"

--- a/edXVideoLocker/OEXAppDelegate.m
+++ b/edXVideoLocker/OEXAppDelegate.m
@@ -47,7 +47,7 @@
     [OEXSession migrateToKeychainIfNecessary];
 	//// Clear keychain for first launch
     OEXSession* session = [OEXSession activeSession];
-    NSString* userDir = [OEXFileUtility userDirectoryPathForUserName:session.currentUser.username];
+    NSString* userDir = [OEXFileUtility pathForUserNameCreatingIfNecessary:session.currentUser.username];
     BOOL hasUserDir = [[NSFileManager defaultManager] fileExistsAtPath:userDir];
     BOOL hasInvalidTokenType = session.edxToken.tokenType.length == 0;
     if(session != nil && (!hasUserDir || hasInvalidTokenType)) {

--- a/edXVideoLocker/OEXCourseVideoDownloadTableViewController.m
+++ b/edXVideoLocker/OEXCourseVideoDownloadTableViewController.m
@@ -1084,12 +1084,12 @@ typedef  enum OEXAlertType
 	//stop current video
     [_videoPlayerInterface.moviePlayerController stop];
     NSFileManager* filemgr = [NSFileManager defaultManager];
-    NSString* slink = [video.filePath stringByAppendingPathExtension:@"mp4"];
-    if(![filemgr fileExistsAtPath:slink]) {
+    NSString* path = [video.filePath stringByAppendingPathExtension:@"mp4"];
+    if(![filemgr fileExistsAtPath:path]) {
         [self showAlert:OEXAlertTypePlayBackErrorAlert];
     }
 
-    self.currentVideoURL = [NSURL fileURLWithPath:slink];
+    self.currentVideoURL = [NSURL fileURLWithPath:path];
     self.currentPlayingOnlineURL = video.summary.videoURL;
     self.currentTappedVideo = video;
     _isStratingNewVideo = YES;

--- a/edXVideoLocker/OEXDBManager.m
+++ b/edXVideoLocker/OEXDBManager.m
@@ -130,7 +130,8 @@ static OEXDBManager* _sharedManager = nil;
         return _persistentStoreCoordinator;
     }
 
-    NSURL* storeURL = [[self applicationDocumentsDirectory] URLByAppendingPathComponent:[NSString stringWithFormat:@"%@/Database/edXDB.sqlite", self.userName]];
+    NSString* storePath = [[OEXFileUtility userDirectory] stringByAppendingPathComponent:@"Database/edXDB.sqlite"];
+    NSURL* storeURL = [NSURL fileURLWithPath:storePath];
 
     ELog(@"DB path %@", storeURL);
 
@@ -515,20 +516,6 @@ static OEXDBManager* _sharedManager = nil;
     return data;
 }
 
-- (BOOL)storeResumeData:(NSData*)data forVideoID:(NSString*)video_id {
-    VideoData* videoData = [self getVideoDataForVideoID:video_id];
-
-    if(!videoData) {
-        return NO;
-    }
-
-    if(![data writeToURL:[NSURL fileURLWithPath:videoData.filepath] atomically:YES]) {
-        return NO;
-    }
-
-    return YES;
-}
-
 - (void)startedDownloadForVideo:(VideoData*)videoData {
     if(videoData) {
         videoData.download_state = [NSNumber numberWithFloat:OEXDownloadStatePartial];
@@ -743,7 +730,6 @@ static OEXDBManager* _sharedManager = nil;
     Title: (NSString*)title
     Size: (NSString*)size
     Durartion: (NSString*)duration
-    FilePath: (NSString*)filepath
     OEXDownloadState: (int)download_state
     VideoURL: (NSString*)video_url
     VideoID: (NSString*)video_id
@@ -769,7 +755,6 @@ static OEXDBManager* _sharedManager = nil;
     videoObj.title = title;
     videoObj.size = size;
     videoObj.duration = duration;
-    videoObj.filepath = filepath;
     videoObj.download_state = [NSNumber numberWithInt:download_state];
     videoObj.video_url = video_url;
     videoObj.video_id = video_id;
@@ -921,19 +906,6 @@ static OEXDBManager* _sharedManager = nil;
     }
 }
 
-// Update the video data with download file path
-- (void)updateDownloadFilePath: (NSString*)username
-    VideoID: (NSString*)video_id
-    WithVideoURL: (NSString*)video_url {
-    NSArray* resultArray = [self getRecordsForOperation:username VideoID:video_id];
-
-    if([resultArray count] > 0) {
-        VideoData* videoObj = [resultArray objectAtIndex:0];
-        videoObj.filepath = [OEXFileUtility relativePathForUrl:video_url];
-        [self saveCurrentStateToDB];
-    }
-}
-
 // Update the video downloaded timestamp
 - (void)updateDownloadTimestamp: (NSString*)username
     VideoID: (NSString*)video_id
@@ -967,12 +939,6 @@ static OEXDBManager* _sharedManager = nil;
         videoObj.is_registered = [NSNumber numberWithBool:is_registered];
         [self saveCurrentStateToDB];
     }
-}
-
-#pragma mark - Application's Documents directory
-
-- (NSURL*)applicationDocumentsDirectory {
-    return [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
 }
 
 @end

--- a/edXVideoLocker/OEXDownloadManager.h
+++ b/edXVideoLocker/OEXDownloadManager.h
@@ -43,6 +43,4 @@
 
 -(void)activateDownloadManager;
 
-+(void) clearDownlaodManager;
-
 @end

--- a/edXVideoLocker/OEXDownloadManager.m
+++ b/edXVideoLocker/OEXDownloadManager.m
@@ -266,8 +266,8 @@ static NSURLSession* videosBackgroundSession = nil;
                   if(user) {
                       if(resumeData) {
                           NSString* resume = [[NSString alloc] initWithData:resumeData encoding:NSUTF8StringEncoding];
-                          ELog(@"Resume data written at path %@ ==>> \n %@", [OEXFileUtility completeFilePathForUrl:[task.originalRequest.URL absoluteString] andUserName:userName], resume);
-                          [OEXFileUtility writeData:resumeData atFilePath:[OEXFileUtility completeFilePathForUrl:[task.originalRequest.URL absoluteString] andUserName:userName]];
+                          ELog(@"Resume data written at path %@ ==>> \n %@", [OEXFileUtility completeFilePathForUrl:[task.originalRequest.URL absoluteString] userName:userName], resume);
+                          [OEXFileUtility writeData:resumeData atFilePath:[OEXFileUtility completeFilePathForUrl:[task.originalRequest.URL absoluteString] userName:userName]];
                       }
                   }
                   cancelledCount++;
@@ -285,7 +285,7 @@ static NSURLSession* videosBackgroundSession = nil;
      }];
 }
 
-+(void) clearDownlaodManager {
++(void) clearDownloadManager {
     [_downloadManager cancelAllDownloadsForUser:[OEXAuthentication getLoggedInUser].username completionHandler:^{
          _downloadManager = nil;
      }];

--- a/edXVideoLocker/OEXFileUtility.h
+++ b/edXVideoLocker/OEXFileUtility.h
@@ -12,17 +12,13 @@
 
 + (void)updateData:(NSData*)data ForURLString:(NSString*)URLString;
 
-+(NSString*) documentDir;
-
+/// Returns a path for saving user specific data. This data is not backed up
+/// When called it will create the directory if it does not already exist
++(NSString*) pathForUserNameCreatingIfNecessary:(NSString*)userName;
+/// Shortcut for userDirectoryPathForUserName: with the current user
 +(NSString*) userDirectory;
 
-+(NSString*) relativePathForUrl:(NSString*)url;
-
-+(NSString*) userRelativePathForUrl:(NSString*)url;
-
 +(NSString*) completeFilePathForUrl:(NSString*)url;
-
-+(NSString*) completeFilePathForRelativePath:(NSString*)relativePath;
 
 +(BOOL ) writeData:(NSData*)data atFilePath:(NSString*)filePath;
 
@@ -30,12 +26,17 @@
 
 + (NSData*)resumeDataForURLString:(NSString*)URLString;
 
-+ (void)deleteResumeDataForURLString:(NSString*)URLString;
-
 +(NSString*)localFilePathForVideoUrl:(NSString*)videoUrl;
 
-+(NSString*)completeFilePathForUrl:(NSString*)url andUserName:(NSString*)username;
++(NSString*)completeFilePathForUrl:(NSString*)url userName:(NSString*)username;
 
-+(NSString*) userDirectoryPathForUserName:(NSString*)userName;
+
+@end
+
+@interface OEXFileUtility (Testing)
+
++ (NSString*)t_legacyPathForUserName:(NSString *)userName;
+// Unlike the non test version, this does not create the directory
++ (NSString*)t_pathForUserName:(NSString *)userName;
 
 @end

--- a/edXVideoLocker/OEXInterface.m
+++ b/edXVideoLocker/OEXInterface.m
@@ -403,7 +403,6 @@ static OEXInterface* _sharedInterface = nil;
             Title: helperVideo.summary.name
             Size: [NSString stringWithFormat:@"%.2f", [helperVideo.summary.size doubleValue]]
             Durartion: [NSString stringWithFormat:@"%.2f", helperVideo.summary.duration]
-            FilePath: [OEXFileUtility userRelativePathForUrl:helperVideo.summary.videoURL]
             OEXDownloadState: helperVideo.state
             VideoURL: helperVideo.summary.videoURL
             VideoID: helperVideo.summary.videoID

--- a/edXVideoLocker/OEXMyVideosSubSectionViewController.m
+++ b/edXVideoLocker/OEXMyVideosSubSectionViewController.m
@@ -550,29 +550,17 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
 	// Set the path of the downloaded videos
     [_dataInterface downloadTranscripts:obj];
 
-    NSFileManager* filemgr = [NSFileManager defaultManager];
-    NSString* slink = [obj.filePath stringByAppendingPathExtension:@"mp4"];
-    if(![filemgr fileExistsAtPath:slink]) {
-        NSError* error = nil;
-        [filemgr createSymbolicLinkAtPath:[obj.filePath stringByAppendingPathExtension:@"mp4"] withDestinationPath:obj.filePath error:&error];
-
-        if(error) {
-            [self showAlert:OEXAlertTypePlayBackErrorAlert];
-        }
-    }
-
 	//stop current video
     [_videoPlayerInterface.moviePlayerController stop];
 
     self.currentTappedVideo = obj;
-    self.currentVideoURL = [NSURL fileURLWithPath:slink];
+    self.currentVideoURL = [NSURL fileURLWithPath:self.currentTappedVideo.filePath];
     self.lbl_videoHeader.text = [NSString stringWithFormat:@"%@ ", self.currentTappedVideo.summary.name];
     self.lbl_videobottom.text = [NSString stringWithFormat:@"%@ ", obj.summary.name];
     self.lbl_section.text = [NSString stringWithFormat:@"%@\n%@", self.currentTappedVideo.summary.sectionPathEntry.name, self.currentTappedVideo.summary.chapterPathEntry.name];
     [self.table_SubSectionVideos deselectRowAtIndexPath:indexPath animated:NO];
     self.contraintEditingView.constant = 0;
     [self handleComponentsFrame];
-	// [_videoPlayerInterface playVideoFor:obj];
     [_videoPlayerInterface playVideoFor:obj];
 
 	// Send Analytics

--- a/edXVideoLocker/OEXMyVideosViewController.m
+++ b/edXVideoLocker/OEXMyVideosViewController.m
@@ -813,26 +813,12 @@ typedef  enum OEXAlertType
 	// Set the path of the downloaded videos
     [_dataInterface downloadTranscripts:self.currentTappedVideo];
 
-    NSFileManager* filemgr = [NSFileManager defaultManager];
-    NSString* slink = [self.currentTappedVideo.filePath stringByAppendingPathExtension:@"mp4"];
-    if(![filemgr fileExistsAtPath:slink]) {
-        NSError* error = nil;
-        [filemgr createSymbolicLinkAtPath:slink withDestinationPath:self.currentTappedVideo.filePath error:&error];
-
-        if(error) {
-            [self showAlert:OEXAlertTypePlayBackErrorAlert];
-        }
-    }
-
     [self activatePlayer];
 
     self.video_containerView.hidden = NO;
     [_videoPlayerInterface setShouldRotate:YES];
     [self.videoPlayerInterface.moviePlayerController stop];
-    if(slink) {
-        self.currentVideoURL = [NSURL fileURLWithPath:slink];
-    }
-	// handle the frame of table, videoplayer & bottom view
+    self.currentVideoURL = [NSURL fileURLWithPath:self.currentTappedVideo.filePath];
     [self handleComponentsFrame];
 
     self.lbl_videoHeader.text = [NSString stringWithFormat:@"%@ ", self.currentTappedVideo.summary.name];

--- a/edXVideoLocker/OEXStorageInterface.h
+++ b/edXVideoLocker/OEXStorageInterface.h
@@ -80,9 +80,6 @@
 // Returns the data of the video to resume download.
 - (NSData*)resumeDataForVideoID:(NSString*)video_id;
 
-// Store the video data when download stopped
-- (BOOL)storeResumeData:(NSData*)data forVideoID:(NSString*)video_id;
-
 // Set the video details & set the download state to PARTIAL for a video.
 - (void)startedDownloadForVideo:(VideoData*)videoData;
 
@@ -134,7 +131,6 @@
     Title: (NSString*)title
     Size: (NSString*)size
     Durartion: (NSString*)duration
-    FilePath: (NSString*)filepath
     OEXDownloadState: (int)download_state
     VideoURL: (NSString*)video_url
     VideoID: (NSString*)video_id
@@ -184,11 +180,6 @@
 - (void)updatePlayedState: (NSString*)username
     VideoID: (NSString*)video_id
     WithPlayedState: (int)played_state;
-
-// Update the video data with download file path
-- (void)updateDownloadFilePath: (NSString*)username
-    VideoID: (NSString*)video_id
-    WithVideoURL: (NSString*)video_url;
 
 // Update the video downloaded timestamp
 - (void)updateDownloadTimestamp: (NSString*)username

--- a/edXVideoLocker/OEXVideoPlayerInterface.m
+++ b/edXVideoLocker/OEXVideoPlayerInterface.m
@@ -83,13 +83,13 @@
     NSURL* url = [NSURL URLWithString:video.summary.videoURL];
 
     NSFileManager* filemgr = [NSFileManager defaultManager];
-    NSString* slink = [video.filePath stringByAppendingPathExtension:@"mp4"];
+    NSString* path = [video.filePath stringByAppendingPathExtension:@"mp4"];
 
-    if([filemgr fileExistsAtPath:slink]) {
-        url = [NSURL fileURLWithPath:slink];
+    if([filemgr fileExistsAtPath:path]) {
+        url = [NSURL fileURLWithPath:path];
     }
 
-    if(video.state == OEXDownloadStateComplete && ![filemgr fileExistsAtPath:slink]) {
+    if(video.state == OEXDownloadStateComplete && ![filemgr fileExistsAtPath:path]) {
         return;
     }
 

--- a/edXVideoLocker/VideoData.h
+++ b/edXVideoLocker/VideoData.h
@@ -17,7 +17,8 @@
 @property (nonatomic, retain) NSDate* downloadCompleteDate;
 @property (nonatomic, retain) NSString* duration;
 @property (nonatomic, retain) NSString* enrollment_id;
-@property (nonatomic, retain) NSString* filepath;
+// TODO: next time we do a schema migration we should get rid of this property
+@property (nonatomic, retain) NSString* filepath DEPRECATED_ATTRIBUTE;
 @property (nonatomic, retain) NSNumber* is_registered;
 @property (nonatomic, retain) NSNumber* last_played_offset;
 @property (nonatomic, retain) NSNumber* played_state;

--- a/edXVideoLockerTests/OEXDBTests.m
+++ b/edXVideoLockerTests/OEXDBTests.m
@@ -41,7 +41,6 @@
                             Title:@"Video1"
                              Size:@"150000"
                         Durartion:@"200"
-                         FilePath:@"/"
                     OEXDownloadState:1
                          VideoURL:VIDEO_URL
                           VideoID:VIDEO_ID
@@ -363,8 +362,6 @@
 
 
 // Store the video data when download stopped
-//- (BOOL)storeResumeData:(NSData *)data forVideoID:(NSString *)video_id;
-
 
 
 // Returns the data of the video to resume download.

--- a/edXVideoLockerTests/OEXFileUtilityTests.m
+++ b/edXVideoLockerTests/OEXFileUtilityTests.m
@@ -1,0 +1,71 @@
+//
+//  OEXFileUtilityTests.m
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 3/19/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+@interface OEXFileUtilityTests : XCTestCase
+
+@property (copy, nonatomic) NSString* username;
+
+@end
+
+@implementation OEXFileUtilityTests
+
+- (void)setUp {
+    self.username = [NSUUID UUID].UUIDString;
+}
+
+- (void)tearDown {
+    NSError* error = nil;
+    [[NSFileManager defaultManager] removeItemAtPath:[OEXFileUtility pathForUserNameCreatingIfNecessary:self.username] error:&error];
+    XCTAssertNil(error);
+}
+
+- (BOOL)pathIsExcludedFromBackup:(NSString*)path {
+    NSError* error = nil;
+    NSDictionary* values = [[NSURL fileURLWithPath:path] resourceValuesForKeys:@[NSURLIsExcludedFromBackupKey] error:&error];
+    XCTAssertNil(error);
+    return [values[NSURLIsExcludedFromBackupKey] boolValue];
+}
+
+- (void)testUserDirectoryMigration {
+    NSString* legacyDirectory = [OEXFileUtility t_legacyPathForUserName:self.username];
+    NSError* error = nil;
+    [[NSFileManager defaultManager] createDirectoryAtPath:legacyDirectory withIntermediateDirectories:YES attributes:nil error:&error];
+    XCTAssertNil(error);
+    
+    NSString* directory = [OEXFileUtility pathForUserNameCreatingIfNecessary:self.username];
+    
+    XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:legacyDirectory]);
+    XCTAssertTrue([self pathIsExcludedFromBackup:directory]);
+}
+
+- (void)testUserDirectoryCreation {
+    NSString* directory = [OEXFileUtility pathForUserNameCreatingIfNecessary:self.username];
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:directory]);
+    XCTAssertTrue([self pathIsExcludedFromBackup:directory]);
+}
+
+- (void)testUserDirectoryAlreadyExists {
+    NSString* existingPath = [OEXFileUtility t_pathForUserName:self.username];
+    // shouldn't affect anything
+    NSError* error = nil;
+    [[NSFileManager defaultManager] createDirectoryAtPath:existingPath withIntermediateDirectories:YES attributes:nil error:&error];
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:existingPath]);
+    XCTAssertNil(error);
+    
+    NSString* path = [OEXFileUtility pathForUserNameCreatingIfNecessary:self.username];
+    XCTAssertEqualObjects(existingPath, path);
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:path]);
+    
+    XCTAssertTrue([self pathIsExcludedFromBackup:path]);
+}
+
+
+@end


### PR DESCRIPTION
This significantly cleans up the file path code, removing a bunch of
stuff that is unnecessary or does not appear to be used. Additionally,
paths now funnel through central methods instead of duplicating code.

JIRA: https://openedx.atlassian.net/browse/MOB-1245