### PR TITLE
Add nullability annotations to OEXConfig

### DIFF
--- a/Source/CourseAnnouncementsViewController.swift
+++ b/Source/CourseAnnouncementsViewController.swift
@@ -13,13 +13,13 @@ private let notificationLabelTrailingOffset = -10.0
 private let notificationBarHeight = 50.0
 
 class CourseAnnouncementsViewControllerEnvironment : NSObject {
-    let config : OEXConfig
+    let config : OEXConfig?
     let dataInterface : OEXInterface
     weak var router : OEXRouter?
     let styles : OEXStyles
     let pushSettingsManager : OEXPushSettingsManager
     
-    init(config : OEXConfig, dataInterface : OEXInterface, router : OEXRouter, styles : OEXStyles, pushSettingsManager : OEXPushSettingsManager) {
+    init(config : OEXConfig?, dataInterface : OEXInterface, router : OEXRouter, styles : OEXStyles, pushSettingsManager : OEXPushSettingsManager) {
         self.config = config
         self.dataInterface = dataInterface
         self.router = router
@@ -180,6 +180,7 @@ class CourseAnnouncementsViewController: UIViewController {
                 }
         }
         var displayHTML = self.environment.styles.styleHTMLContent(html)
-        self.webView?.loadHTMLString(displayHTML, baseURL: NSURL(string: self.environment.config.apiHostURL()))
+        let baseURL = self.environment.config?.apiHostURL().flatMap { NSURL(string: $0 ) }
+        self.webView?.loadHTMLString(displayHTML, baseURL: baseURL)
     }
 }

--- a/Source/CourseDashboardCourseInfoCell.swift
+++ b/Source/CourseDashboardCourseInfoCell.swift
@@ -104,7 +104,7 @@ class CourseDashboardCourseInfoCell: UITableViewCell {
     
     func setCoverImage() {
         if let courseInCell = self.course {
-            let imgUrlString: String? = OEXConfig.sharedConfig().apiHostURL() + courseInCell.course_image_url
+            let imgUrlString = OEXConfig.sharedConfig().apiHostURL().map { $0 + courseInCell.course_image_url}
             if let imgUrl = imgUrlString {
                 OEXImageCache.sharedInstance().getImage(imgUrl)
             }
@@ -117,7 +117,7 @@ class CourseDashboardCourseInfoCell: UITableViewCell {
         let downloadImageUrl: String? = dictObj.objectForKey("image_url") as? String
         
         if let downloadedImage = image, courseInCell = self.course {
-            let imgUrlString: String? = OEXConfig.sharedConfig().apiHostURL() + courseInCell.course_image_url
+            let imgUrlString = OEXConfig.sharedConfig().apiHostURL().map { $0  + courseInCell.course_image_url}
             if imgUrlString == downloadImageUrl {
                 self.coverImage.image = downloadedImage
             }

--- a/Source/OEXConfig.h
+++ b/Source/OEXConfig.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class OEXEnrollmentConfig;
 @class OEXFabricConfig;
 @class OEXFacebookConfig;
@@ -27,8 +29,8 @@
 - (id)initWithAppBundleData;
 - (id)initWithDictionary:(NSDictionary*)dictionary;
 
-- (id)objectForKey:(NSString*)key;
-- (NSString*)stringForKey:(NSString*)key;
+- (nullable id)objectForKey:(NSString*)key;
+- (nullable NSString*)stringForKey:(NSString*)key;
 
 @end
 
@@ -38,23 +40,23 @@
 // in case we need to do something clever in individual cases
 @interface OEXConfig (OEXKnownConfigs)
 
-- (NSString*)environmentName;
+- (nullable NSString*)environmentName;
 
 // Network
 // TODO: Transition this to an actual NSURL
-- (NSString*)apiHostURL;
-- (NSString*)feedbackEmailAddress;
-- (NSString*)oauthClientID;
+- (nullable NSString*)apiHostURL;
+- (nullable NSString*)feedbackEmailAddress;
+- (nullable NSString*)oauthClientID;
 - (BOOL)pushNotificationsEnabled;
 
-- (OEXEnrollmentConfig*)courseEnrollmentConfig;
-- (OEXFabricConfig*)fabricConfig;
-- (OEXFacebookConfig*)facebookConfig;
-- (OEXGoogleConfig*)googleConfig;
-- (OEXParseConfig*)parseConfig;
-- (OEXNewRelicConfig*)newRelicConfig;
-- (OEXSegmentConfig*)segmentConfig;
-- (OEXZeroRatingConfig*)zeroRatingConfig;
+- (nullable OEXEnrollmentConfig*)courseEnrollmentConfig;
+- (nullable OEXFabricConfig*)fabricConfig;
+- (nullable OEXFacebookConfig*)facebookConfig;
+- (nullable OEXGoogleConfig*)googleConfig;
+- (nullable OEXParseConfig*)parseConfig;
+- (nullable OEXNewRelicConfig*)newRelicConfig;
+- (nullable OEXSegmentConfig*)segmentConfig;
+- (nullable OEXZeroRatingConfig*)zeroRatingConfig;
 
 /// Feature Flag for under development redesign of course views. Will be removed once the feature is done
 - (BOOL)shouldEnableNewCourseNavigation;
@@ -64,3 +66,6 @@
 - (BOOL)shouldEnableDiscussions;
 
 @end
+
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This will make it more obvious that the config might be empty and
prevent crashes when there's an invalid config.