### PR TITLE
Improve interactions with google and facebook libraries.

### DIFF
--- a/edXVideoLocker/OEXFBSocial.m
+++ b/edXVideoLocker/OEXFBSocial.m
@@ -68,7 +68,6 @@
 
 - (void)clearHandler {
     self.completionHandler = nil;
-    [self logout];
 }
 
 - (void)logout {

--- a/edXVideoLocker/OEXFacebookAuthProvider.m
+++ b/edXVideoLocker/OEXFacebookAuthProvider.m
@@ -36,8 +36,8 @@
 
 - (void)authorizeServiceWithCompletion:(void (^)(NSString*, OEXRegisteringUserDetails* userProfile, NSError* error))completion {
     [[OEXFBSocial sharedInstance] login:^(NSString *accessToken, NSError *error) {
+        [[OEXFBSocial sharedInstance] clearHandler];
         if(error) {
-            [[OEXFBSocial sharedInstance] clearHandler];
             completion(accessToken, nil, error);
             return;
         }

--- a/edXVideoLocker/OEXGoogleAuthProvider.m
+++ b/edXVideoLocker/OEXGoogleAuthProvider.m
@@ -39,8 +39,8 @@
 
 - (void)authorizeServiceWithCompletion:(void (^)(NSString* token, OEXRegisteringUserDetails* userProfile, NSError* error))completion {
     [[OEXGoogleSocial sharedInstance] login:^(NSString* token, NSError* error){
+        [[OEXGoogleSocial sharedInstance] clearHandler];
         if(error) {
-            [[OEXGoogleSocial sharedInstance] clearHandler];
             completion(token, nil, error);
         }
         else {

--- a/edXVideoLocker/OEXGoogleSocial.h
+++ b/edXVideoLocker/OEXGoogleSocial.h
@@ -19,7 +19,6 @@ typedef void (^OEXGoogleOEXLoginCompletionHandler)(NSString* accessToken, NSErro
 - (void)logout;
 - (BOOL)isLogin;
 - (void)clearHandler;
-- (void)clearGoogleSession;
 
 - (void)requestUserProfileInfoWithCompletion:(void (^)(GTLPlusPerson* userInfo, NSString* profileEmail, NSError* error))completion;
 @end

--- a/edXVideoLocker/OEXGoogleSocial.m
+++ b/edXVideoLocker/OEXGoogleSocial.m
@@ -58,7 +58,7 @@
 }
 
 - (void)logout {
-    self.completionHandler = nil;
+    [self clearHandler];
     OEXConfig* config = [OEXConfig sharedConfig];
     OEXGoogleConfig* googleConfig = [config googleConfig];
     if(googleConfig.apiKey && googleConfig.enabled) {
@@ -66,37 +66,19 @@
     }
 }
 
-- (void)clearGoogleSession {
-    OEXConfig* config = [OEXConfig sharedConfig];
-    OEXGoogleConfig* googleConfig = [config googleConfig];
-    if(googleConfig.apiKey && googleConfig.enabled) {
-        GPPSignIn* signIn = [GPPSignIn sharedInstance];
-        [signIn disconnect];
-    }
-}
-
 - (void)clearHandler {
     self.completionHandler = nil;
-    [self clearGoogleSession];
 }
 
 - (void)finishedWithAuth:(GTMOAuth2Authentication*)auth
                    error:(NSError*)error {
     NSLog(@"Received error %@ and auth object %@", error, auth);
-    NSString* serverCode = nil;
-    if(error) {
-        // Do some error handling here.
-        [self clearGoogleSession];
-    }
-    else {
-        serverCode = auth.accessToken;
-    }
+    NSString* serverCode = auth.accessToken;
+
     if(self.completionHandler != nil) {
         self.completionHandler(serverCode, error);
     }
-    else {
-        [self clearGoogleSession];
-    }
+    [self clearHandler];
 }
 
 - (void)requestUserProfileInfoWithCompletion:(void (^)(GTLPlusPerson*, NSString* profileEmail, NSError*))completion {

--- a/edXVideoLocker/OEXLoginViewController.m
+++ b/edXVideoLocker/OEXLoginViewController.m
@@ -324,7 +324,7 @@
 - (void)setSignInToDefaultState:(NSNotification*)notification {
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     if(self.handleGoogleSchema && ![[OEXGoogleSocial sharedInstance] handledOpenUrl]) {
-        [[OEXGoogleSocial sharedInstance]clearHandler];
+        [[OEXGoogleSocial sharedInstance] clearHandler];
         [self handleActivationDuringLogin];
     }
     else if(![[OEXFBSocial sharedInstance] isLogin] && self.handleFacebookSchema) {
@@ -496,8 +496,8 @@
 }
 
 - (void)handleLoginResponseWith:(NSData*)data response:(NSURLResponse*)response error:(NSError*)error {
-    [[OEXGoogleSocial sharedInstance]clearHandler];
-    [[OEXFBSocial sharedInstance]clearHandler];
+    [[OEXGoogleSocial sharedInstance] clearHandler];
+    [[OEXFBSocial sharedInstance] clearHandler];
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.view setUserInteractionEnabled:YES];
@@ -591,8 +591,8 @@
     }
     else {
         if(error.code == 401) {
-            [[OEXFBSocial sharedInstance]clearHandler];
-            [[OEXGoogleSocial sharedInstance]clearHandler];
+            [[OEXFBSocial sharedInstance] clearHandler];
+            [[OEXGoogleSocial sharedInstance] clearHandler];
 
             // MOB - 1110 - Social login error if the user's account is not linked with edX.
             if([self.strLoggedInWith isEqualToString:@"Facebook"]) {


### PR DESCRIPTION
In particular:

- We called "disconnect" in OEXGoogleSocial. This actually requires the
user to re-agree to use your app, which is never what we want.

- Need to better clear the completion handler in the auth provider code.

- Were clearing the entire session in several cases we really just
  wanted to clear the handler.