### PR TITLE
Remove unneeded fetch of CSRF token

### DIFF
--- a/edXVideoLocker/OEXAuthentication.h
+++ b/edXVideoLocker/OEXAuthentication.h
@@ -27,7 +27,7 @@ typedef void (^ OEXURLRequestHandler)(NSData* data, NSURLResponse* response, NSE
            completionHandler:(OEXURLRequestHandler)completionBlock;
 + (NSString*)authHeaderForApiAccess;
 
-+ (void)resetPasswordWithEmailId:(NSString*)email CSRFToken:(NSString*)token completionHandler:(OEXURLRequestHandler)completionBlock;
++ (void)resetPasswordWithEmailId:(NSString*)email completionHandler:(OEXURLRequestHandler)completionBlock;
 + (void)socialLoginWith:(OEXSocialLoginType)loginType completionHandler:(OEXURLRequestHandler)handler;
 + (void)authenticateWithAccessToken:(NSString*)token loginType:(OEXSocialLoginType)loginType completionHandler:(OEXURLRequestHandler)handler;
 

--- a/edXVideoLocker/OEXAuthentication.m
+++ b/edXVideoLocker/OEXAuthentication.m
@@ -54,16 +54,12 @@ typedef void (^ OEXSocialLoginCompletionHandler)(NSString* accessToken, NSError*
 }
 
 ////This method is used to reset user password
-+ (void)resetPasswordWithEmailId:(NSString*)email CSRFToken:(NSString*)token completionHandler:(OEXURLRequestHandler)completionBlock {
++ (void)resetPasswordWithEmailId:(NSString*)email completionHandler:(OEXURLRequestHandler)completionBlock {
     NSString* string = [@{@"email" : email} oex_stringByUsingFormEncoding];
     NSData* postData = [string dataUsingEncoding:NSUTF8StringEncoding];
 
     NSURLSessionConfiguration* sessionConfig = [NSURLSessionConfiguration defaultSessionConfiguration];
     NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@%@", [OEXConfig sharedConfig].apiHostURL, URL_RESET_PASSWORD]]];
-    [request addValue:token forHTTPHeaderField:@"Cookie"];
-
-    NSArray* parse = [token componentsSeparatedByString:@"="];
-    [request addValue:[parse objectAtIndex:1] forHTTPHeaderField:@"X-CSRFToken"];
     [request addValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
     [request addValue:@"application/json" forHTTPHeaderField:@"Accept"];
     [request setHTTPMethod:@"POST"];


### PR DESCRIPTION
We don't need CSRF protection for the reset password token. It doesn't
make sense since you don't even have a session when you're doing reset
password.