### PR TITLE
Cache course content screens while scrolling between them

### DIFF
--- a/Source/BlockViewControllerCacheManager.swift
+++ b/Source/BlockViewControllerCacheManager.swift
@@ -8,35 +8,38 @@
 
 import UIKit
 
-class BlockViewControllerCacheManager: NSObject {
+public class BlockViewControllerCacheManager: NSObject {
    
-    var viewControllers = [CourseBlockID : UIViewController]()
+    var viewControllers = NSCache()
     private let enableLogs = false
     
+    override init() {
+        super.init()
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("didRecieveMemoryWarning"), name: UIApplicationDidReceiveMemoryWarningNotification, object: nil)
+    }
+    
     func addToCache(viewController : UIViewController, blockID : CourseBlockID) {
-        if self.viewControllers[blockID] == nil {
-            self.viewControllers[blockID] = viewController
-            if enableLogs {
-                println("ViewController: \(viewController.classForCoder) added for BlockID : \(blockID)")
-            }
+        self.viewControllers.setObject(viewController, forKey: blockID)
+        if enableLogs {
+            println("ViewController: \(viewController.classForCoder) added for BlockID : \(blockID)")
         }
     }
     
     func getCachedViewControllerForBlockID(blockID : CourseBlockID) -> UIViewController? {
-        if let viewController = self.viewControllers[blockID] {
+        let viewController = self.viewControllers.objectForKey(blockID) as? UIViewController
+        if let vc = viewController {
             if enableLogs {
-                println("ViewController: \(viewController.classForCoder) returned for BlockID : \(blockID)")
+                println("ViewController: \(vc.classForCoder) returned for BlockID : \(blockID)")
             }
-            return viewController
         }
-        return nil
+        return viewController
     }
     
     func didRecieveMemoryWarning() {
         if enableLogs {
             println("BlockViewControllerCacheManager did recieve memory warning")
         }
-        self.viewControllers.removeAll(keepCapacity: false)
+        self.viewControllers.removeAllObjects()
     }
     
     

--- a/Source/BlockViewControllerCacheManager.swift
+++ b/Source/BlockViewControllerCacheManager.swift
@@ -10,37 +10,21 @@ import UIKit
 
 public class BlockViewControllerCacheManager: NSObject {
    
-    var viewControllers = NSCache()
-    private let enableLogs = false
+    private let viewControllers = NSCache()
     
     override init() {
         super.init()
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: Selector("didRecieveMemoryWarning"), name: UIApplicationDidReceiveMemoryWarningNotification, object: nil)
+        NSNotificationCenter.defaultCenter().oex_addObserver(self, name: UIApplicationDidReceiveMemoryWarningNotification) { [weak self](_,observer, _) -> Void in
+            observer.viewControllers.removeAllObjects()
+        }
     }
     
     func addToCache(viewController : UIViewController, blockID : CourseBlockID) {
         self.viewControllers.setObject(viewController, forKey: blockID)
-        if enableLogs {
-            println("ViewController: \(viewController.classForCoder) added for BlockID : \(blockID)")
-        }
     }
     
     func getCachedViewControllerForBlockID(blockID : CourseBlockID) -> UIViewController? {
         let viewController = self.viewControllers.objectForKey(blockID) as? UIViewController
-        if let vc = viewController {
-            if enableLogs {
-                println("ViewController: \(vc.classForCoder) returned for BlockID : \(blockID)")
-            }
-        }
         return viewController
     }
-    
-    func didRecieveMemoryWarning() {
-        if enableLogs {
-            println("BlockViewControllerCacheManager did recieve memory warning")
-        }
-        self.viewControllers.removeAllObjects()
-    }
-    
-    
 }

--- a/Source/BlockViewControllerCacheManager.swift
+++ b/Source/BlockViewControllerCacheManager.swift
@@ -1,0 +1,43 @@
+//
+//  BlockViewControllerCacheManager.swift
+//  edX
+//
+//  Created by Ehmad Zubair Chughtai on 24/06/2015.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+import UIKit
+
+class BlockViewControllerCacheManager: NSObject {
+   
+    var viewControllers = [CourseBlockID : UIViewController]()
+    let enableLogs = false
+    
+    func addToCache(viewController : UIViewController, blockID : CourseBlockID) {
+        if self.viewControllers[blockID] == nil {
+            self.viewControllers[blockID] = viewController
+            if enableLogs {
+                println("ViewController: \(viewController.classForCoder) added for BlockID : \(blockID)")
+            }
+        }
+    }
+    
+    func getCachedViewControllerForBlockID(blockID : CourseBlockID) -> UIViewController? {
+        if let viewController = self.viewControllers[blockID] {
+            if enableLogs {
+                println("ViewController: \(viewController.classForCoder) returned for BlockID : \(blockID)")
+            }
+            return viewController
+        }
+        return nil
+    }
+    
+    func didRecieveMemoryWarning() {
+        if enableLogs {
+            println("BlockViewControllerCacheManager did recieve memory warning")
+        }
+        self.viewControllers.removeAll(keepCapacity: false)
+    }
+    
+    
+}

--- a/Source/BlockViewControllerCacheManager.swift
+++ b/Source/BlockViewControllerCacheManager.swift
@@ -11,7 +11,7 @@ import UIKit
 class BlockViewControllerCacheManager: NSObject {
    
     var viewControllers = [CourseBlockID : UIViewController]()
-    let enableLogs = false
+    private let enableLogs = false
     
     func addToCache(viewController : UIViewController, blockID : CourseBlockID) {
         if self.viewControllers[blockID] == nil {

--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -225,6 +225,10 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
             
             if let blockController = nextController as? CourseBlockViewController {
                 currentChildID = blockController.blockID
+                //TODO: Remove when unifying Scrolling with Toolbar Buttons
+                if let childID = blockController.blockID {
+                    self.cacheManager.addToCache(nextController, blockID: childID)
+                }
             }
             return
         }
@@ -240,7 +244,6 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     }
     
     public func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [AnyObject], transitionCompleted completed: Bool) {
-        //Do we need to check for completed here too?
         if let currentController = pageViewController.viewControllers.first as? CourseBlockViewController {
             currentChildID = currentController.blockID
         }

--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -46,7 +46,7 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     
     private var webController : OpenOnWebController!
     
-    private let cachedViewControllers = [UIViewController]()
+    private var cachedViewControllers = [CourseBlockID : AnyObject]()
     
     public init(environment : Environment, courseID : CourseBlockID, rootID : CourseBlockID?, initialChildID: CourseBlockID? = nil) {
         self.environment = environment
@@ -199,6 +199,7 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
                 }
                 else {
                     let sibling = siblings[newIndex]
+                    
                     let controller = self.environment.router?.controllerForBlock(sibling, courseID: courseQuerier.courseID)
                     return controller
                 }
@@ -231,9 +232,16 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     }
     
     public func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [AnyObject], transitionCompleted completed: Bool) {
+        //Do we need to check for completed here too?
         if let currentController = pageViewController.viewControllers.first as? CourseBlockViewController {
             currentChildID = currentController.blockID
         }
+        if let currentViewController = pageViewController.viewControllers.first as? UIViewController {
+            self.cachedViewControllers.append(currentViewController)
+            println("Added a viewcontroller... Total : \(self.cachedViewControllers.count)")
+        }
+        
+        
         self.updateNavigation()
     }
     
@@ -254,6 +262,12 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     
     public func viewControllerForCourseOutlineModeChange() -> UIViewController {
         return self
+    }
+    
+    func printCachedDetails() {
+        if let courseBlockVCs = self.cachedViewControllers as? [CourseBlockViewController] {
+            
+        }
     }
 }
 

