### PR TITLE
Bug Fix: Multiple VCs pushed due to multiple actions being set.

### DIFF
--- a/Source/CourseOutlineHeaderView.swift
+++ b/Source/CourseOutlineHeaderView.swift
@@ -137,7 +137,7 @@ public class CourseOutlineHeaderView: UIView {
     }
     
     public func setViewButtonAction(action: (AnyObject) -> Void) {
-        self.viewButton.oex_removeActions()
+        self.viewButton.oex_removeAllActions()
         self.viewButton.oex_addAction(action, forEvents: UIControlEvents.TouchUpInside)
         
     }

--- a/Source/CourseOutlineHeaderView.swift
+++ b/Source/CourseOutlineHeaderView.swift
@@ -137,7 +137,7 @@ public class CourseOutlineHeaderView: UIView {
     }
     
     public func setViewButtonAction(action: (AnyObject) -> Void) {
-        //TODO: Remove the overlapping view that is blocking the touchListener
+        self.viewButton.oex_removeActions()
         self.viewButton.oex_addAction(action, forEvents: UIControlEvents.TouchUpInside)
         
     }

--- a/Source/UIControl+OEXBlockActions.h
+++ b/Source/UIControl+OEXBlockActions.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface UIControl (OEXBlockActions)
 
 - (id <OEXRemovable>)oex_addAction:(void (^)(id control))action forEvents:(UIControlEvents)events;
-- (void) oex_removeActions;
+- (void) oex_removeAllActions;
 @end
 
 

--- a/Source/UIControl+OEXBlockActions.h
+++ b/Source/UIControl+OEXBlockActions.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface UIControl (OEXBlockActions)
 
 - (id <OEXRemovable>)oex_addAction:(void (^)(id control))action forEvents:(UIControlEvents)events;
-
+- (void) oex_removeActions;
 @end
 
 

--- a/Source/UIControl+OEXBlockActions.m
+++ b/Source/UIControl+OEXBlockActions.m
@@ -27,8 +27,6 @@ static NSString* const OEXControlActionListenersKey = @"OEXControlActionListener
     if(self.removeAction != nil) {
         self.removeAction(self);
     }
-    self.action = nil;
-    self.removeAction = nil;
 }
 
 - (void)actionFired:(UIControl*)sender {
@@ -59,7 +57,7 @@ static NSString* const OEXControlActionListenersKey = @"OEXControlActionListener
     listener.removeAction = ^(OEXControlActionListener* listener){
         listener.removeAction = nil;
         listener.action = nil;
-        [weakself removeTarget:self action:NULL forControlEvents:UIControlEventAllEvents];
+        [weakself removeTarget:nil action:NULL forControlEvents:UIControlEventAllEvents];
         [[weakself oex_actionListeners] removeObject:listener];
     };
     [listeners addObject:listener];
@@ -67,6 +65,14 @@ static NSString* const OEXControlActionListenersKey = @"OEXControlActionListener
     [self addTarget:listener action:@selector(actionFired:) forControlEvents:events];
     
     return listener;
+}
+
+- (void) oex_removeActions {
+    NSMutableArray* listeners = [self oex_actionListeners];
+    for (OEXControlActionListener* listener in listeners) {
+        [listener remove];
+    }
+    [listeners removeAllObjects];
 }
 
 @end

--- a/Source/UIControl+OEXBlockActions.m
+++ b/Source/UIControl+OEXBlockActions.m
@@ -57,7 +57,7 @@ static NSString* const OEXControlActionListenersKey = @"OEXControlActionListener
     listener.removeAction = ^(OEXControlActionListener* listener){
         listener.removeAction = nil;
         listener.action = nil;
-        [weakself removeTarget:nil action:NULL forControlEvents:UIControlEventAllEvents];
+        [weakself removeTarget:listener action:NULL forControlEvents:UIControlEventAllEvents];
         [[weakself oex_actionListeners] removeObject:listener];
     };
     [listeners addObject:listener];

--- a/Source/UIControl+OEXBlockActions.m
+++ b/Source/UIControl+OEXBlockActions.m
@@ -67,7 +67,7 @@ static NSString* const OEXControlActionListenersKey = @"OEXControlActionListener
     return listener;
 }
 
-- (void) oex_removeActions {
+- (void) oex_removeAllActions {
     NSMutableArray* listeners = [self oex_actionListeners];
     for (OEXControlActionListener* listener in listeners) {
         [listener remove];

--- a/Source/UserAPI.swift
+++ b/Source/UserAPI.swift
@@ -39,7 +39,7 @@ public struct UserAPI {
         return NetworkRequest(
             method: HTTPMethod.GET,
             path : "/api/mobile/v0.5/users/{username}/course_status_info/{course_id}".oex_formatWithParameters(["course_id" : courseID, "username":OEXSession.sharedSession()?.currentUser?.username ?? ""]),
-            // Not asserting here, because test cases need to run without an active Session.
+            requiresAuth : true,
             deserializer: lastAccessedDeserializer)
     }
     

--- a/Source/ViewTopMessageController.swift
+++ b/Source/ViewTopMessageController.swift
@@ -56,10 +56,11 @@ public class ViewTopMessageController : NSObject, ContentInsetsSource {
             make.trailing.equalTo(containerView)
             
             if active() {
-                //TODO: Remove interference with View Button in lastAccessedView.
+                containerView.userInteractionEnabled = true
                 make.top.equalTo(containerView.snp_top).constraint
             }
             else {
+                containerView.userInteractionEnabled = false
                 make.bottom.equalTo(containerView.snp_top).constraint
             }
         }


### PR DESCRIPTION
Added oex_removeActions to cater for setting unique actions. If you need to test this manually, you'll have to merge #244's changes first.




Alternatively, we could make a method in `UIControl+OEXBlockAdditions` named `oex_addUniqueAction`



@aleffert Thoughts?