### PR TITLE
Add safe notification center utility.

### DIFF
--- a/edXVideoLocker.xcodeproj/project.pbxproj
+++ b/edXVideoLocker.xcodeproj/project.pbxproj
@@ -152,6 +152,10 @@
 		77567B4C1AC5E8EC00877A7B /* OEXAnalyticsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77567B4B1AC5E8EC00877A7B /* OEXAnalyticsTests.m */; };
 		77567B4F1AC5EBFE00877A7B /* OEXMockAnalyticsTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 77567B4E1AC5EBFE00877A7B /* OEXMockAnalyticsTracker.m */; };
 		77567B551AC5F06F00877A7B /* OEXSafeCastTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77567B541AC5F06F00877A7B /* OEXSafeCastTests.m */; };
+		77567B701AC9F6FC00877A7B /* NSObject+OEXDeallocAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 77567B6F1AC9F6FC00877A7B /* NSObject+OEXDeallocAction.m */; };
+		77567B741AC9F8ED00877A7B /* NSObject+OEXDeallocActionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77567B731AC9F8ED00877A7B /* NSObject+OEXDeallocActionTests.m */; };
+		77567B771AC9FC1400877A7B /* NSNotificationCenter+OEXSafeAccess.m in Sources */ = {isa = PBXBuildFile; fileRef = 77567B761AC9FC1400877A7B /* NSNotificationCenter+OEXSafeAccess.m */; };
+		77567B791ACA00F900877A7B /* NSNotificationCenter+OEXSafeAccessTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77567B781ACA00F900877A7B /* NSNotificationCenter+OEXSafeAccessTests.m */; };
 		7764597F1A096339008404CC /* NSString+OEXEncoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 7764597E1A096339008404CC /* NSString+OEXEncoding.m */; };
 		776459821A09650C008404CC /* NSDictionary+OEXEncoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 776459811A09650C008404CC /* NSDictionary+OEXEncoding.m */; };
 		7769071E1AD5DAF200F5E7EB /* OEXApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 7769071D1AD5DAF200F5E7EB /* OEXApplication.m */; };
