### PR TITLE
Remove client secret, which isn't actually necessary

### DIFF
--- a/Source/OEXAuthentication.m
+++ b/Source/OEXAuthentication.m
@@ -127,15 +127,14 @@ OEXNSDataTaskRequestHandler OEXWrapURLCompletion(OEXURLRequestHandler completion
 // This retuns header for password authentication method
 + (NSString*)plainTextAuthorizationHeaderForUserName:(NSString*)userName password:(NSString*)password {
     NSString* clientID = [[OEXConfig sharedConfig] oauthClientID];
-    NSString* clientSecret = [[OEXConfig sharedConfig] oauthClientSecret];
-
-    return [@{
-                @"client_id" : clientID,
-                @"client_secret" : clientSecret,
-                @"grant_type" : @"password",
-                @"username" : userName,
-                @"password" : password
-            } oex_stringByUsingFormEncoding];
+    
+    NSMutableDictionary* arguments = [[NSMutableDictionary alloc] init];
+    [arguments safeSetObject:clientID forKey:@"client_id"];
+    [arguments safeSetObject:@"password" forKey:@"grant_type"];
+    [arguments safeSetObject:userName forKey:@"username"];
+    [arguments safeSetObject:password forKey:@"password"];
+    
+    return [arguments oex_stringByUsingFormEncoding];
 }
 
 //// This methods is used to get user details when user access token is available

--- a/Source/OEXConfig.h
+++ b/Source/OEXConfig.h
@@ -45,7 +45,6 @@
 - (NSString*)apiHostURL;
 - (NSString*)feedbackEmailAddress;
 - (NSString*)oauthClientID;
-- (NSString*)oauthClientSecret;
 - (BOOL)pushNotificationsEnabled;
 
 - (OEXEnrollmentConfig*)courseEnrollmentConfig;

--- a/Source/OEXConfig.m
+++ b/Source/OEXConfig.m
@@ -27,7 +27,6 @@ static NSString* const OEXFeedbackEmailAddress = @"FEEDBACK_EMAIL_ADDRESS";
 // This key is temporary and will be removed once this feature is completed.
 static NSString* const OEXNewCourseNavigationEnabledKey = @"NEW_COURSE_NAVIGATION_ENABLED";
 
-static NSString* const OEXOAuthClientSecret = @"OAUTH_CLIENT_SECRET";
 static NSString* const OEXOAuthClientID = @"OAUTH_CLIENT_ID";
 static NSString* const OEXPushNotificationsKey = @"PUSH_NOTIFICATIONS";
 
@@ -114,10 +113,6 @@ static OEXConfig* sSharedConfig;
 
 - (NSString*)feedbackEmailAddress {
     return [self stringForKey: OEXFeedbackEmailAddress];
-}
-
-- (NSString*)oauthClientSecret {
-    return [self stringForKey:OEXOAuthClientSecret];
 }
 
 - (NSString*)oauthClientID {


### PR DESCRIPTION
@hanningni please review. We were sending a client secret but with the password grant type this isn't necessary.

cc @nasthagiri 