### PR TITLE
Prioritize google profile email address

### DIFF
--- a/edXVideoLocker/OEXGoogleAuthProvider.m
+++ b/edXVideoLocker/OEXGoogleAuthProvider.m
@@ -44,10 +44,10 @@
             completion(token, nil, error);
         }
         else {
-            [[OEXGoogleSocial sharedInstance] requestUserProfileInfoWithCompletion:^(GTLPlusPerson *userInfo, NSError *error) {
+            [[OEXGoogleSocial sharedInstance] requestUserProfileInfoWithCompletion:^(GTLPlusPerson *userInfo, NSString* profileEmail, NSError *error) {
                 OEXRegisteringUserDetails* profile = [[OEXRegisteringUserDetails alloc] init];
-                GTLPlusPersonEmailsItem* email = userInfo.emails.firstObject;
-                profile.email = email.value;
+                GTLPlusPersonEmailsItem* email =  userInfo.emails.firstObject;
+                profile.email = profileEmail ?: email.value;
                 profile.name = userInfo.name.formatted;
                 NSDate* date = [OEXDateFormatting dateWithGPlusBirthDate:userInfo.birthday];
                 if(date != nil) {

--- a/edXVideoLocker/OEXGoogleSocial.h
+++ b/edXVideoLocker/OEXGoogleSocial.h
@@ -21,5 +21,5 @@ typedef void (^OEXGoogleOEXLoginCompletionHandler)(NSString* accessToken, NSErro
 - (void)clearHandler;
 - (void)clearGoogleSession;
 
-- (void)requestUserProfileInfoWithCompletion:(void (^)(GTLPlusPerson* userInfo, NSError* error))completion;
+- (void)requestUserProfileInfoWithCompletion:(void (^)(GTLPlusPerson* userInfo, NSString* profileEmail, NSError* error))completion;
 @end

--- a/edXVideoLocker/OEXGoogleSocial.m
+++ b/edXVideoLocker/OEXGoogleSocial.m
@@ -100,12 +100,12 @@
     }
 }
 
-- (void)requestUserProfileInfoWithCompletion:(void (^)(GTLPlusPerson*, NSError*))completion {
+- (void)requestUserProfileInfoWithCompletion:(void (^)(GTLPlusPerson*, NSString* profileEmail, NSError*))completion {
     GTLServicePlus* service = [[GTLServicePlus alloc] init];
     service.authorizer = [GPPSignIn sharedInstance].authentication;
     GTLQueryPlus* query = [GTLQueryPlus queryForPeopleGetWithUserId:@"me"];
     [service executeQuery:query completionHandler:^(GTLServiceTicket *ticket, id object, NSError *error) {
-        completion(object, error);
+        completion(object, [[GPPSignIn sharedInstance] userEmail], error);
     }];
 }
 


### PR DESCRIPTION
There's a case where the google profile info isn't coming through. I
can't reproduce it, but it seemed like we should at least be able to get
an email address as part of the google authenitcation, so this tries to
use that email first. It's more likely to be the primary email address
anyway.

JIRA: https://openedx.atlassian.net/browse/MA-390