### PR TITLE
iOS - Assessment - My videos - Recent videos - Pressing edit button the video titles weirdly shift over

### DIFF
--- a/Source/OEXMyVideosViewController.m
+++ b/Source/OEXMyVideosViewController.m
@@ -570,12 +570,14 @@ typedef  enum OEXAlertType
         if(self.isTableEditing) {
             // Unhide the checkbox and set the tag
             cell.btn_CheckboxDelete.hidden = NO;
-            cell.btn_CheckboxDelete.alpha = 0;
-            cell.courseVideoStateLeadingConstraint.constant = 60;
-            [UIView animateWithDuration:0.2 animations:^{
-                [self.view layoutIfNeeded];
-                cell.btn_CheckboxDelete.alpha = 1;
-            }];
+            if ([self isRTL]) {
+                cell.btn_CheckboxDelete.alpha = 0;
+                cell.courseVideoStateLeadingConstraint.constant = 60;
+                [UIView animateWithDuration:0.2 animations:^{
+                    [self.view layoutIfNeeded];
+                    cell.btn_CheckboxDelete.alpha = 1;
+                }];
+            }
             cell.btn_CheckboxDelete.tag = (indexPath.section * 100) + indexPath.row;
             [cell.btn_CheckboxDelete addTarget:self action:@selector(selectCheckbox:) forControlEvents:UIControlEventTouchUpInside];
 
@@ -589,14 +591,19 @@ typedef  enum OEXAlertType
             }
         }
         else {
-            cell.courseVideoStateLeadingConstraint.constant = 20;
-            [UIView animateWithDuration:0.2 animations:^{
-                [self.view layoutIfNeeded];
-                cell.btn_CheckboxDelete.alpha = 0;
-            } completion:^(BOOL finished) {
+            if ([self isRTL]) {
+                cell.courseVideoStateLeadingConstraint.constant = 20;
+                [UIView animateWithDuration:0.2 animations:^{
+                    [self.view layoutIfNeeded];
+                    cell.btn_CheckboxDelete.alpha = 0;
+                } completion:^(BOOL finished) {
+                    cell.btn_CheckboxDelete.hidden = YES;
+                }];
+                
+            }
+            else {
                 cell.btn_CheckboxDelete.hidden = YES;
-            }];
-            
+            }
             if(self.currentTappedVideo == obj_video && !self.isTableEditing) {
                 [self setSelectedCellAtIndexPath:indexPath tableView:tableView];
                 _selectedIndexPath = indexPath;


### PR DESCRIPTION
Bug Fixed. 

This shifting was done to cater for the overlapping in the case of RTL layout.

#### LTR
![ios simulator screen shot 01-jul-2015 12 16 38 pm](https://cloud.githubusercontent.com/assets/10597112/8449502/643da148-1feb-11e5-9e51-be976a53cf5c.png)

#### RTL
![ios simulator screen shot 01-jul-2015 12 16 05 pm](https://cloud.githubusercontent.com/assets/10597112/8449510/6d65a1e4-1feb-11e5-8372-046b8fc10d79.png)

