### PR TITLE
Better solution to hide back button text.

### DIFF
--- a/Source/CourseDashboardViewController.swift
+++ b/Source/CourseDashboardViewController.swift
@@ -41,7 +41,8 @@ public class CourseDashboardViewController: UIViewController, UITableViewDataSou
         
         super.init(nibName: nil, bundle: nil)
         
-        self.navigationItem.title = course?.name
+        navigationItem.title = course?.name
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: " ", style: .Plain, target: nil, action: nil)
     }
     
     public required init(coder aDecoder: NSCoder) {

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -70,6 +70,7 @@ public class CourseOutlineViewController : UIViewController, CourseBlockViewCont
         tableController.delegate = self
         
         navigationItem.rightBarButtonItems = [webController.barButtonItem,modeController.barItem]
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: " ", style: .Plain, target: nil, action: nil)
     }
 
     public required init(coder aDecoder: NSCoder) {

--- a/Source/OEXFrontCourseViewController.m
+++ b/Source/OEXFrontCourseViewController.m
@@ -198,6 +198,9 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle: @" " style: UIBarButtonItemStylePlain target: nil action: nil];
+    
     //self.lbl_NavTitle.accessibilityLabel=@"txtHeader";
     self.lbl_NavTitle.text = OEXLocalizedString(@"MY_COURSES", nil);
 

--- a/Source/OEXStyles+Swift.swift
+++ b/Source/OEXStyles+Swift.swift
@@ -30,9 +30,6 @@ extension OEXStyles {
             UINavigationBar.appearance().titleTextAttributes = navigationTitleTextStyle.attributes
             UIBarButtonItem.appearance().setTitleTextAttributes(navigationButtonTextStyle.attributes, forState: .Normal)
             UIBarButtonItem.appearance().setTitleTextAttributes(navigationButtonTextStyle.attributes, forState: .Normal)
-            // Hide back button text. Don't have enough room for it
-            // TODO: Hide only on iPhone
-            UIBarButtonItem.appearance().setBackButtonTitlePositionAdjustment(UIOffsetMake(0, -100), forBarMetrics: .Default)
             
             UIToolbar.appearance().barTintColor = navigationBarColor()
             


### PR DESCRIPTION
This is still kind of hacky, but the solution of just offseting the text away resulted in funny behavior for long back strings.