### PR TITLE
Remove unnecessary methods on OEXAuthentication. Misc cleanup

### DIFF
--- a/edXVideoLocker/Main.storyboard
+++ b/edXVideoLocker/Main.storyboard
@@ -341,12 +341,10 @@
                         <outlet property="constraint_ForgotTop" destination="qSH-lF-g6V" id="tUf-Vk-0Lv"/>
                         <outlet property="constraint_GoogleTop" destination="A62-OR-V0i" id="WpR-fC-U8A"/>
                         <outlet property="constraint_LeftSepTop" destination="adB-Ch-SkK" id="KcK-sG-5fc"/>
-                        <outlet property="constraint_Left_Facebook_Btn" destination="SRr-Yi-jEt" id="4X3-dY-ySt"/>
                         <outlet property="constraint_MapTop" destination="UoH-Qe-sBT" id="7xU-13-gR4"/>
                         <outlet property="constraint_PassGreyTop" destination="gG2-Fb-52H" id="3H5-kK-Hr3"/>
                         <outlet property="constraint_PasswordTop" destination="DFX-Cf-mvd" id="J9t-n2-X3X"/>
                         <outlet property="constraint_RightSepTop" destination="3ON-jd-LJN" id="UHg-sq-NfO"/>
-                        <outlet property="constraint_Right_Google_Btn" destination="8kN-wW-JPV" id="2LE-6r-Y9G"/>
                         <outlet property="constraint_SignInTop" destination="Wpv-G4-A8C" id="S6l-gk-1ZJ"/>
                         <outlet property="constraint_SignTop" destination="pP3-3c-bbI" id="wwu-cz-tBI"/>
                         <outlet property="constraint_UserGreyTop" destination="qUr-aj-qKj" id="FFf-nx-uSD"/>