@@ -550,6 +554,13 @@
 		77567B4E1AC5EBFE00877A7B /* OEXMockAnalyticsTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXMockAnalyticsTracker.m; sourceTree = "<group>"; };
 		77567B511AC5EFE800877A7B /* OEXCast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXCast.h; sourceTree = "<group>"; };
 		77567B541AC5F06F00877A7B /* OEXSafeCastTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXSafeCastTests.m; sourceTree = "<group>"; };
+		77567B6E1AC9F6FC00877A7B /* NSObject+OEXDeallocAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+OEXDeallocAction.h"; sourceTree = "<group>"; };
+		77567B6F1AC9F6FC00877A7B /* NSObject+OEXDeallocAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+OEXDeallocAction.m"; sourceTree = "<group>"; };
+		77567B711AC9F87300877A7B /* OEXRemovable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXRemovable.h; sourceTree = "<group>"; };
+		77567B731AC9F8ED00877A7B /* NSObject+OEXDeallocActionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+OEXDeallocActionTests.m"; sourceTree = "<group>"; };
+		77567B751AC9FC1400877A7B /* NSNotificationCenter+OEXSafeAccess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSNotificationCenter+OEXSafeAccess.h"; sourceTree = "<group>"; };
+		77567B761AC9FC1400877A7B /* NSNotificationCenter+OEXSafeAccess.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSNotificationCenter+OEXSafeAccess.m"; sourceTree = "<group>"; };
+		77567B781ACA00F900877A7B /* NSNotificationCenter+OEXSafeAccessTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSNotificationCenter+OEXSafeAccessTests.m"; sourceTree = "<group>"; };
 		7764597D1A096339008404CC /* NSString+OEXEncoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+OEXEncoding.h"; sourceTree = "<group>"; };
 		7764597E1A096339008404CC /* NSString+OEXEncoding.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+OEXEncoding.m"; sourceTree = "<group>"; };
 		776459801A09650C008404CC /* NSDictionary+OEXEncoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+OEXEncoding.h"; sourceTree = "<group>"; };
@@ -1242,6 +1253,10 @@
 		776459831A0968F0008404CC /* Library Additions */ = {
 			isa = PBXGroup;
 			children = (
+				77567B751AC9FC1400877A7B /* NSNotificationCenter+OEXSafeAccess.h */,
+				77567B761AC9FC1400877A7B /* NSNotificationCenter+OEXSafeAccess.m */,
+				77567B6E1AC9F6FC00877A7B /* NSObject+OEXDeallocAction.h */,
+				77567B6F1AC9F6FC00877A7B /* NSObject+OEXDeallocAction.m */,
 				77567B511AC5EFE800877A7B /* OEXCast.h */,
 				77FFA2BF1AC3087A00B4D69B /* NSAttributedString+OEXFormatting.h */,
 				77FFA2C01AC3087A00B4D69B /* NSAttributedString+OEXFormatting.m */,
@@ -1707,6 +1722,7 @@
 			children = (
 				7769071C1AD5DAF200F5E7EB /* OEXApplication.h */,
 				7769071D1AD5DAF200F5E7EB /* OEXApplication.m */,
+				77567B711AC9F87300877A7B /* OEXRemovable.h */,
 				7714A2581AB376E4004C2254 /* OEXHTTPStatusCodes.h */,
 				777EFEFB1A7AFF0E00F8BF06 /* OEXRouter.h */,
 				777EFEFC1A7AFF0E00F8BF06 /* OEXRouter.m */,
@@ -1760,6 +1776,8 @@
 			isa = PBXGroup;
 			children = (
 				776907231AD6E7E400F5E7EB /* OEXApplicationTests.m */,
+				77567B781ACA00F900877A7B /* NSNotificationCenter+OEXSafeAccessTests.m */,
+				77567B731AC9F8ED00877A7B /* NSObject+OEXDeallocActionTests.m */,
 				77567B541AC5F06F00877A7B /* OEXSafeCastTests.m */,
 				77567B501AC5EC0400877A7B /* Test Doubles */,
 				77FFA2C41AC30D6300B4D69B /* Data Factories */,
@@ -2321,10 +2339,12 @@
 				B4B6D6391A95042B000F44E8 /* OEXCheckBoxView.m in Sources */,
 				19DC02041A1F226300A874D3 /* OEXFindCourseTableViewCell.m in Sources */,
 				9CD7D2F21A9499D200E7126E /* OEXHandoutsViewController.m in Sources */,
+				77567B701AC9F6FC00877A7B /* NSObject+OEXDeallocAction.m in Sources */,
 				77FFAB9A1A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.m in Sources */,
 				BE45DA8919260604003BD39B /* OEXCustomTabBarViewViewController.m in Sources */,
 				19321F651961698B00B7D75C /* OEXDownloadTableCell.m in Sources */,
 				77FFA2CC1AC35CE800B4D69B /* OEXRegistrationStyles.m in Sources */,
+				77567B771AC9FC1400877A7B /* NSNotificationCenter+OEXSafeAccess.m in Sources */,
 				B4B6D5E91A9490FC000F44E8 /* OEXRegistrationViewController.m in Sources */,
 				77ADF4A31AC1AF9800AC8955 /* OEXFacebookAuthProvider.m in Sources */,
 				8F41F4791A834A8F0041B30D /* OEXImageCache.m in Sources */,
@@ -2357,6 +2377,7 @@
 				8F7F6DAD1A795AA60063B9D6 /* OEXSessionTests.m in Sources */,
 				77A340211AB2461800C8E141 /* OEXRegistrationViewControllerTests.m in Sources */,
 				B4B6D6491A95CF33000F44E8 /* OEXUserLicenseAgreementViewController.m in Sources */,
+				77567B741AC9F8ED00877A7B /* NSObject+OEXDeallocActionTests.m in Sources */,
 				B4B6D6441A95335C000F44E8 /* OEXRegistrationAgreementController.m in Sources */,
 				770A27AA1A70261F00DFC6FF /* NSObject+OEXReplaceNullTests.m in Sources */,
 				77000A471A77555B007D306C /* OEXDateFormattingTests.m in Sources */,
@@ -2375,6 +2396,7 @@
 				77567B4C1AC5E8EC00877A7B /* OEXAnalyticsTests.m in Sources */,
 				7778F0951ABA2C3600B4CDA0 /* OEXRegistrationFieldEmailViewTests.m in Sources */,
 				770A27A11A6F172300DFC6FF /* OEXVideoSummaryTests.m in Sources */,
+				77567B791ACA00F900877A7B /* NSNotificationCenter+OEXSafeAccessTests.m in Sources */,
 				77000A4C1A775904007D306C /* NSDate+OEXComparisonsTests.m in Sources */,
 				77567B4F1AC5EBFE00877A7B /* OEXMockAnalyticsTracker.m in Sources */,
 				770A27A71A700E1600DFC6FF /* OEXVideoSummary+OEXTestDataFactory.m in Sources */,

--- a/edXVideoLocker/NSNotificationCenter+OEXSafeAccess.h
+++ b/edXVideoLocker/NSNotificationCenter+OEXSafeAccess.h
@@ -1,0 +1,21 @@
+//
+//  NSNotificationCenter+OEXSafeAccess.h
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 3/30/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol OEXRemovable;
+
+@interface NSNotificationCenter (OEXSafeAccess)
+
+/// Safer way of dealing with NSNotification registration
+/// The notification listener will be removed automatically when observer is dealloced
+/// Additionally, you can use the removable argument to the listener to preemptively remove the
+/// listener making it easy to do one off notification observations
+- (id <OEXRemovable>)oex_addObserver:(id)observer notification:(NSString*)name action:(void(^)(NSNotification* notification, id observer, id <OEXRemovable> removable))action;
+
+@end

--- a/edXVideoLocker/NSNotificationCenter+OEXSafeAccess.m
+++ b/edXVideoLocker/NSNotificationCenter+OEXSafeAccess.m
@@ -1,0 +1,61 @@
+//
+//  NSNotificationCenter+OEXSafeAccess.m
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 3/30/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import "NSNotificationCenter+OEXSafeAccess.h"
+
+#import "OEXRemovable.h"
+#import "NSObject+OEXDeallocAction.h"
+
+@interface OEXNotificationListener : NSObject <OEXRemovable>
+
+@property (strong, nonatomic) id observer;
+@property (weak, nonatomic) id owner;
+@property (copy, nonatomic) void (^action)(NSNotification* notification, id observer, id <OEXRemovable> removable);
+
+@end
+
+@implementation OEXNotificationListener
+
+- (void)notificationFired:(NSNotification*)notification {
+    if(self.action != nil) {
+        self.action(notification, self.owner, self);
+    }
+}
+
+- (void)remove {
+    [[NSNotificationCenter defaultCenter] removeObserver:self.observer name:nil object:nil];
+    self.observer = nil;
+    self.owner = nil;
+    self.action = nil;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self.observer name:nil object:nil];
+}
+
+@end
+
+@implementation NSNotificationCenter (OEXSafeAccess)
+
+- (id <OEXRemovable>)oex_addObserver:(id)observer notification:(NSString*)name action:(void (^)(NSNotification *, id, id<OEXRemovable>))action {
+    
+    OEXNotificationListener* listener = [[OEXNotificationListener alloc] init];
+    listener.owner = observer;
+    listener.action = action;
+    
+    __weak __typeof(listener) weakListener = listener;
+    listener.observer = [[NSNotificationCenter defaultCenter] addObserverForName:name object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *note) {
+        [weakListener notificationFired:note];
+    }];
+    [observer oex_performActionOnDealloc: ^{
+        [listener remove];
+    }];
+    return listener;
+}
+
+@end

--- a/edXVideoLocker/NSObject+OEXDeallocAction.h
+++ b/edXVideoLocker/NSObject+OEXDeallocAction.h
@@ -1,0 +1,19 @@
+//
+//  NSObject+OEXDeallocAction.h
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 3/30/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol OEXRemovable;
+
+@interface NSObject (OEXDeallocAction)
+
+/// Execute an action when the current object is deallocated. Note that at the time
+/// the action is called, the original object is already nil
+- (id <OEXRemovable>)oex_performActionOnDealloc:(void(^)(void))action;
+
+@end

--- a/edXVideoLocker/NSObject+OEXDeallocAction.m
+++ b/edXVideoLocker/NSObject+OEXDeallocAction.m
@@ -1,0 +1,53 @@
+//
+//  NSObject+OEXDeallocAction.m
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 3/30/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import "NSObject+OEXDeallocAction.h"
+
+#import "OEXRemovable.h"
+
+#import <objc/runtime.h>
+
+@interface OEXDeallocActionRunner : NSObject <OEXRemovable>
+
+@property (copy, nonatomic) void (^action)(void);
+@property (copy, nonatomic) void (^removeAction)(id);
+
+@end
+
+@implementation OEXDeallocActionRunner
+
+- (void)dealloc {
+    if(self.action != nil) {
+        self.action();
+    }
+}
+
+- (void)remove {
+    if(self.removeAction != nil) {
+        self.removeAction(self);
+    }
+    self.action = nil;
+    self.removeAction = nil;
+}
+
+@end
+
+@implementation NSObject (OEXDeallocActions)
+
+- (id <OEXRemovable>)oex_performActionOnDealloc:(void(^)(void))action {
+    OEXDeallocActionRunner* runner = [[OEXDeallocActionRunner alloc] init];
+    runner.action = action;
+    __weak __typeof(self) weakself = self;
+    runner.removeAction = ^(id sender){
+        objc_setAssociatedObject(weakself, (__bridge void*)sender, nil, OBJC_ASSOCIATION_RETAIN);
+    };
+    objc_setAssociatedObject(self, (__bridge void*)runner, runner, OBJC_ASSOCIATION_RETAIN);
+    return runner;
+}
+
+@end

--- a/edXVideoLocker/OEXRemovable.h
+++ b/edXVideoLocker/OEXRemovable.h
@@ -1,0 +1,15 @@
+//
+//  OEXRemovable.h
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 3/30/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol OEXRemovable <NSObject>
+
+- (void)remove;
+
+@end

--- a/edXVideoLockerTests/NSNotificationCenter+OEXSafeAccessTests.m
+++ b/edXVideoLockerTests/NSNotificationCenter+OEXSafeAccessTests.m
@@ -1,0 +1,72 @@
+//
+//  NSNotificationCenter+OEXSafeAccessTests.m
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 3/30/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+#import "NSObject+OEXDeallocAction.h"
+#import "NSNotificationCenter+OEXSafeAccess.h"
+#import "OEXRemovable.h"
+
+
+static NSString* OEXSampleNotification = @"OEXSampleNotification";
+
+@interface NSNotificationCenter_OEXSafeAccessTests : XCTestCase
+
+@end
+
+@implementation NSNotificationCenter_OEXSafeAccessTests
+
+- (void)testActionFires {
+    NSObject* owner = [[NSObject alloc] init];
+    __block BOOL fired = NO;
+    [[NSNotificationCenter defaultCenter] oex_addObserver:owner notification:OEXSampleNotification action:^(NSNotification *notification, id observer, id<OEXRemovable> removable) {
+        fired = YES;
+    }];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:OEXSampleNotification object:nil];
+    XCTAssertTrue(fired);
+}
+
+- (void)testClearedOnDealloc {
+    __block BOOL fired = NO;
+    __block BOOL dealloced = NO;
+    void(^make)(void) = ^{
+        @autoreleasepool {
+            NSObject* owner = [[NSObject alloc] init];
+            [[NSNotificationCenter defaultCenter] oex_addObserver:owner notification:OEXSampleNotification action:^(NSNotification *notification, id observer, id<OEXRemovable> removable) {
+                fired = YES;
+            }];
+            [owner oex_performActionOnDealloc:^{
+                dealloced = YES;
+            }];
+        };
+    };
+    make();
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:OEXSampleNotification object:nil];
+    XCTAssertFalse(fired);
+    XCTAssertTrue(dealloced);
+}
+
+- (void)testRemove {
+    __block BOOL fired = NO;
+    
+    NSObject* owner = [[NSObject alloc] init];
+    id <OEXRemovable> removable = [[NSNotificationCenter defaultCenter] oex_addObserver:owner notification:OEXSampleNotification action:^(NSNotification *notification, id observer, id<OEXRemovable> removable) {
+        fired = YES;
+    }];
+    [removable remove];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:OEXSampleNotification object:nil];
+    XCTAssertFalse(fired);
+}
+
+
+
+@end

