### PR TITLE
iOS - Assessment - Download Video - Back arrow is missing in video downloading screen

### DIFF
--- a/Source/OEXDownloadViewController.m
+++ b/Source/OEXDownloadViewController.m
@@ -17,6 +17,7 @@
 #import "OEXInterface.h"
 #import "OEXNetworkConstants.h"
 #import "OEXRouter.h"
+#import "OEXStyles.h"
 #import "OEXVideoSummary.h"
 #import "Reachability.h"
 #import "SWRevealViewController.h"
@@ -52,6 +53,24 @@
     [super viewWillDisappear:animated];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:DOWNLOAD_PROGRESS_NOTIFICATION object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:OEXDownloadEndedNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:kReachabilityChangedNotification object:nil];
+    [self.navigationController setNavigationBarHidden:NO animated:animated];
+
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.navigationController setNavigationBarHidden:YES animated:animated];
+    // Add Observer
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reachabilityDidChange:) name:kReachabilityChangedNotification object:nil];
+
+    // Check Reachability for OFFLINE
+    if(_edxInterface.reachable) {
+        [self HideOfflineLabel:YES];
+    }
+    else {
+        [self HideOfflineLabel:NO];
+    }   // Add Open In Browser to the view and adjust the table accordingly
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -61,9 +80,12 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-
+    
     [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
-
+    
+    [[OEXStyles sharedStyles] applyMockNavigationBarStyleToView:self.customNavView label:self.customNavView.lbl_TitleView leftIconButton:self.customNavView.btn_Back];
+    [[OEXStyles sharedStyles] applyMockBackButtonStyleToButton:self.customNavView.btn_Back];
+    
     // Do any additional setup after loading the view.
 #ifdef __IPHONE_8_0
     if(IS_IOS8) {

--- a/Source/OEXDownloadViewController.m
+++ b/Source/OEXDownloadViewController.m
@@ -285,4 +285,16 @@
     }
 }
 
+- (void)dealloc {
+}
+- (void)didReceiveMemoryWarning {
+    ELog(@"MemoryWarning DownloadViewController");
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return [OEXStyles sharedStyles].standardStatusBarStyle;
+}
+
 @end

--- a/Source/OEXDownloadViewController.m
+++ b/Source/OEXDownloadViewController.m
@@ -53,24 +53,6 @@
     [super viewWillDisappear:animated];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:DOWNLOAD_PROGRESS_NOTIFICATION object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:OEXDownloadEndedNotification object:nil];
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:kReachabilityChangedNotification object:nil];
-    [self.navigationController setNavigationBarHidden:NO animated:animated];
-
-}
-
-- (void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
-    [self.navigationController setNavigationBarHidden:YES animated:animated];
-    // Add Observer
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reachabilityDidChange:) name:kReachabilityChangedNotification object:nil];
-
-    // Check Reachability for OFFLINE
-    if(_edxInterface.reachable) {
-        [self HideOfflineLabel:YES];
-    }
-    else {
-        [self HideOfflineLabel:NO];
-    }   // Add Open In Browser to the view and adjust the table accordingly
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -82,9 +64,6 @@
     [super viewDidLoad];
     
     [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
-    
-    [[OEXStyles sharedStyles] applyMockNavigationBarStyleToView:self.customNavView label:self.customNavView.lbl_TitleView leftIconButton:self.customNavView.btn_Back];
-    [[OEXStyles sharedStyles] applyMockBackButtonStyleToButton:self.customNavView.btn_Back];
     
     // Do any additional setup after loading the view.
 #ifdef __IPHONE_8_0


### PR DESCRIPTION
Fixed.

![ios simulator screen shot 01-jul-2015 3 19 39 pm](https://cloud.githubusercontent.com/assets/10597112/8452437/9e17e0e0-2004-11e5-9518-56d94d87826e.png)
