### PR TITLE
Fix issue saving video location when pressing Back

### DIFF
--- a/edXVideoLocker/OEXCourseVideoDownloadTableViewController.m
+++ b/edXVideoLocker/OEXCourseVideoDownloadTableViewController.m
@@ -213,7 +213,6 @@ typedef  enum OEXAlertType
 
 - (void)navigateBack {
     [self.videoPlayerInterface.moviePlayerController setShouldAutoplay:NO];
-    [self.videoPlayerInterface resetPlayer];
     [self.videoPlayerInterface.moviePlayerController stop];
     [self.videoPlayerInterface resetPlayer];
     [self removeObserver];


### PR DESCRIPTION
We were resetting the video player before stopping the video, where
stopping the video is the thing that saves its location. There was
already a reset call after stop, so this just removes the seemingly
otherwise unnecessary one right before it.