### PR TITLE
Discussed modifications to OEXFBSocial

### DIFF
--- a/Source/OEXFBSocial.h
+++ b/Source/OEXFBSocial.h
@@ -13,7 +13,7 @@
 
 - (void)login:(void(^)(NSString* accessToken,NSError* error))completionHandler;
 - (void)logout;
-+ (BOOL)isLogin;
+- (BOOL)isLogin;
 
 - (void)requestUserProfileInfoWithCompletion:(void(^)(NSDictionary* userProfile, NSError* error))completion;
 

--- a/Source/OEXFBSocial.h
+++ b/Source/OEXFBSocial.h
@@ -11,11 +11,9 @@
 
 @interface OEXFBSocial : NSObject
 
-+ (instancetype)sharedInstance;
 - (void)login:(void(^)(NSString* accessToken,NSError* error))completionHandler;
 - (void)logout;
-- (void)clearHandler;
-- (BOOL)isLogin;
++ (BOOL)isLogin;
 
 - (void)requestUserProfileInfoWithCompletion:(void(^)(NSDictionary* userProfile, NSError* error))completion;
 

--- a/Source/OEXFBSocial.m
+++ b/Source/OEXFBSocial.m
@@ -52,7 +52,7 @@
     }];
 }
 
-+ (BOOL)isLogin {
+- (BOOL)isLogin {
     OEXConfig* config = [OEXConfig sharedConfig];
     OEXFacebookConfig* facebookConfig = [config facebookConfig];
     if(facebookConfig.appId && facebookConfig.enabled) {
@@ -62,7 +62,7 @@
 }
 
 - (void)logout {
-    if([OEXFBSocial isLogin]) {
+    if([self isLogin]) {
         FBSDKLoginManager* fbLoginManager = [[FBSDKLoginManager alloc]init];
         [fbLoginManager logOut];
     }

--- a/Source/OEXFBSocial.m
+++ b/Source/OEXFBSocial.m
@@ -16,20 +16,10 @@
 
 @interface OEXFBSocial ()
 
-@property(copy, nonatomic) void(^completionHandler)(NSString* accessToken, NSError* error);
 
 @end
 
 @implementation OEXFBSocial
-
-+ (id)sharedInstance {
-    static OEXFBSocial* sharedInstance = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedInstance = [[self alloc] init];
-    });
-    return sharedInstance;
-}
 
 - (id)init {
     self = [super init];
@@ -42,15 +32,14 @@
 }
 
 - (void)login:(void (^)(NSString *, NSError *))completionHandler {
-    self.completionHandler = completionHandler;
     FBSDKLoginManager* fbLoginManager = [[FBSDKLoginManager alloc]init];
     [fbLoginManager logInWithReadPermissions:@[@"email", @"public_profile"] handler:^(FBSDKLoginManagerLoginResult *result, NSError *error) {
         FBSDKAccessToken* accessToken = [FBSDKAccessToken currentAccessToken];
         
         if (error) {
-            self.completionHandler(nil, error);
+            completionHandler(nil, error);
         } else if (result.isCancelled) {
-            self.completionHandler(nil, error); //Reflecting as an error for now, before further discussion
+            completionHandler(nil, error); //Reflecting as an error for now, before further discussion
         } else {
             if (![result.grantedPermissions containsObject:@"email"]) {
                 NSLog(@"Email permission is missing");
@@ -58,12 +47,12 @@
             if (![result.grantedPermissions containsObject:@"public_profile"]) {
                 NSLog(@"Public profile permission is missing");
             }
-            self.completionHandler([accessToken tokenString],error);
+            completionHandler([accessToken tokenString],error);
         }
     }];
 }
 
-- (BOOL)isLogin {
++ (BOOL)isLogin {
     OEXConfig* config = [OEXConfig sharedConfig];
     OEXFacebookConfig* facebookConfig = [config facebookConfig];
     if(facebookConfig.appId && facebookConfig.enabled) {
@@ -72,12 +61,8 @@
     return NO;
 }
 
-- (void)clearHandler {
-    self.completionHandler = nil;
-}
-
 - (void)logout {
-    if([self isLogin]) {
+    if([OEXFBSocial isLogin]) {
         FBSDKLoginManager* fbLoginManager = [[FBSDKLoginManager alloc]init];
         [fbLoginManager logOut];
     }

--- a/Source/OEXFacebookAuthProvider.m
+++ b/Source/OEXFacebookAuthProvider.m
@@ -35,14 +35,14 @@
 }
 
 - (void)authorizeServiceFromController:(UIViewController *)controller requestingUserDetails:(BOOL)loadUserDetails withCompletion:(void (^)(NSString *, OEXRegisteringUserDetails *, NSError *))completion {
-    [[OEXFBSocial sharedInstance] login:^(NSString *accessToken, NSError *error) {
-        [[OEXFBSocial sharedInstance] clearHandler];
+    OEXFBSocial* facebookManager = [[OEXFBSocial alloc] init]; //could be named facebookHelper.
+    [facebookManager login:^(NSString *accessToken, NSError *error) {
         if(error) {
             completion(accessToken, nil, error);
             return;
         }
         if(loadUserDetails) {
-            [[OEXFBSocial sharedInstance] requestUserProfileInfoWithCompletion:^(NSDictionary *userInfo, NSError *error) {
+            [facebookManager requestUserProfileInfoWithCompletion:^(NSDictionary *userInfo, NSError *error) {
                 // userInfo is a facebook user object
                 OEXRegisteringUserDetails* profile = [[OEXRegisteringUserDetails alloc] init];
                 profile.email = userInfo[@"email"];

--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -299,12 +299,13 @@
 }
 
 - (void)setSignInToDefaultState:(NSNotification*)notification {
+    OEXFBSocial *facebookManager = [[OEXFBSocial alloc]init];
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     if(self.handleGoogleSchema && ![[OEXGoogleSocial sharedInstance] handledOpenUrl]) {
         [[OEXGoogleSocial sharedInstance] clearHandler];
         [self handleActivationDuringLogin];
     }
-    else if(![OEXFBSocial isLogin] && self.handleFacebookSchema) {
+    else if(![facebookManager isLogin] && self.handleFacebookSchema) {
         [self handleActivationDuringLogin];
     }
 

--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -304,8 +304,7 @@
         [[OEXGoogleSocial sharedInstance] clearHandler];
         [self handleActivationDuringLogin];
     }
-    else if(![[OEXFBSocial sharedInstance] isLogin] && self.handleFacebookSchema) {
-        [[OEXFBSocial sharedInstance]clearHandler];
+    else if(![OEXFBSocial isLogin] && self.handleFacebookSchema) {
         [self handleActivationDuringLogin];
     }
 
@@ -474,7 +473,6 @@
 
 - (void)handleLoginResponseWith:(NSData*)data response:(NSURLResponse*)response error:(NSError*)error {
     [[OEXGoogleSocial sharedInstance] clearHandler];
-    [[OEXFBSocial sharedInstance] clearHandler];
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.view setUserInteractionEnabled:YES];
@@ -568,7 +566,6 @@
     }
     else {
         if(error.code == 401) {
-            [[OEXFBSocial sharedInstance] clearHandler];
             [[OEXGoogleSocial sharedInstance] clearHandler];
 
             // MOB - 1110 - Social login error if the user's account is not linked with edX.


### PR DESCRIPTION
- `OEXFBSocial` is no* longer a singleton.
- `completionHandler` isn't a property of `OEXFBSocial` anymore, it's only passed on `login`
- `isLogin()` is changed to a class method for convenient access.
- `OEXFacebookAuthProvider` code has been refactored accordingly.