--- a/edXVideoLockerTests/NSObject+OEXDeallocActionTests.m
+++ b/edXVideoLockerTests/NSObject+OEXDeallocActionTests.m
@@ -1,0 +1,61 @@
+//
+//  NSObject+OEXDeallocActionTests.m
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 3/30/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "NSObject+OEXDeallocAction.h"
+
+#import "OEXRemovable.h"
+
+@interface NSObject_OEXDeallocActionTests : XCTestCase
+
+@end
+
+@implementation NSObject_OEXDeallocActionTests
+- (void)testDealloc {
+    __block BOOL observed = NO;
+    void (^make)(void) = ^{
+        @autoreleasepool {
+            NSObject* object = [[NSObject alloc] init];
+            [object oex_performActionOnDealloc:^{
+                observed = YES;
+            }];
+        }
+    };
+    
+    make();
+    XCTAssertTrue(observed);
+}
+
+- (void)testStillAlive {
+    __block BOOL observed = NO;
+    
+    NSObject* object = [[NSObject alloc] init];
+    [object oex_performActionOnDealloc: ^{
+        observed = YES;
+    }];
+    
+    XCTAssertFalse(observed);
+}
+
+- (void)testManualRemove {
+    __block BOOL observed = NO;
+    void (^make)(void) = ^{
+        @autoreleasepool {
+            NSObject* object = [[NSObject alloc] init];
+            id <OEXRemovable> removable = [object oex_performActionOnDealloc:^{
+                observed = YES;
+            }];
+            [removable remove];
+        }
+    };
+    make();
+    XCTAssertFalse(observed);
+}
+
+@end


### PR DESCRIPTION
This wraps up NSNotificationCenter so that observers can be removed
automatically, which is much less error prone.