--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -219,10 +219,6 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
             
             if let blockController = nextController as? CourseBlockViewController {
                 currentChildID = blockController.blockID
-                //TODO: Remove when unifying Scrolling with Toolbar Buttons
-                if let childID = blockController.blockID {
-                    self.cacheManager.addToCache(nextController, blockID: childID)
-                }
             }
             return
         }
@@ -240,9 +236,6 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     public func pageViewController(pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [AnyObject], transitionCompleted completed: Bool) {
         if let currentController = pageViewController.viewControllers.first as? CourseBlockViewController {
             currentChildID = currentController.blockID
-        }
-        if let currentViewController = pageViewController.viewControllers.first as? UIViewController, currentBlockID = currentChildID {
-            self.cacheManager.addToCache(currentViewController, blockID: currentBlockID)
         }
         self.updateNavigation()
     }
@@ -272,7 +265,11 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
         }
         else {
             // Instantiate a new VC from the router if not found in cache already
-            return self.environment.router?.controllerForBlock(block, courseID: courseQuerier.courseID)
+            if let viewController = self.environment.router?.controllerForBlock(block, courseID: courseQuerier.courseID) {
+                cacheManager.addToCache(viewController, blockID: block.blockID)
+                return viewController
+            }
+            return nil
         }
     }
     