--- a/edXVideoLocker/OEXAuthentication.h
+++ b/edXVideoLocker/OEXAuthentication.h
@@ -31,12 +31,6 @@ typedef void (^ OEXURLRequestHandler)(NSData* data, NSURLResponse* response, NSE
 + (void)socialLoginWith:(OEXSocialLoginType)loginType completionHandler:(OEXURLRequestHandler)handler;
 + (void)authenticateWithAccessToken:(NSString*)token loginType:(OEXSocialLoginType)loginType completionHandler:(OEXURLRequestHandler)handler;
 
-+ (BOOL)isUserLoggedIn;
-
-+ (OEXUserDetails*)getLoggedInUser;
-
-+ (void)clearUserSession;
-
 + (void)registerUserWithParameters:(NSDictionary*)parameters completionHandler:(OEXURLRequestHandler)handler;
 
 @end

--- a/edXVideoLocker/OEXAuthentication.m
+++ b/edXVideoLocker/OEXAuthentication.m
@@ -131,30 +131,7 @@ typedef void (^ OEXSocialLoginCompletionHandler)(NSString* accessToken, NSError*
     completionHandler([mutablerequest copy]);
 }
 
-+ (void)clearUserSession {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if([OEXAuthentication getLoggedInUser]) {
-            ELog(@"clearUserSessoin -1");
-            [[OEXFBSocial sharedInstance] logout];
-            [[OEXGoogleSocial sharedInstance] logout];
-            [[OEXSession activeSession] closeAndClearSession];
-        }
-        ELog(@"clearUserSession -2");
-    });
-}
-
-+ (BOOL)isUserLoggedIn {
-    return [[OEXSession activeSession] currentUser] != nil;
-}
-
-+ (OEXUserDetails*)getLoggedInUser {
-    return [[OEXSession activeSession] currentUser];
-}
-
-+ (void)saveUserCredentials {
-}
-
-#pragma mark Social Login Mrthods
+#pragma mark Social Login Methods
 
 + (void)loginWithGoogle:(OEXSocialLoginCompletionHandler)handler {
     [[OEXGoogleSocial sharedInstance] googleLogin:^(NSString* accessToken, NSError* error){
@@ -245,7 +222,7 @@ typedef void (^ OEXSocialLoginCompletionHandler)(NSString* accessToken, NSError*
                     NSError* error;
                     NSDictionary* dictionary = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
                     OEXAccessToken* token = [[OEXAccessToken alloc] initWithTokenDetails:dictionary];
-                    [OEXAuthentication handleSuccessfulLoginWithToken:token completionHandler:handler];
+                    [self handleSuccessfulLoginWithToken:token completionHandler:handler];
                     return;
                 }
                 else if(httpResp.statusCode == 401) {

--- a/edXVideoLocker/OEXCourseVideoDownloadTableViewController.m
+++ b/edXVideoLocker/OEXCourseVideoDownloadTableViewController.m
@@ -1152,7 +1152,7 @@ typedef  enum OEXAlertType
 
                 if(success) {
                     [[OEXStatusMessageViewController sharedInstance]
-                                 showMessage:OEXLocalizedString(@"DOWNLOADING_1_VIDEO", nil) onViewController:self];
+                     showMessage:OEXLocalizedString(@"DOWNLOADING_1_VIDEO", nil) onViewController:self];
                     if(video.DownloadProgress == 100) {
                         OEXCourseVideosTableViewCell* cell = (OEXCourseVideosTableViewCell*)[self.table_Videos cellForRowAtIndexPath:[NSIndexPath indexPathForRow:tagValue inSection:0]];
                         cell.customProgressView.hidden = NO;

--- a/edXVideoLocker/OEXDownloadManager.m
+++ b/edXVideoLocker/OEXDownloadManager.m
@@ -7,9 +7,10 @@
 //
 
 #import "OEXDownloadManager.h"
-#import "OEXNetworkConstants.h"
-#import "OEXAuthentication.h"
+
 #import "OEXAppDelegate.h"
+#import "OEXNetworkConstants.h"
+#import "OEXSession.h"
 #import "OEXStorageInterface.h"
 #import "OEXStorageFactory.h"
 
@@ -73,7 +74,7 @@ static NSURLSession* videosBackgroundSession = nil;
 - (void)deactivateWithCompletionHandler:(void (^)(void))completionHandler {
     [self.storage pausedAllDownloads];
     _isActive = NO;
-    [self pauseAllDownloadsForUser:[OEXAuthentication getLoggedInUser].username completionHandler:^{
+    [self pauseAllDownloadsForUser:[OEXSession activeSession].currentUser.username completionHandler:^{
         // [videosBackgroundSession invalidateAndCancel];
         // _downloadManager=nil;
         completionHandler();
@@ -286,7 +287,7 @@ static NSURLSession* videosBackgroundSession = nil;
 }
 
 + (void)clearDownloadManager {
-    [_downloadManager cancelAllDownloadsForUser:[OEXAuthentication getLoggedInUser].username completionHandler:^{
+    [_downloadManager cancelAllDownloadsForUser:[OEXSession activeSession].currentUser.username completionHandler:^{
         _downloadManager = nil;
     }];
     _downloadManager = nil;
@@ -423,7 +424,7 @@ static NSURLSession* videosBackgroundSession = nil;
 }
 
 - (NSString*)keyForDownloadTask:(NSURLSessionDownloadTask*)downloadTask {
-    NSString* strTaskID = [NSString stringWithFormat:@"%@_%lu", [OEXAuthentication getLoggedInUser].username, (unsigned long)downloadTask.taskIdentifier];
+    NSString* strTaskID = [NSString stringWithFormat:@"%@_%lu", [OEXSession activeSession].currentUser.username, (unsigned long)downloadTask.taskIdentifier];
     return strTaskID;
 }
 

--- a/edXVideoLocker/OEXInterface.h
+++ b/edXVideoLocker/OEXInterface.h
@@ -25,13 +25,8 @@
 @property (nonatomic, assign) NSInteger selectedCCIndex;
 @property (nonatomic, assign) NSInteger selectedVideoSpeedIndex;
 
-@property (nonatomic, strong) OEXUserDetails* userdetail;
 @property (nonatomic, strong) NSArray* courses;
 @property (nonatomic, strong) NSMutableDictionary* courseVideos;
-//Auth
-@property (nonatomic, strong) NSString* signInID;
-@property (nonatomic, strong) NSString* signInUserName;
-@property (nonatomic, strong) NSString* signInPassword;
 @property(nonatomic, assign) BOOL shownOfflineView;
 
 //Reachability
@@ -46,8 +41,6 @@
 + (BOOL)isURLForVideo:(NSString*)URLString;
 + (BOOL)isURLForImage:(NSString*)URLString;
 + (BOOL)isURLForedXDomain:(NSString*)URLString;
-
-- (void)loggedInUser:(OEXUserDetails*)user;
 
 #pragma mark Resource downloading
 - (BOOL)downloadWithRequestString:(NSString*)URLString forceUpdate:(BOOL)update;

--- a/edXVideoLocker/OEXNetworkInterface.m
+++ b/edXVideoLocker/OEXNetworkInterface.m
@@ -11,6 +11,7 @@
 #import "OEXConfig.h"
 #import "OEXInterface.h"
 #import "OEXNetworkConstants.h"
+#import "OEXSession.h"
 
 @interface OEXNetworkInterface ()
 
@@ -43,11 +44,11 @@
 - (NSString*)descriptionForURLString:(NSString*)URLString {
     NSMutableString* comparisonString = [NSMutableString stringWithString:[OEXConfig sharedConfig].apiHostURL];
     if([URLString isEqualToString:[comparisonString stringByAppendingFormat:
-                                   @"/%@/%@", URL_USER_DETAILS, [[OEXInterface sharedInterface] signInUserName]]]) {
+                                   @"/%@/%@", URL_USER_DETAILS, [OEXSession activeSession].currentUser.username]]) {
         return REQUEST_USER_DETAILS;
     }
     else if([URLString isEqualToString:[comparisonString stringByAppendingFormat:
-                                        @"/%@/%@%@", URL_USER_DETAILS, [[OEXInterface sharedInterface] signInUserName], URL_COURSE_ENROLLMENTS]]) {
+                                        @"/%@/%@%@", URL_USER_DETAILS, [OEXSession activeSession].currentUser.username, URL_COURSE_ENROLLMENTS]]) {
         return REQUEST_COURSE_ENROLLMENTS;
     }
     else {
@@ -91,10 +92,10 @@
     NSMutableString* URLString = [OEXConfig sharedConfig].apiHostURL.mutableCopy;
 
     if([type isEqualToString:URL_USER_DETAILS]) {
-        [URLString appendFormat:@"%@/%@", URL_USER_DETAILS, [[OEXInterface sharedInterface] signInUserName]];
+        [URLString appendFormat:@"%@/%@", URL_USER_DETAILS, [OEXSession activeSession].currentUser.username];
     }
     else if([type isEqualToString:URL_COURSE_ENROLLMENTS]) {
-        [URLString appendFormat:@"%@/%@%@", URL_USER_DETAILS, [[OEXInterface sharedInterface] signInUserName], URL_COURSE_ENROLLMENTS];
+        [URLString appendFormat:@"%@/%@%@", URL_USER_DETAILS, [OEXSession activeSession].currentUser.username, URL_COURSE_ENROLLMENTS];
     }
     else {
         URLString = [NSMutableString stringWithString:type];

--- a/edXVideoLocker/OEXRearTableViewController.m
+++ b/edXVideoLocker/OEXRearTableViewController.m
@@ -13,7 +13,6 @@
 
 #import "OEXAppDelegate.h"
 #import "OEXCustomLabel.h"
-#import "OEXAuthentication.h"
 #import "OEXConfig.h"
 #import "OEXFindCoursesViewController.h"
 #import "OEXImageCache.h"
@@ -21,6 +20,7 @@
 #import "OEXMySettingsViewController.h"
 #import "OEXMyVideosViewController.h"
 #import "OEXNetworkConstants.h"
+#import "OEXSession.h"
 #import "OEXUserDetails.h"
 #import "SWRevealViewController.h"
 
@@ -58,16 +58,9 @@ typedef NS_ENUM (NSUInteger, OEXRearViewOptions)
     self.dataInterface = [OEXInterface sharedInterface];
 
     //Call API
-    if(!_dataInterface.userdetail) {
-        if([OEXAuthentication getLoggedInUser]) {
-            _dataInterface.userdetail = [OEXAuthentication getLoggedInUser];
-            self.userNameLabel.text = _dataInterface.userdetail.name;
-            self.userEmailLabel.text = _dataInterface.userdetail.email;
-        }
-    }
-    else {
-        self.userNameLabel.text = _dataInterface.userdetail.name;
-        self.userEmailLabel.text = _dataInterface.userdetail.email;
+    if([OEXSession activeSession].currentUser) {
+        self.userNameLabel.text = [OEXSession activeSession].currentUser.name;
+        self.userEmailLabel.text = [OEXSession activeSession].currentUser.email;
     }
 
     NSString* environmentName = [[OEXConfig sharedConfig] environmentName];
@@ -195,8 +188,8 @@ typedef NS_ENUM (NSUInteger, OEXRearViewOptions)
     NSString* successString = [userDetailsDict objectForKey:NOTIFICATION_KEY_STATUS];
     NSString* URLString = [userDetailsDict objectForKey:NOTIFICATION_KEY_URL];
     if([successString isEqualToString:NOTIFICATION_VALUE_URL_STATUS_SUCCESS] && [URLString isEqualToString:[_dataInterface URLStringForType:URL_USER_DETAILS]]) {
-        self.userNameLabel.text = _dataInterface.userdetail.name;
-        self.userEmailLabel.text = _dataInterface.userdetail.email;
+        self.userNameLabel.text = [OEXSession activeSession].currentUser.username;
+        self.userEmailLabel.text = [OEXSession activeSession].currentUser.email;
     }
 }
 
@@ -219,7 +212,7 @@ typedef NS_ENUM (NSUInteger, OEXRearViewOptions)
     [[OEXInterface sharedInterface] deactivateWithCompletionHandler:^{
         NSLog(@"should pop");
         [self performSelectorOnMainThread:@selector(pop) withObject:nil waitUntilDone:NO];
-        [OEXAuthentication clearUserSession];
+        [[OEXSession activeSession] closeAndClearSession];
     }];
 }
 

--- a/edXVideoLocker/OEXSession.h
+++ b/edXVideoLocker/OEXSession.h
@@ -10,6 +10,9 @@
 #import "OEXAccessToken.h"
 #import "OEXUserDetails.h"
 @interface OEXSession : NSObject
+
+- (id)initWithAccessToken:(OEXAccessToken*)edxToken andUser:(OEXUserDetails*)userDetails;
+
 @property(readonly, copy) OEXAccessToken* edxToken;
 @property(readonly, copy) OEXUserDetails* currentUser;
 

--- a/edXVideoLocker/OEXSession.m
+++ b/edXVideoLocker/OEXSession.m
@@ -8,6 +8,9 @@
 
 #import "OEXSession.h"
 #import "OEXKeychainAccess.h"
+#import "OEXFBSocial.h"
+#import "OEXGoogleSocial.h"
+
 static OEXSession* activeSession = nil;
 
 NSString* const authTokenResponse = @"authTokenResponse";
@@ -39,6 +42,10 @@ NSString* const loggedInUser = @"loginUserDetails";
 
 - (void)closeAndClearSession {
     [[OEXKeychainAccess sharedKeychainAccess] endSession];
+    if(self.currentUser != nil) {
+        [[OEXFBSocial sharedInstance] logout];
+        [[OEXGoogleSocial sharedInstance] logout];
+    }
     activeSession = nil;
 }
 

--- a/edXVideoLockerTests/OEXSessionTests.m
+++ b/edXVideoLockerTests/OEXSessionTests.m
@@ -16,36 +16,27 @@
 
 @implementation OEXSessionTests
 
-- (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [[OEXSession activeSession] closeAndClearSession];
-    [super tearDown];
-}
-
--(void)DISABLED_testCreateSession{
+-(void)testCreateSession {
+    NSDictionary *userDetails =
+    @{
+      @"email":@"test@example.com",
+      @"username":@"testUser",
+      @"course_enrollments":@"http://www.edx.org/enrollments.com",
+      @"name":@"testuser",
+      @"id":@"test@example.com",
+      @"url":@"test@example.com"
+      };
     
-    NSDictionary *userDetails=@{@"email":@"test@example.com",
-                                @"username":@"testUser",
-                                @"course_enrollments":@"http://www.edx.org/enrollments.com",
-                                @"name":@"testuser",
-                                @"id":@"test@example.com",
-                                @"url":@"test@example.com"
-                                };
+    NSDictionary *tokenDetails =
+    @{@"access_token":@"test@example.com",
+      @"token_type":@"testUser",
+      @"expires_in":@"http://www.edx.org/enrollments.com",
+      @"scope":@"testuser"
+      };
     
-    NSDictionary *tokenDetails=@{@"access_token":@"test@example.com",
-                                 @"token_type":@"testUser",
-                                 @"expires_in":@"http://www.edx.org/enrollments.com",
-                                 @"scope":@"testuser"
-                                 };
-    
-    OEXAccessToken *edxToken=[[OEXAccessToken alloc] initWithTokenDetails:tokenDetails];
-    OEXUserDetails *user=[[OEXUserDetails alloc] initWithUserDictionary:userDetails];
-    OEXSession *session=[OEXSession createSessionWithAccessToken:edxToken andUserDetails:user];
+    OEXAccessToken *accessToken = [[OEXAccessToken alloc] initWithTokenDetails:tokenDetails];
+    OEXUserDetails *user = [[OEXUserDetails alloc] initWithUserDictionary:userDetails];
+    OEXSession *session = [[OEXSession alloc] initWithAccessToken:accessToken andUser:user];
     
     XCTAssertNotNil(session,@"Session should not be nil");
     


### PR DESCRIPTION
We didn't need those static passthrough methods on OEXAuthentication. They were redundant and it was confusing having them in two places. Eventually we'll replace it entirely with a thing that just generates requests.