### PR TITLE
Prepare data for scrolling between units.

### DIFF
--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -39,7 +39,7 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     
     private var openURLButtonItem : UIBarButtonItem?
     
-    private var contentLoader = BackedStream<[CourseBlock]>()
+    private var contentLoader = BackedStream<BlockGroup>()
     
     private let courseQuerier : CourseOutlineQuerier
     private let modeController : CourseOutlineModeController
@@ -116,7 +116,8 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     }
     
     private func addStreamListeners() {
-        contentLoader.listen(self, success : {[weak self] blocks -> Void in
+        contentLoader.listen(self, success : {[weak self] group -> Void in
+            let blocks = group.children
             // Start by trying to show the currently set child
             // Handle the case where the given child id is invalid
             // By verifiying it's in the children
@@ -153,7 +154,7 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     }
     
     private func titleOfCurrentChild() -> String? {
-        if let children = contentLoader.value, child = children.firstObjectMatching({$0.blockID == currentChildID}) {
+        if let children = contentLoader.value?.children, child = children.firstObjectMatching({$0.blockID == currentChildID}) {
             return child.name
         }
         return nil
@@ -162,7 +163,7 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     private func updateNavigation() {
         self.navigationItem.title = titleOfCurrentChild()
         
-        let children = contentLoader.value
+        let children = contentLoader.value?.children
         let index = children.flatMap {
             $0.firstIndexMatching {node in
                 return node.blockID == currentChildID
@@ -185,7 +186,8 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     
     private func siblingAtOffset(offset : Int, fromController viewController: UIViewController) -> UIViewController? {
         let blockController = viewController as! CourseBlockViewController
-        return contentLoader.value.flatMap { siblings in
+        let blocks = contentLoader.value?.children
+        return blocks.flatMap { siblings in
             return siblings.firstIndexMatching {node in
                 return node.blockID == blockController.blockID
             }.flatMap {index in

--- a/Source/CourseOutline.swift
+++ b/Source/CourseOutline.swift
@@ -14,12 +14,12 @@ public struct CourseOutline {
     public let root : CourseBlockID
     public let blocks : [CourseBlockID:CourseBlock]
     
-    init(root : CourseBlockID, blocks : [CourseBlockID:CourseBlock]) {
+    public init(root : CourseBlockID, blocks : [CourseBlockID:CourseBlock]) {
         self.root = root
         self.blocks = blocks
     }
     
-    init?(json : JSON) {
+    public init?(json : JSON) {
         if let root = json["root"].string, blocks = json["blocks+navigation"].dictionaryObject {
             var validBlocks : [CourseBlockID:CourseBlock] = [:]
             for (blockID, blockBody) in blocks {
@@ -137,6 +137,7 @@ public struct CourseBlock {
     /// Suitable for embedding in a web view.
     public let blockURL : NSURL?
     
+    /// If this is web content, can we actually display it.
     public let isResponsive : Bool
     
     /// A full web page for the block.

--- a/Source/CourseOutlineTableSource.swift
+++ b/Source/CourseOutlineTableSource.swift
@@ -29,8 +29,7 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
         fatalError("init(coder:) has not been implemented")
     }
     
-    var nodes : [CourseBlock] = []
-    var children : [CourseBlockID : [CourseBlock]] = [:]
+    var groups : [BlockGroup] = []
     
     override func viewDidLoad() {
         tableView.dataSource = self
@@ -50,12 +49,12 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
     }
     
     override func numberOfSectionsInTableView(tableView: UITableView) -> Int {
-        return nodes.count
+        return groups.count
     }
     
     override func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        let blockID = nodes[section].blockID
-        return children[blockID]?.count ?? 0
+        let group = groups[section]
+        return group.children.count
     }
     
     override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -68,50 +67,44 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
     }
     
     override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let node = nodes[section]
+        let group = groups[section]
         let header = tableView.dequeueReusableHeaderFooterViewWithIdentifier(CourseOutlineHeaderCell.identifier) as! CourseOutlineHeaderCell
-        header.block = node
+        header.block = group.block
         return header
     }
     
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        
-        let node = nodes[indexPath.section]
-        if let nodes = children[node.blockID] {
-            let block = nodes[indexPath.row]
-            switch nodes[indexPath.row].displayType {
-            case .Video:
-                let cell = tableView.dequeueReusableCellWithIdentifier(CourseVideoTableViewCell.identifier, forIndexPath: indexPath) as! CourseVideoTableViewCell
-                cell.block = block
-                cell.localState = OEXInterface.sharedInterface().stateForVideoWithID(block.blockID, courseID : courseID)
-                cell.delegate = self
-                return cell
-            case .HTML:
-                let cell = tableView.dequeueReusableCellWithIdentifier(CourseHTMLTableViewCell.identifier, forIndexPath: indexPath) as! CourseHTMLTableViewCell
-                cell.block = block
-                cell.kind = CourseHTMLTableViewCell.kindForBlockType(block.type)
-                return cell
-            case .Unknown:
-                let cell = tableView.dequeueReusableCellWithIdentifier(CourseUnknownTableViewCell.identifier, forIndexPath: indexPath) as! CourseUnknownTableViewCell
-                cell.block = block
-                return cell
-            case .Outline, .Unit:
-                var cell = tableView.dequeueReusableCellWithIdentifier(CourseSectionTableViewCell.identifier, forIndexPath: indexPath) as! CourseSectionTableViewCell
-                cell.block = nodes[indexPath.row]
-                cell.delegate = self
-                return cell
-            }
+        let group = groups[indexPath.section]
+        let nodes = group.children
+        let block = nodes[indexPath.row]
+        switch nodes[indexPath.row].displayType {
+        case .Video:
+            let cell = tableView.dequeueReusableCellWithIdentifier(CourseVideoTableViewCell.identifier, forIndexPath: indexPath) as! CourseVideoTableViewCell
+            cell.block = block
+            cell.localState = OEXInterface.sharedInterface().stateForVideoWithID(block.blockID, courseID : courseID)
+            cell.delegate = self
+            return cell
+        case .HTML:
+            let cell = tableView.dequeueReusableCellWithIdentifier(CourseHTMLTableViewCell.identifier, forIndexPath: indexPath) as! CourseHTMLTableViewCell
+            cell.block = block
+            cell.kind = CourseHTMLTableViewCell.kindForBlockType(block.type)
+            return cell
+        case .Unknown:
+            let cell = tableView.dequeueReusableCellWithIdentifier(CourseUnknownTableViewCell.identifier, forIndexPath: indexPath) as! CourseUnknownTableViewCell
+            cell.block = block
+            return cell
+        case .Outline, .Unit:
+            var cell = tableView.dequeueReusableCellWithIdentifier(CourseSectionTableViewCell.identifier, forIndexPath: indexPath) as! CourseSectionTableViewCell
+            cell.block = nodes[indexPath.row]
+            cell.delegate = self
+            return cell
         }
-        assertionFailure("Control reached undesireable state at index : \(indexPath.row)");
-        return UITableViewCell()
     }
     
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        let node = nodes[indexPath.section]
-        if let nodes = children[node.blockID] {
-            let chosenBlock = nodes[indexPath.row]
-            self.delegate?.outlineTableController(self, choseBlock: chosenBlock, withParentID: node.blockID)
-        }
+        let group = groups[indexPath.section]
+        let chosenBlock = group.children[indexPath.row]
+        self.delegate?.outlineTableController(self, choseBlock: chosenBlock, withParentID: group.block.blockID)
     }
     
     func videoCellChoseDownload(cell: CourseVideoTableViewCell, block : CourseBlock) {
@@ -122,23 +115,23 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
         self.delegate?.outlineTableController(self, choseDownloadVideosRootedAtBlock: block)
     }
     
+    func choseViewLastAccessedWithItem(item : CourseLastAccessed) {
+        for group in groups {
+            let childNodes = group.children
+            let currentLastViewedIndex = childNodes.firstIndexMatching({$0.blockID == item.moduleId})
+            if let matchedIndex = currentLastViewedIndex {
+                self.delegate?.outlineTableController(self, choseBlock: childNodes[matchedIndex], withParentID: group.block.blockID)
+                break
+            }
+        }
+    }
+    
     /// Shows the last accessed Header from the item as argument. Also, sets the relevant action if the course block exists in the course outline.
     func showLastAccessedWithItem(item : CourseLastAccessed) {
         tableView.tableHeaderView = self.headerContainer
         lastAccessedView.subtitleText = item.moduleName
-        lastAccessedView.setViewButtonAction({ [weak self] (sender:AnyObject) -> Void in
-            if let owner = self {
-                for node in owner.nodes {
-                    if let childNodes = owner.children[node.blockID] {
-                        let currentLastViewedIndex = childNodes.firstIndexMatching({$0.blockID == item.moduleId})
-                        if let matchedIndex = currentLastViewedIndex {
-                            owner.delegate?.outlineTableController(owner, choseBlock: childNodes[matchedIndex], withParentID: node.blockID)
-                            break
-                        }
-                        
-                    }
-                }
-            }
-        })
+        lastAccessedView.setViewButtonAction { [weak self] _ in
+            self?.choseViewLastAccessedWithItem(item)
+        }
     }
 }

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -33,9 +33,8 @@ public class CourseOutlineViewController : UIViewController, CourseBlockViewCont
     private let courseQuerier : CourseOutlineQuerier
     private let tableController : CourseOutlineTableController
     
-    private let blockLoader = BackedStream<CourseBlock>()
-    private let headersLoader = BackedStream<[CourseBlock]>()
-    private let rowsLoader = BackedStream<[(CourseBlockID, [CourseBlock])]>()
+    private let headersLoader = BackedStream<BlockGroup>()
+    private let rowsLoader = BackedStream<[BlockGroup]>()
     private let lastAccessedLoader = BackedStream<(CourseBlock, CourseLastAccessed)>()
     
     private let loadController : LoadStateViewController
@@ -100,7 +99,6 @@ public class CourseOutlineViewController : UIViewController, CourseBlockViewCont
         
         self.view.setNeedsUpdateConstraints()
         
-        self.blockLoader.backWithStream(courseQuerier.blockWithID(self.blockID).dropFailuresAfterSuccess())
         loadContentIfNecessary()
         addListeners()
         
@@ -159,11 +157,10 @@ public class CourseOutlineViewController : UIViewController, CourseBlockViewCont
         }
     }
     
-    private func loadedHeaders(headers : [CourseBlock]) {
-        let children = headers.map {header in
-            return self.courseQuerier.childrenOfBlockWithID(header.blockID, forMode: self.modeController.currentMode).map {
-                return (header.blockID, $0)
-            }
+    private func loadedHeaders(headers : BlockGroup) {
+        self.setupNavigationItem(headers.block)
+        let children = headers.children.map {header in
+            return self.courseQuerier.childrenOfBlockWithID(header.blockID, forMode: self.modeController.currentMode)
         }
         rowsLoader.backWithStream(joinStreams(children))
     }
@@ -180,12 +177,6 @@ public class CourseOutlineViewController : UIViewController, CourseBlockViewCont
             }
         }
         
-        blockLoader.listen(self) {[weak self] block in
-            block.ifSuccess {
-                self?.setupNavigationItem($0)
-            }
-        }
-        
         headersLoader.listen(self,
             success: {[weak self] headers in
                 self?.loadedHeaders(headers)
@@ -197,12 +188,11 @@ public class CourseOutlineViewController : UIViewController, CourseBlockViewCont
         )
         
         rowsLoader.listen(self,
-            success : {[weak self] children in
+            success : {[weak self] groups in
                 if let owner = self, nodes = owner.headersLoader.value {
-                    owner.tableController.nodes = nodes
-                    owner.tableController.children = Dictionary(elements: children)
+                    owner.tableController.groups = groups
                     owner.tableController.tableView.reloadData()
-                    owner.loadController.state = nodes.count == 0 ? owner.emptyState() : .Loaded
+                    owner.loadController.state = groups.count == 0 ? owner.emptyState() : .Loaded
                 }
             },
             failure : {[weak self] error in
@@ -311,7 +301,7 @@ extension CourseOutlineViewController {
     }
     
     public func t_currentChildCount() -> Int {
-        return tableController.nodes.count
+        return tableController.groups.count
     }
     
     public func t_populateLastAccessedItem(item : CourseLastAccessed) -> Bool {

--- a/Source/CourseStructureAPI.swift
+++ b/Source/CourseStructureAPI.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public struct CourseOutlineAPI {
-    public struct Parameters {
+    struct Parameters {
         let fields : [String]
         let blockCount : [String]
         let blockJSON : [String:AnyObject]
@@ -29,7 +29,7 @@ public struct CourseOutlineAPI {
         }
     }
     
-    static func requestWithCourseID(courseID : String) -> NetworkRequest<CourseOutline> {
+    public static func requestWithCourseID(courseID : String) -> NetworkRequest<CourseOutline> {
         let parameters = Parameters(
             fields : ["graded", "responsive_ui", "format"],
             blockCount : [CourseBlock.Category.Video.rawValue],

--- a/Source/ListCursor.swift
+++ b/Source/ListCursor.swift
@@ -1,0 +1,80 @@
+//
+//  ListCursor.swift
+//  edX
+//
+//  Created by Akiva Leffert on 6/26/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+import Foundation
+
+public class ListCursor<A> {
+    
+    private var index : Int
+    private var list : [A]
+    
+    public init(list : [A], index : Int) {
+        self.index = index
+        self.list = list
+    }
+    
+    /// Return the previous value if available and decrement the index
+    public func prev() -> A? {
+        if hasPrev {
+            index = index - 1
+            return list[index]
+        }
+        else {
+            return nil
+        }
+    }
+    
+    /// Return the next value if available and increment the index
+    public func next() -> A? {
+        if hasNext {
+            index = index + 1
+            return list[index]
+        }
+        else {
+            return nil
+        }
+    }
+    
+    public var hasPrev : Bool {
+        return index > 0
+    }
+    
+    public var hasNext : Bool {
+        return index + 1 < list.count
+    }
+    
+    public var current : A? {
+        if index >= 0 && index < list.count {
+            return list[index]
+        }
+        else {
+            return nil
+        }
+    }
+    
+    /// Return the previous value if possible without changing the current index
+    public func peekPrev() -> A? {
+        if hasPrev {
+            return list[index]
+        }
+        else {
+            return nil
+        }
+    }
+    
+    
+    /// Return the next value if possible without changing the current index
+    public func peekNext() -> A? {
+        if hasNext {
+            return list[index]
+        }
+        else {
+            return nil
+        }
+    }
+}

--- a/Source/NSObject+OEXDeallocAction.m
+++ b/Source/NSObject+OEXDeallocAction.m
@@ -17,6 +17,10 @@
 @property (copy, nonatomic) void (^action)(void);
 @property (copy, nonatomic) void (^removeAction)(id);
 
+#if DEBUG
+@property (copy, nonatomic) NSString* debugInfo;
+#endif
+
 @end
 
 @implementation OEXDeallocActionRunner
@@ -47,6 +51,11 @@
         objc_setAssociatedObject(weakself, (__bridge void*)sender, nil, OBJC_ASSOCIATION_RETAIN);
     };
     objc_setAssociatedObject(self, (__bridge void*)runner, runner, OBJC_ASSOCIATION_RETAIN);
+    
+#if DEBUG
+    runner.debugInfo = self.description;
+#endif
+    
     return runner;
 }
 

--- a/Source/Stream.swift
+++ b/Source/Stream.swift
@@ -90,7 +90,7 @@ public class Stream<A> {
         }
         listeners.append(listener)
         
-        owner.oex_performActionOnDealloc {
+        let removable = owner.oex_performActionOnDealloc {
             listener.remove()
         }
         
@@ -102,6 +102,7 @@ public class Stream<A> {
         }
         
         return BlockRemovable {
+            removable.remove()
             listener.remove()
         }
     }

--- a/Test/CourseOutlineQuerierTests.swift
+++ b/Test/CourseOutlineQuerierTests.swift
@@ -1,0 +1,88 @@
+//
+//  CourseOutlineQuerierTests.swift
+//  edX
+//
+//  Created by Akiva Leffert on 6/24/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+import edX
+import UIKit
+import XCTest
+
+class CourseOutlineQuerierTests: XCTestCase {
+    
+    let courseID = OEXCourse.freshCourse().course_id!
+    
+    func testBlockLoadsFromNetwork() {
+        let outline = CourseOutlineTestDataFactory.freshCourseOutline(courseID)
+        let networkManager = MockNetworkManager(authorizationHeaderProvider: nil, baseURL: NSURL(string : "http://www.example.com")!)
+        let request = CourseOutlineAPI.requestWithCourseID(courseID)
+        networkManager.addMatcher({_ in return true}, successResponse: {
+            return (nil, outline)
+        })
+        let querier = CourseOutlineQuerier(courseID: "course", interface: nil, networkManager: networkManager)
+        
+        let blockID = CourseOutlineTestDataFactory.knownSection()
+        let blockStream = querier.blockWithID(blockID)
+        let expectation = expectationWithDescription("block loads")
+        let removable = blockStream.listen(self) {block in
+            XCTAssertEqual(block.value!.blockID, blockID)
+            expectation.fulfill()
+        }
+        waitForExpectations()
+        removable.remove()
+    }
+    
+    func testModeFilter() {
+        let outline = CourseOutlineTestDataFactory.freshCourseOutline(courseID)
+        let querier = CourseOutlineQuerier(courseID: courseID, outline: outline)
+        let block = CourseOutlineTestDataFactory.knownVideoFilterableSection()
+        let fullStream = querier.childrenOfBlockWithID(block, forMode: .Full)
+        let filteredStream = querier.childrenOfBlockWithID(block, forMode: .Video)
+        let joined = joinStreams(fullStream, filteredStream)
+        let expectation = expectationWithDescription("Child stream loaded")
+        
+        let removable = joined.listen(self) {result in
+            let (full, filtered) = result.value!
+            XCTAssertGreaterThan(full.children.count, filtered.children.count)
+            expectation.fulfill()
+        }
+        waitForExpectations()
+        removable.remove()
+    }
+    
+    func testFlatMap() {
+        let outline = CourseOutlineTestDataFactory.freshCourseOutline(courseID)
+        let querier = CourseOutlineQuerier(courseID: courseID, outline: outline)
+        let knownNodes = CourseOutlineTestDataFactory.knownHTMLBlockIDs()
+        let htmlNodeStream = querier.flatMapRootedAtBlockWithID(outline.root) {block -> [CourseBlockID] in
+            switch block.type {
+            case .HTML: return [block.blockID]
+            default: return []
+            }
+        }
+        let expectation = expectationWithDescription("Map Finished")
+        let removable = htmlNodeStream.listen(self) {blocks in
+            XCTAssertEqual(Set(blocks.value!), Set(knownNodes))
+            expectation.fulfill()
+        }
+        waitForExpectations()
+        removable.remove()
+    }
+    
+    func testDepthQuerier() {
+        let outline = CourseOutlineTestDataFactory.freshCourseOutline(courseID)
+        let querier = CourseOutlineQuerier(courseID: courseID, outline: outline)
+        let root = outline.blocks[outline.root]!
+        let child = root.children[1]
+        let cursor = querier.spanningCursorForBlockWithID(child, forMode: .Full).value!
+        let block = cursor.prev()!.block
+        XCTAssertEqual(root.children[0], block.blockID)
+        var i = 1
+        while let group = cursor.next() {
+            XCTAssertEqual(root.children[i], group.block.blockID)
+            i = i + 1
+        }
+    }
+}

--- a/Test/CourseOutlineTestDataFactory.swift
+++ b/Test/CourseOutlineTestDataFactory.swift
@@ -32,7 +32,7 @@ public class CourseOutlineTestDataFactory {
                 "block1": CourseBlock(type: CourseBlockType.HTML, children : [], blockID : "block1", name : "Block 1"),
                 "block2": CourseBlock(type: CourseBlockType.HTML, children : [], blockID : "block2", name : "Block 2"),
                 "block3": CourseBlock(type: CourseBlockType.Problem, children : [], blockID : "block3", name : "Block 3"),
-                "block4": CourseBlock(type: CourseBlockType.Video(OEXVideoSummaryTestDataFactory.localVideoWithID("block4", pathIDs: ["chapter1", "section1.1", "unit2"])), children : [], blockID : "block4", name : "Block 4"),
+                "block4": CourseBlock(type: CourseBlockType.Video(OEXVideoSummaryTestDataFactory.localVideoWithID("block4", pathIDs: ["chapter1", "section1.1", "unit2"])), children : [], blockID : "block4", name : "Block 4", blockCounts : ["video" : 1]),
                 "block5": CourseBlock(type: CourseBlockType.Unknown("something"), children : [], blockID : "block5", name : "Block 5", isResponsive : false)
             ])
     }
@@ -53,4 +53,11 @@ public class CourseOutlineTestDataFactory {
         return "section2.1"
     }
 
+    public static func knownVideoFilterableSection() -> CourseBlockID {
+        return "unit2"
+    }
+    
+    public static func knownHTMLBlockIDs() -> [CourseBlockID] {
+        return ["block1", "block2"]
+    }
 }

--- a/Test/CourseOutlineViewControllerTests.swift
+++ b/Test/CourseOutlineViewControllerTests.swift
@@ -65,9 +65,9 @@ class CourseOutlineViewControllerTests: SnapshotTestCase {
         
         let expectation = expectationWithDescription("Loaded children")
         let stream = joinStreams(fullChildren, filteredChildren).listen(NSObject()) {
-            let fullChildren = $0.value!.0
-            let filteredChildren = $0.value!.1
-            XCTAssertGreaterThan(fullChildren.count, filteredChildren.count)
+            let full = $0.value!.0
+            let filtered = $0.value!.1
+            XCTAssertGreaterThan(full.children.count, filtered.children.count)
             expectation.fulfill()
         }
         self.waitForExpectations()

--- a/Test/ListCursorTests.swift
+++ b/Test/ListCursorTests.swift
@@ -1,0 +1,57 @@
+//
+//  ListCursorTests.swift
+//  edX
+//
+//  Created by Akiva Leffert on 6/26/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+import edX
+import UIKit
+import XCTest
+
+class ListCursorTests: XCTestCase {
+    
+    let list = [1, 2, 3, 4, 5]
+    
+    func testForwardIteration() {
+        let cursor = ListCursor(list: list, index: 0)
+        var acc = [cursor.current!]
+        while let value = cursor.next() {
+            acc.append(value)
+            XCTAssertEqual(value, cursor.current!)
+            XCTAssertEqual(cursor.peekPrev()!, acc.last!)
+        }
+        XCTAssertEqual(acc, list)
+        XCTAssertTrue(cursor.hasPrev)
+        XCTAssertFalse(cursor.hasNext)
+        XCTAssertNil(cursor.next())
+    }
+    
+    
+    func testReverseIteration() {
+        let cursor = ListCursor(list: list, index: list.count - 1)
+        var acc = [cursor.current!]
+        while let value = cursor.prev() {
+            acc.append(value)
+            XCTAssertEqual(value, cursor.current!)
+            XCTAssertEqual(cursor.peekNext()!, acc.last!)
+        }
+        XCTAssertEqual(acc.reverse(), list)
+        XCTAssertTrue(cursor.hasNext)
+        XCTAssertFalse(cursor.hasPrev)
+        XCTAssertNil(cursor.prev())
+    }
+    
+    func testNextPrev() {
+        let cursor = ListCursor(list: list, index: 2)
+        let original = cursor.current
+        let a = cursor.next()
+        let b = cursor.prev()
+        let c = cursor.next()
+        XCTAssertEqual(a!, c!)
+        XCTAssertEqual(b!, original!)
+        XCTAssertEqual(c!, cursor.current!)
+    }
+
+}

--- a/Test/NetworkManagerTests.swift
+++ b/Test/NetworkManagerTests.swift
@@ -110,7 +110,7 @@ class NetworkManagerTests: XCTestCase {
         let networkData = "network".dataUsingEncoding(NSUTF8StringEncoding)!
         manager.addMatcher({_ -> Bool in return true },
             delay : 0.1,
-            response: {
+            response: {_ in
             return NetworkResult(request: URLRequest, response: response, data: networkData, baseData: networkData, error: nil)
             }
         )
@@ -139,7 +139,7 @@ class NetworkManagerTests: XCTestCase {
         
         let (manager, request, URLRequest) = requestEnvironment()
         manager.addMatcher({_ -> Bool in return true },
-            response: {
+            response: {_ in
                 return NetworkResult<NSData>(request: URLRequest, response: nil, data: nil, baseData: nil, error: NSError.oex_unknownError())
             }
         )
@@ -164,7 +164,7 @@ class NetworkManagerTests: XCTestCase {
         let headers = ["a" : "b"]
         let response = NSHTTPURLResponse(URL: URLRequest.URL!, statusCode: 404, HTTPVersion: nil, headerFields: headers)!
         manager.addMatcher({_ -> Bool in return true },
-            response: {
+            response: {_ in
                 return NetworkResult<NSData>(request: URLRequest, response: response, data: testData, baseData: testData, error: NSError.oex_unknownError())
             }
         )

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -217,6 +217,8 @@
 		77691FA31B3B4596003922F2 /* UIColor+OEXHex.m in Sources */ = {isa = PBXBuildFile; fileRef = 77691FA21B3B4596003922F2 /* UIColor+OEXHex.m */; };
 		77691FAB1B3C74AF003922F2 /* OpenOnWebControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77691FA91B3C7470003922F2 /* OpenOnWebControllerTests.swift */; };
 		77691FAD1B3C764F003922F2 /* UIBarButtonItem+Touchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77691FAC1B3C764F003922F2 /* UIBarButtonItem+Touchable.swift */; };
+		77691FB01B3C820B003922F2 /* CourseOutlineViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77691FAE1B3C81E4003922F2 /* CourseOutlineViewControllerTests.swift */; };
+		77691FB21B3C824E003922F2 /* CourseOutlineQuerierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77691FB11B3C824E003922F2 /* CourseOutlineQuerierTests.swift */; };
 		77696C021A51FEA8009F9D8C /* OEXConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 77696C011A51FEA8009F9D8C /* OEXConfig.m */; };
 		7772BE731AF2FECC0081CA7A /* CourseOutlineHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7772BE721AF2FECC0081CA7A /* CourseOutlineHeaderCell.swift */; };
 		7772BE7A1AF41E660081CA7A /* CourseBlockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7772BE791AF41E660081CA7A /* CourseBlockViewController.swift */; };
@@ -255,6 +257,8 @@
 		778B82EC1A520F2A0040D9E0 /* OEXEnvironment.m in Sources */ = {isa = PBXBuildFile; fileRef = 778B82EB1A520F2A0040D9E0 /* OEXEnvironment.m */; };
 		778C72EF1B179C4A00FC3F68 /* CourseOutlineModeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778C72EE1B179C4A00FC3F68 /* CourseOutlineModeController.swift */; };
 		778C72F11B17C30000FC3F68 /* Dictionary+Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778C72F01B17C30000FC3F68 /* Dictionary+Functional.swift */; };
+		778D53351B3D96E900441A98 /* ListCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778D53341B3D96E900441A98 /* ListCursor.swift */; };
+		778D53371B3D97CC00441A98 /* ListCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778D53361B3D97CC00441A98 /* ListCursorTests.swift */; };
 		77A340211AB2461800C8E141 /* OEXRegistrationViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77A340201AB2461800C8E141 /* OEXRegistrationViewControllerTests.m */; };
 		77AB8C7A1B33770800AB3FC0 /* Operation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AB8C791B33770800AB3FC0 /* Operation.swift */; };
 		77AB8C7F1B33875000AB3FC0 /* NSString+OEXCrypto.m in Sources */ = {isa = PBXBuildFile; fileRef = 77AB8C7E1B33875000AB3FC0 /* NSString+OEXCrypto.m */; };
@@ -295,7 +299,6 @@
 		77F76A6B1B0BCAE300ED3E39 /* SwiftyJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F76A6A1B0BCAE300ED3E39 /* SwiftyJSON.swift */; };
 		77F76A6E1B0BD32A00ED3E39 /* OEXSession+Authorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F76A6D1B0BD32A00ED3E39 /* OEXSession+Authorization.swift */; };
 		77F76A701B0BD5EC00ED3E39 /* OEXSession+AuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F76A6F1B0BD5EC00ED3E39 /* OEXSession+AuthorizationTests.swift */; };
-		77F76A721B0CDF0800ED3E39 /* CourseOutlineViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F76A711B0CDF0800ED3E39 /* CourseOutlineViewControllerTests.swift */; };
 		77F76A741B0CE01E00ED3E39 /* MockCourseDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F76A731B0CE01E00ED3E39 /* MockCourseDataManager.swift */; };
 		77F9C1741B0D496B004D39E7 /* CourseStructureAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77F9C1731B0D496B004D39E7 /* CourseStructureAPI.swift */; };
 		77FDF40F1AFBAE7700E8C639 /* OEXRouter+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77FDF40E1AFBAE7700E8C639 /* OEXRouter+Swift.swift */; };
@@ -786,6 +789,8 @@
 		77691FA21B3B4596003922F2 /* UIColor+OEXHex.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+OEXHex.m"; sourceTree = "<group>"; };
 		77691FA91B3C7470003922F2 /* OpenOnWebControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OpenOnWebControllerTests.swift; sourceTree = "<group>"; };
 		77691FAC1B3C764F003922F2 /* UIBarButtonItem+Touchable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+Touchable.swift"; sourceTree = "<group>"; };
+		77691FAE1B3C81E4003922F2 /* CourseOutlineViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseOutlineViewControllerTests.swift; sourceTree = "<group>"; };
+		77691FB11B3C824E003922F2 /* CourseOutlineQuerierTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseOutlineQuerierTests.swift; sourceTree = "<group>"; };
 		77696C001A51FEA8009F9D8C /* OEXConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXConfig.h; sourceTree = "<group>"; };
 		77696C011A51FEA8009F9D8C /* OEXConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXConfig.m; sourceTree = "<group>"; };
 		7772BE721AF2FECC0081CA7A /* CourseOutlineHeaderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseOutlineHeaderCell.swift; sourceTree = "<group>"; };
@@ -829,6 +834,8 @@
 		778B82EB1A520F2A0040D9E0 /* OEXEnvironment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXEnvironment.m; sourceTree = "<group>"; };
 		778C72EE1B179C4A00FC3F68 /* CourseOutlineModeController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseOutlineModeController.swift; sourceTree = "<group>"; };
 		778C72F01B17C30000FC3F68 /* Dictionary+Functional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Functional.swift"; sourceTree = "<group>"; };
+		778D53341B3D96E900441A98 /* ListCursor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListCursor.swift; sourceTree = "<group>"; };
+		778D53361B3D97CC00441A98 /* ListCursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListCursorTests.swift; sourceTree = "<group>"; };
 		77A340201AB2461800C8E141 /* OEXRegistrationViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXRegistrationViewControllerTests.m; sourceTree = "<group>"; };
 		77AB8C791B33770800AB3FC0 /* Operation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operation.swift; sourceTree = "<group>"; };
 		77AB8C7D1B33875000AB3FC0 /* NSString+OEXCrypto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+OEXCrypto.h"; sourceTree = "<group>"; };
@@ -882,7 +889,6 @@
 		77F76A6A1B0BCAE300ED3E39 /* SwiftyJSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftyJSON.swift; path = Libraries/SwiftyJSON/Source/SwiftyJSON.swift; sourceTree = SOURCE_ROOT; };
 		77F76A6D1B0BD32A00ED3E39 /* OEXSession+Authorization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OEXSession+Authorization.swift"; sourceTree = "<group>"; };
 		77F76A6F1B0BD5EC00ED3E39 /* OEXSession+AuthorizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OEXSession+AuthorizationTests.swift"; sourceTree = "<group>"; };
-		77F76A711B0CDF0800ED3E39 /* CourseOutlineViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseOutlineViewControllerTests.swift; sourceTree = "<group>"; };
 		77F76A731B0CE01E00ED3E39 /* MockCourseDataManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockCourseDataManager.swift; sourceTree = "<group>"; };
 		77F9C1731B0D496B004D39E7 /* CourseStructureAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseStructureAPI.swift; sourceTree = "<group>"; };
 		77FDF40E1AFBAE7700E8C639 /* OEXRouter+Swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OEXRouter+Swift.swift"; sourceTree = "<group>"; };
@@ -1738,17 +1744,18 @@
 			name = FontAwesome.swift;
 			sourceTree = "<group>";
 		};
-		77864DDA1B10057600182FC2 /* Base Containers */ = {
+		77864DDA1B10057600182FC2 /* Base Structures */ = {
 			isa = PBXGroup;
 			children = (
-				77C1CB291B3353D400E9DB99 /* DetachedStreamOperation.swift */,
 				772BF2131B0E5305008FB89D /* Box.swift */,
+				77C1CB291B3353D400E9DB99 /* DetachedStreamOperation.swift */,
+				778D53341B3D96E900441A98 /* ListCursor.swift */,
 				77503E951B2F1BC900C47229 /* Removable.swift */,
 				772D99961B0E61BF00679572 /* Result.swift */,
 				77503E931B2F1A8200C47229 /* Stream.swift */,
 				77567B711AC9F87300877A7B /* OEXRemovable.h */,
 			);
-			name = "Base Containers";
+			name = "Base Structures";
 			sourceTree = "<group>";
 		};
 		77ADF4A01AC1AD3500AC8955 /* XIB/Storyboard */ = {
@@ -2272,7 +2279,7 @@
 			isa = PBXGroup;
 			children = (
 				9EAFFA211B2F00B600B100AB /* Utils */,
-				77864DDA1B10057600182FC2 /* Base Containers */,
+				77864DDA1B10057600182FC2 /* Base Structures */,
 				7772BE781AF40A730081CA7A /* Controller Helpers */,
 				772619B41ADC5CE8005BD7E4 /* Application */,
 				77D76BFE1AA5077600C51C2C /* Localization */,
@@ -2319,24 +2326,24 @@
 		BECB7B331924C0C3009C77F1 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				77691F951B389B62003922F2 /* NSNotificationCenter+SafeSwiftTests.swift */,
-				77AB8C841B345F6400AB3FC0 /* NSString+OEXCryptoTests.swift */,
-				77AB8C821B33C2A300AB3FC0 /* PersistentResponseCacheTests.swift */,
-				77503E971B2F53C300C47229 /* StreamTests.swift */,
 				7772BE8B1AF8389F0081CA7A /* Array+FunctionalTests.swift */,
 				775DF4141AFAA36100F96B2F /* CourseContentPageViewControllerTests.swift */,
 				46CECC431B055B0F0073C63A /* CourseDashboardViewControllerTests.swift */,
-				77F76A711B0CDF0800ED3E39 /* CourseOutlineViewControllerTests.swift */,
+				77691FB11B3C824E003922F2 /* CourseOutlineQuerierTests.swift */,
+				77691FAE1B3C81E4003922F2 /* CourseOutlineViewControllerTests.swift */,
 				9E9AA36B1B3174E300CD7D44 /* CourseLastAccessedTests.swift */,
 				775EB3A91B1FBF58009526A8 /* DownloadProgressViewTests.swift */,
 				77503E8F1B2882C800C47229 /* KeyboardInsetsSourceTests.swift */,
+				778D53361B3D97CC00441A98 /* ListCursorTests.swift */,
 				77864DD41B0FF12800182FC2 /* NetworkManagerTests.swift */,
-				77567B781ACA00F900877A7B /* NSNotificationCenter+OEXSafeAccessTests.m */,
-				77567B731AC9F8ED00877A7B /* NSObject+OEXDeallocActionTests.m */,
 				770A27971A6F12B200DFC6FF /* NSArray+OEXFunctionalTests.m */,
+				77567B781ACA00F900877A7B /* NSNotificationCenter+OEXSafeAccessTests.m */,
+				77691F951B389B62003922F2 /* NSNotificationCenter+SafeSwiftTests.swift */,
+				77567B731AC9F8ED00877A7B /* NSObject+OEXDeallocActionTests.m */,
 				77FFA2C21AC30C1500B4D69B /* NSAttributedString+OEXFormattingTests.m */,
 				77000A4B1A775904007D306C /* NSDate+OEXComparisonsTests.m */,
 				770A27A91A70261F00DFC6FF /* NSObject+OEXReplaceNullTests.m */,
+				77AB8C841B345F6400AB3FC0 /* NSString+OEXCryptoTests.swift */,
 				77EC889F1AB878880050F9CF /* NSString+OEXFormattingTests.m */,
 				77000A381A76EFF2007D306C /* NSString+OEXValidationTests.m */,
 				776907231AD6E7E400F5E7EB /* OEXApplicationTests.m */,
@@ -2355,6 +2362,7 @@
 				194E018F1A54204A00A0CFAE /* OEXDBTests.m */,
 				770A27AB1A702B6500DFC6FF /* OEXDataParserTests.m */,
 				77000A461A77555B007D306C /* OEXDateFormattingTests.m */,
+				9E35A2831B32D7090040B9A9 /* OEXDateFormattingTests.swift */,
 				194E01901A54204A00A0CFAE /* OEXFormEncodingTests.m */,
 				7778F0921ABA1F8000B4CDA0 /* OEXStatusMessageViewControllerTests.m */,
 				77A340201AB2461800C8E141 /* OEXRegistrationViewControllerTests.m */,
@@ -2364,6 +2372,8 @@
 				774B9C101B0B9CD0000B1069 /* OfflineModeControllerTests.swift */,
 				77BECB071B0A771700894276 /* OfflineModeViewTests.swift */,
 				77691FA91B3C7470003922F2 /* OpenOnWebControllerTests.swift */,
+				77AB8C821B33C2A300AB3FC0 /* PersistentResponseCacheTests.swift */,
+				77503E971B2F53C300C47229 /* StreamTests.swift */,
 				7772BE811AF822500081CA7A /* UIBarButtonItem+OEXBlockActionsTests.m */,
 				77E2097E1AF032CC0071316D /* UIControl+OEXBlockActionsTests.m */,
 				77BECB091B0A8AD800894276 /* UIEdgeInsets+GeometryTests.swift */,
@@ -2372,7 +2382,6 @@
 				7772BE901AF90C8A0081CA7A /* Helpers */,
 				77567B501AC5EC0400877A7B /* Test Doubles */,
 				BECB7B341924C0C3009C77F1 /* Supporting Files */,
-				9E35A2831B32D7090040B9A9 /* OEXDateFormattingTests.swift */,
 			);
 			name = Tests;
 			path = Test;
@@ -2821,6 +2830,7 @@
 				1927486719B5AB9E00196B8F /* OEXTranscriptsData.m in Sources */,
 				770A3D451AF0167A008F09D9 /* UIControl+OEXBlockActions.m in Sources */,
 				770848C41B21334F002FEEEE /* OEXMathUtilities.m in Sources */,
+				778D53351B3D96E900441A98 /* ListCursor.swift in Sources */,
 				B498405919753C6C00019D1F /* CLVideoPlayer.m in Sources */,
 				B4B6D62A1A949F1B000F44E8 /* OEXRegistrationFieldSelectController.m in Sources */,
 				B4B6D5E51A9490E9000F44E8 /* OEXLoginSplashViewController.m in Sources */,
@@ -3109,6 +3119,7 @@
 				77691FAD1B3C764F003922F2 /* UIBarButtonItem+Touchable.swift in Sources */,
 				77D7FD281B04FEC8002ACA8C /* SnapshotTestCase.swift in Sources */,
 				7754348C1AD83E4600635A40 /* OEXPushNotificationManagerTests.m in Sources */,
+				778D53371B3D97CC00441A98 /* ListCursorTests.swift in Sources */,
 				77567B4C1AC5E8EC00877A7B /* OEXAnalyticsTests.m in Sources */,
 				7778F0951ABA2C3600B4CDA0 /* OEXRegistrationFieldEmailViewTests.m in Sources */,
 				774B9C121B0B9D18000B1069 /* MockReachability.swift in Sources */,
@@ -3117,10 +3128,11 @@
 				77567B791ACA00F900877A7B /* NSNotificationCenter+OEXSafeAccessTests.m in Sources */,
 				9E9AA36C1B3174E300CD7D44 /* CourseLastAccessedTests.swift in Sources */,
 				77000A4C1A775904007D306C /* NSDate+OEXComparisonsTests.m in Sources */,
-				77F76A721B0CDF0800ED3E39 /* CourseOutlineViewControllerTests.swift in Sources */,
 				770848BF1B20D5F9002FEEEE /* TestEnvironmentBuilder.swift in Sources */,
 				77567B4F1AC5EBFE00877A7B /* OEXMockAnalyticsTracker.m in Sources */,
 				77503E901B2882C800C47229 /* KeyboardInsetsSourceTests.swift in Sources */,
+				77691FB21B3C824E003922F2 /* CourseOutlineQuerierTests.swift in Sources */,
+				77691FB01B3C820B003922F2 /* CourseOutlineViewControllerTests.swift in Sources */,
 				770A27A71A700E1600DFC6FF /* OEXVideoSummary+OEXTestDataFactory.m in Sources */,
 				77F76A741B0CE01E00ED3E39 /* MockCourseDataManager.swift in Sources */,
 				776907241AD6E7E400F5E7EB /* OEXApplicationTests.m in Sources */,


### PR DESCRIPTION
- Add tests for CourseOutlineQuerier.
- Modify CourseOutlineQuerier to group the block itself with its fully loaded
children and update users as appropriate. This will simplify traversing
between groups (like sections and subsections).
- Add cursor type for imperatively walking a list. If this ends up
  having performance problems, the abstraction will easily let us
  replace it with a memoized generator.
- Add utilities to CourseOutlineQuerier for horizontally walking the
  tree at a given depth. This will be used iterate between units.

TODO: Update the UI to walk across the tree so we can go between units.

JIRA: https://openedx.atlassian.net/browse/MA-839