--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -203,13 +203,7 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
                 }
                 else {
                     let sibling = siblings[newIndex]
-                    
-                    if let cachedController = self.cacheManager.getCachedViewControllerForBlockID(sibling.blockID) {
-                        return cachedController
-                    }
-                    
-                    let controller = self.environment.router?.controllerForBlock(sibling, courseID: courseQuerier.courseID)
-                    return controller
+                    return controllerForBlock(sibling)
                 }
 
             }
@@ -272,10 +266,16 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
         return self
     }
     
-    public override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        self.cacheManager.didRecieveMemoryWarning()
+    func controllerForBlock(block : CourseBlock) -> UIViewController? {
+        if let cachedViewController = self.cacheManager.getCachedViewControllerForBlockID(block.blockID) {
+            return cachedViewController
+        }
+        else {
+            // Instantiate a new VC from the router if not found in cache already
+            return self.environment.router?.controllerForBlock(block, courseID: courseQuerier.courseID)
+        }
     }
+    
 }
 
 // MARK: Testing

--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -46,7 +46,9 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     
     private var webController : OpenOnWebController!
     
-    private var cachedViewControllers = [CourseBlockID : AnyObject]()
+    ///Manages the caching of the viewControllers that have been viewed atleast once.
+    ///Removes the ViewControllers from memory in case of a memory warning
+    private let cacheManager : BlockViewControllerCacheManager
     
     public init(environment : Environment, courseID : CourseBlockID, rootID : CourseBlockID?, initialChildID: CourseBlockID? = nil) {
         self.environment = environment
@@ -59,6 +61,8 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
         nextItem = UIBarButtonItem(title: OEXLocalizedString("NEXT", nil), style: UIBarButtonItemStyle.Plain, target: nil, action:nil)
         
         modeController = environment.dataManager.courseDataManager.freshOutlineModeController()
+        
+        cacheManager = BlockViewControllerCacheManager()
         
         super.init(transitionStyle: .Scroll, navigationOrientation: .Horizontal, options: nil)
         
@@ -200,6 +204,10 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
                 else {
                     let sibling = siblings[newIndex]
                     
+                    if let cachedController = self.cacheManager.getCachedViewControllerForBlockID(sibling.blockID) {
+                        return cachedController
+                    }
+                    
                     let controller = self.environment.router?.controllerForBlock(sibling, courseID: courseQuerier.courseID)
                     return controller
                 }
@@ -236,12 +244,9 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
         if let currentController = pageViewController.viewControllers.first as? CourseBlockViewController {
             currentChildID = currentController.blockID
         }
-        if let currentViewController = pageViewController.viewControllers.first as? UIViewController {
-            self.cachedViewControllers.append(currentViewController)
-            println("Added a viewcontroller... Total : \(self.cachedViewControllers.count)")
+        if let currentViewController = pageViewController.viewControllers.first as? UIViewController, currentBlockID = currentChildID {
+            self.cacheManager.addToCache(currentViewController, blockID: currentBlockID)
         }
-        
-        
         self.updateNavigation()
     }
     
@@ -264,10 +269,9 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
         return self
     }
     
-    func printCachedDetails() {
-        if let courseBlockVCs = self.cachedViewControllers as? [CourseBlockViewController] {
-            
-        }
+    public override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        self.cacheManager.didRecieveMemoryWarning()
     }
 }
 

--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -46,6 +46,8 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     
     private var webController : OpenOnWebController!
     
+    private let cachedViewControllers = [UIViewController]()
+    
     public init(environment : Environment, courseID : CourseBlockID, rootID : CourseBlockID?, initialChildID: CourseBlockID? = nil) {
         self.environment = environment
         self.blockID = rootID

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -355,6 +355,7 @@
 		9EBED5EA1B26D9F0007AD266 /* bt_facebook_RTL.png in Resources */ = {isa = PBXBuildFile; fileRef = 9EBED5E91B26D9F0007AD266 /* bt_facebook_RTL.png */; };
 		9EBED5EC1B26D9F8007AD266 /* bt_google_RTL.png in Resources */ = {isa = PBXBuildFile; fileRef = 9EBED5EB1B26D9F8007AD266 /* bt_google_RTL.png */; };
 		9ED03B951B204CDF0081A19A /* CourseSectionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED03B941B204CDF0081A19A /* CourseSectionTableViewCell.swift */; };
+		9ED105441B3AAC5B00D244FF /* BlockViewControllerCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED105431B3AAC5B00D244FF /* BlockViewControllerCacheManager.swift */; };
 		9ED168AE1B29A4ED00AA7B5B /* UserAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED168AD1B29A4ED00AA7B5B /* UserAPI.swift */; };
 		9ED168B01B29A9EF00AA7B5B /* CouseLastAccessed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ED168AF1B29A9EF00AA7B5B /* CouseLastAccessed.swift */; };
 		9ED269C81AEF8A5200328A34 /* OEXCourseVideoDownloadTableViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9ED269C71AEF8A5200328A34 /* OEXCourseVideoDownloadTableViewController.storyboard */; };
@@ -971,6 +972,7 @@
 		9EBED5E91B26D9F0007AD266 /* bt_facebook_RTL.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = bt_facebook_RTL.png; sourceTree = "<group>"; };
 		9EBED5EB1B26D9F8007AD266 /* bt_google_RTL.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = bt_google_RTL.png; sourceTree = "<group>"; };
 		9ED03B941B204CDF0081A19A /* CourseSectionTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseSectionTableViewCell.swift; sourceTree = "<group>"; };
+		9ED105431B3AAC5B00D244FF /* BlockViewControllerCacheManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockViewControllerCacheManager.swift; sourceTree = "<group>"; };
 		9ED168AD1B29A4ED00AA7B5B /* UserAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAPI.swift; sourceTree = "<group>"; };
 		9ED168AF1B29A9EF00AA7B5B /* CouseLastAccessed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CouseLastAccessed.swift; sourceTree = "<group>"; };
 		9ED269C71AEF8A5200328A34 /* OEXCourseVideoDownloadTableViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = OEXCourseVideoDownloadTableViewController.storyboard; sourceTree = "<group>"; };
@@ -2198,6 +2200,7 @@
 				1913DD3E194EC56800573977 /* Generic View */,
 				9EEFFD641B300E87002A88B0 /* OEXInterface+Swift.swift */,
 				9EE684CA1B3D5FAB00C7B157 /* CourseHandoutsViewController.swift */,
+				9ED105431B3AAC5B00D244FF /* BlockViewControllerCacheManager.swift */,
 			);
 			name = Course;
 			sourceTree = "<group>";
@@ -2949,6 +2952,7 @@
 				770C514B1B1685E3009B9696 /* HTMLBlockViewController.swift in Sources */,
 				46CECC3A1B041CDC0073C63A /* CourseDashboardCourseInfoCell.swift in Sources */,
 				77C1CB2A1B3353D400E9DB99 /* DetachedStreamOperation.swift in Sources */,
+				9ED105441B3AAC5B00D244FF /* BlockViewControllerCacheManager.swift in Sources */,
 				199627831945AB5B0022C489 /* OEXCustomTextField.m in Sources */,
 				193B50481945A0520038E11C /* OEXCustomLabel.m in Sources */,
 				77000A371A76EF8C007D306C /* NSString+OEXValidation.m in Sources */,


### PR DESCRIPTION
Right now when we scroll between different pieces of course content, we reload the entire page each time. We should:
- Cache pages we've already visited.
- Optimistically load the following (and previous?) page.

We should flush this cache on memory warnings.
Note that preloading the surrounding pages might have funny behavior for videos where they start playing right away. If so, let's not worry about the optimistic loading stuff.