### PR TITLE
Fix issue with stale data when logging out/in as a different user

### DIFF
--- a/Source/CourseDataManager.swift
+++ b/Source/CourseDataManager.swift
@@ -11,16 +11,23 @@ import UIKit
 private let CourseOutlineModeChangedNotification = "CourseOutlineModeChangedNotification"
 private let CurrentCourseOutlineModeKey = "OEXCurrentCourseOutlineMode"
 
+private let DefaultCourseMode = CourseOutlineMode.Video
+
 public class CourseDataManager: NSObject, CourseOutlineModeControllerDataSource {
     
     private let interface : OEXInterface?
     private let networkManager : NetworkManager?
     
-    private let DefaultCourseMode = CourseOutlineMode.Video
-    
     public init(interface : OEXInterface?, networkManager : NetworkManager?) {
         self.interface = interface
         self.networkManager = networkManager
+        
+        super.init()
+        
+        NSNotificationCenter.defaultCenter().oex_addObserver(self, name: OEXSessionEndedNotification) { (_, observer, _) -> Void in
+            observer.queriers = [:]
+            NSUserDefaults.standardUserDefaults().setObject(DefaultCourseMode.rawValue, forKey: CurrentCourseOutlineModeKey)
+        }
     }
     
     private var queriers : [String:CourseOutlineQuerier] = [:]

--- a/Source/DataManager.swift
+++ b/Source/DataManager.swift
@@ -18,4 +18,6 @@ public class DataManager : NSObject {
         self.pushSettings = pushSettings
         self.interface = interface
     }
+    
+    
 }

--- a/Source/OEXRemovable.h
+++ b/Source/OEXRemovable.h
@@ -8,9 +8,19 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 // This protocol should be avoided in Swift code. See plain "Removable"
 @protocol OEXRemovable <NSObject>
 
 - (void)remove;
 
 @end
+
+@interface OEXBlockRemovable : NSObject <OEXRemovable>
+
+- (id)initWithRemovalAction:(nullable void (^)(void))action;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/OEXRemovable.m
+++ b/Source/OEXRemovable.m
@@ -1,0 +1,36 @@
+//
+//  OEXRemovable.m
+//  edXVideoLocker
+//
+//  Created by Akiva Leffert on 3/30/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "OEXRemovable.h"
+
+@interface OEXBlockRemovable ()
+
+@property (copy, nonatomic) void (^action)(void);
+
+@end
+
+@implementation OEXBlockRemovable
+
+- (id)initWithRemovalAction:(void (^)(void))action {
+    self = [super init];
+    if(self != nil) {
+        self.action = action;
+    }
+    return self;
+}
+
+- (void)remove {
+    if(self.action != nil) {
+        self.action();
+    }
+    self.action = nil;
+}
+
+@end

--- a/Source/Stream.swift
+++ b/Source/Stream.swift
@@ -129,11 +129,19 @@ public class Stream<A> {
     /// :param: success The action to fire when the stream receives a Success result.
     /// :param: success The action to fire when the stream receives a Failure result.
     public func listenOnce(owner : NSObject, fireIfAlreadyLoaded : Bool = true, success : A -> Void, failure : NSError -> Void) -> Removable {
-        let removable = listen(owner, fireIfAlreadyLoaded: fireIfAlreadyLoaded, success: success, failure: failure)
+
+        return listenOnce(owner, fireIfAlreadyLoaded: fireIfAlreadyLoaded, action : {
+            switch $0 {
+            case let .Success(box): success(box.value)
+            case let .Failure(error): failure(error)
+            }
+        })
+    }
+    
+    public func listenOnce(owner : NSObject, fireIfAlreadyLoaded : Bool = true, action : Result<A> -> Void) -> Removable {
+        let removable = listen(owner, fireIfAlreadyLoaded: fireIfAlreadyLoaded, action : action)
         let followup = listen(owner, fireIfAlreadyLoaded: fireIfAlreadyLoaded,
-            success: {_ in
-                removable.remove()
-            }, failure: {_ in
+            action: {_ in
                 removable.remove()
             }
         )

--- a/Test/CourseDataManagerTests.swift
+++ b/Test/CourseDataManagerTests.swift
@@ -1,0 +1,74 @@
+//
+//  CourseDataManagerTests.swift
+//  edX
+//
+//  Created by Akiva Leffert on 7/2/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+import edX
+import UIKit
+import XCTest
+
+class CourseDataManagerTests: XCTestCase {
+    
+    let networkManager = MockNetworkManager(authorizationHeaderProvider: nil, baseURL: NSURL(string : "http://example.com")!)
+    let outline = CourseOutlineTestDataFactory.freshCourseOutline(OEXCourse.freshCourse().course_id!)
+    
+    override func tearDown() {
+        networkManager.reset()
+    }
+    
+    func checkOutlineLoadsWithQuerier(querier : CourseOutlineQuerier, rootID : CourseBlockID, line : UInt = __LINE__, file : String = __FILE__) {
+        let rootStream = querier.blockWithID(nil)
+        let expectation = self.expectationWithDescription("Outline loads from network")
+        rootStream.listenOnce(self) {rootBlock in
+            XCTAssertEqual(rootBlock.value!.blockID, rootID, file : file, line : line)
+            expectation.fulfill()
+        }
+        waitForExpectations()
+    }
+    
+    func addInterceptorForOutline(outline : CourseOutline) {
+        networkManager.interceptWhenMatching({_ in true}, successResponse: {
+            return (NSData(), outline)
+        })
+    }
+    
+    func loadAndVerifyOutline() -> CourseDataManager {
+        let manager = CourseDataManager(interface: nil, networkManager: networkManager)
+        addInterceptorForOutline(outline)
+        var querier = manager.querierForCourseWithID(outline.root)
+        checkOutlineLoadsWithQuerier(querier, rootID: outline.root)
+        return manager
+    }
+    
+    func testQuerierCaches() {
+        let manager = loadAndVerifyOutline()
+
+        // Now remove network interception
+        networkManager.reset()
+        
+        // The course should still load since the querier saves it
+        let querier = manager.querierForCourseWithID(outline.root)
+        checkOutlineLoadsWithQuerier(querier, rootID: outline.root)
+    }
+    
+    func testQuerierClearedOnSignOut() {
+        let manager = loadAndVerifyOutline()
+        let defaultsMockRemover = OEXMockUserDefaults().installAsStandardUserDefaults()
+        
+        let session = OEXSession(credentialStore: OEXMockCredentialStorage())
+        // Close session so the course data should be cleared
+        session.closeAndClearSession()
+        networkManager.reset()
+        
+        let querier = manager.querierForCourseWithID(outline.root)
+        let newOutline = CourseOutlineTestDataFactory.freshCourseOutline(OEXCourse.freshCourse().course_id!)
+        addInterceptorForOutline(newOutline)
+        checkOutlineLoadsWithQuerier(querier, rootID: newOutline.root)
+        XCTAssertNotEqual(newOutline.root, outline.root, "Fresh Courses should be distinct")
+        
+        defaultsMockRemover.remove()
+    }
+}

--- a/Test/CourseOutlineQuerierTests.swift
+++ b/Test/CourseOutlineQuerierTests.swift
@@ -18,7 +18,7 @@ class CourseOutlineQuerierTests: XCTestCase {
         let outline = CourseOutlineTestDataFactory.freshCourseOutline(courseID)
         let networkManager = MockNetworkManager(authorizationHeaderProvider: nil, baseURL: NSURL(string : "http://www.example.com")!)
         let request = CourseOutlineAPI.requestWithCourseID(courseID)
-        networkManager.addMatcher({_ in return true}, successResponse: {
+        networkManager.interceptWhenMatching({_ in true}, successResponse: {
             return (nil, outline)
         })
         let querier = CourseOutlineQuerier(courseID: "course", interface: nil, networkManager: networkManager)

--- a/Test/CourseOutlineTestDataFactory.swift
+++ b/Test/CourseOutlineTestDataFactory.swift
@@ -17,7 +17,7 @@ public class CourseOutlineTestDataFactory {
         return CourseOutline(
             root : courseID,
             blocks : [
-                courseID: CourseBlock(type: CourseBlockType.Course, children : ["chapter1", "chapter2", "chapter3", "chapter4"], blockID : "course", name : "A Course", blockCounts : ["video" : 1]),
+                courseID: CourseBlock(type: CourseBlockType.Course, children : ["chapter1", "chapter2", "chapter3", "chapter4"], blockID : courseID, name : "A Course", blockCounts : ["video" : 1]),
                 "chapter1": CourseBlock(type: CourseBlockType.Chapter, children : ["section1.1", "section1.2"], blockID : "chapter1", name : "Chapter 1", blockCounts : ["video" : 1]),
                 "chapter2": CourseBlock(type: CourseBlockType.Chapter, children : ["section2.1", "section2.2"], blockID : "chapter2", name : "Chapter 2"),
                 "chapter3": CourseBlock(type: CourseBlockType.Chapter, children : ["section3.1"], blockID : "chapter3", name : "Chapter 3"),

--- a/Test/NetworkManagerTests.swift
+++ b/Test/NetworkManagerTests.swift
@@ -108,9 +108,9 @@ class NetworkManagerTests: XCTestCase {
         
         // make a request
         let networkData = "network".dataUsingEncoding(NSUTF8StringEncoding)!
-        manager.addMatcher({_ -> Bool in return true },
-            delay : 0.1,
-            response: {_ in
+        manager.interceptWhenMatching({_ -> Bool in return true },
+            afterDelay : 0.1,
+            withResponse: {_ in
             return NetworkResult(request: URLRequest, response: response, data: networkData, baseData: networkData, error: nil)
             }
         )
@@ -138,8 +138,8 @@ class NetworkManagerTests: XCTestCase {
         // Test that the cache doesn't get an entry when the underlying request fails (e.g. network failure, not a 404
         
         let (manager, request, URLRequest) = requestEnvironment()
-        manager.addMatcher({_ -> Bool in return true },
-            response: {_ in
+        manager.interceptWhenMatching({_ -> Bool in return true },
+            withResponse: {_ in
                 return NetworkResult<NSData>(request: URLRequest, response: nil, data: nil, baseData: nil, error: NSError.oex_unknownError())
             }
         )
@@ -163,8 +163,8 @@ class NetworkManagerTests: XCTestCase {
         let testData = "testData".dataUsingEncoding(NSUTF8StringEncoding)
         let headers = ["a" : "b"]
         let response = NSHTTPURLResponse(URL: URLRequest.URL!, statusCode: 404, HTTPVersion: nil, headerFields: headers)!
-        manager.addMatcher({_ -> Bool in return true },
-            response: {_ in
+        manager.interceptWhenMatching({_ -> Bool in return true },
+            withResponse: {_ in
                 return NetworkResult<NSData>(request: URLRequest, response: response, data: testData, baseData: testData, error: NSError.oex_unknownError())
             }
         )

--- a/Test/OEXMockUserDefaults.h
+++ b/Test/OEXMockUserDefaults.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
+@protocol OEXRemovable;
 
 // Simplified version of NSUserDefaults for testing that does not persist its data
 @interface OEXMockUserDefaults : NSObject
@@ -25,5 +26,9 @@
 - (void)removeObjectForKey:(NSString*)key;
 
 - (void)synchronize;
+
+/// Globally replace [NSUserDefaults standardUserDefaults] with this mock. Make sure to remove it
+/// when your test is done.
+- (id <OEXRemovable>)installAsStandardUserDefaults;
 
 @end

--- a/Test/OEXMockUserDefaults.m
+++ b/Test/OEXMockUserDefaults.m
@@ -8,6 +8,9 @@
 
 #import "OEXMockUserDefaults.h"
 
+#import <OCMock/OCMock.h>
+#import "OEXRemovable.h"
+
 @interface OEXMockUserDefaults ()
 
 @property (strong, nonatomic) NSMutableDictionary* store;
@@ -54,6 +57,16 @@
 
 - (void)synchronize {
     // We don't write to disk so do nothing
+}
+
+- (id <OEXRemovable>)installAsStandardUserDefaults {
+    OCMockObject* defaultsClassMock = OCMStrictClassMock([NSUserDefaults class]);
+    id defaultsStub = [defaultsClassMock stub];
+    [defaultsStub standardUserDefaults];
+    [defaultsStub andReturn:self];
+    return [[OEXBlockRemovable alloc] initWithRemovalAction:^{
+        [defaultsClassMock stopMocking];
+    }];
 }
 
 @end

--- a/Test/OEXParsePushProviderTests.m
+++ b/Test/OEXParsePushProviderTests.m
@@ -18,6 +18,7 @@
 #import "OEXMockUserDefaults.h"
 #import "OEXPushSettingsManager.h"
 #import "OEXParsePushProvider.h"
+#import "OEXRemovable.h"
 #import "OEXUserDetails+OEXTestDataFactory.h"
 
 @interface OEXMockPFInstallation : NSObject
@@ -59,7 +60,7 @@
 @interface OEXParsePushProviderTests : XCTestCase
 
 @property (strong, nonatomic) OEXMockPFInstallation* installation;
-@property (strong, nonatomic) OCMockObject* defaultsClassMock;
+@property (strong, nonatomic) id <OEXRemovable> defaultsMockRemover;
 @property (strong, nonatomic) OCMockObject* installationClassMock;
 @property (strong, nonatomic) OEXParsePushProvider* provider;
 
@@ -75,17 +76,14 @@
     [installationStub andReturn:self.installation];
     
     OEXMockUserDefaults* defaults = [[OEXMockUserDefaults alloc] init];
-    OCMockObject* defaultsClassMock = OCMStrictClassMock([NSUserDefaults class]);
-    id defaultsStub = [defaultsClassMock stub];
-    [defaultsStub standardUserDefaults];
-    [defaultsStub andReturn:defaults];
+    self.defaultsMockRemover = [defaults installAsStandardUserDefaults];
     
     self.provider = [[OEXParsePushProvider alloc] init];
 }
 
 - (void)tearDown {
+    [self.defaultsMockRemover remove];
     [self.installationClassMock stopMocking];
-    [self.defaultsClassMock stopMocking];
     self.provider = nil;
 }
 

--- a/Test/OEXSessionTests.m
+++ b/Test/OEXSessionTests.m
@@ -38,7 +38,7 @@
 @property (strong, nonatomic) OEXMockCredentialStorage* credentialStore;
 @property (strong, nonatomic) id cacheClassMock;
 
-@property (strong, nonatomic) OCMockObject* defaultsClassMock;
+@property (strong, nonatomic) id <OEXRemovable> defaultsMockRemover;
 @property (strong, nonatomic) OEXMockUserDefaults* mockUserDefaults;
 
 @property (strong, nonatomic) OEXMockURLCache* mockURLCache;
@@ -52,11 +52,7 @@
     self.credentialStore = [[OEXMockCredentialStorage alloc] init];
     
     self.mockUserDefaults = [[OEXMockUserDefaults alloc] init];
-    self.defaultsClassMock = OCMStrictClassMock([NSUserDefaults class]);
-    
-    id defaultsStub = [self.defaultsClassMock stub];
-    [defaultsStub standardUserDefaults];
-    [defaultsStub andReturn:self.mockUserDefaults];
+    self.defaultsMockRemover = [self.mockUserDefaults installAsStandardUserDefaults];
     
     self.cacheClassMock = OCMStrictClassMock([NSURLCache class]);
     self.mockURLCache = [[OEXMockURLCache alloc] init];
@@ -69,7 +65,7 @@
 - (void)tearDown {
     [super tearDown];
     [self.cacheClassMock stopMocking];
-    [self.defaultsClassMock stopMocking];
+    [self.defaultsMockRemover remove];
 }
 
 - (void)testLoadCredentialsFromStorage {

--- a/Test/edXTests-Bridging-Header.h
+++ b/Test/edXTests-Bridging-Header.h
@@ -8,4 +8,5 @@
 
 #import "OEXCourse+OEXTestDataFactory.h"
 #import "OEXMockCredentialStorage.h"
+#import "OEXMockUserDefaults.h"
 #import "OEXUserDetails+OEXTestDataFactory.h"

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -158,6 +158,8 @@
 		7713DFCA1AC45542005A1756 /* icon_facebook_white@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7713DFC81AC45542005A1756 /* icon_facebook_white@2x.png */; };
 		7713DFCB1AC45542005A1756 /* icon_google_white@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 7713DFC91AC45542005A1756 /* icon_google_white@2x.png */; };
 		7714A2601AB37CF7004C2254 /* OEXRegistrationFieldError.m in Sources */ = {isa = PBXBuildFile; fileRef = 7714A25F1AB37CF7004C2254 /* OEXRegistrationFieldError.m */; };
+		771FA0161B4588D80067F22D /* CourseDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771FA0151B4588D80067F22D /* CourseDataManagerTests.swift */; };
+		771FA0181B458C7C0067F22D /* OEXRemovable.m in Sources */ = {isa = PBXBuildFile; fileRef = 771FA0171B458C7C0067F22D /* OEXRemovable.m */; };
 		772619B71ADDA8ED005BD7E4 /* OEXPushSettingsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 772619B61ADDA8ED005BD7E4 /* OEXPushSettingsManager.m */; };
 		772619BA1ADDC68E005BD7E4 /* OEXMockUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 772619B91ADDC68E005BD7E4 /* OEXMockUserDefaults.m */; };
 		7726BD1D1A36572F003B3354 /* NSMutableDictionary+OEXSafeAccess.m in Sources */ = {isa = PBXBuildFile; fileRef = 7726BD1C1A36572F003B3354 /* NSMutableDictionary+OEXSafeAccess.m */; };
@@ -713,6 +715,8 @@
 		771772CA1ADC4032001A5AC6 /* Pods-edXTests.coverage.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "Pods-edXTests.coverage.xcconfig"; path = "Pods/Target Support Files/Pods-edXTests/Pods-edXTests.coverage.xcconfig"; sourceTree = "<group>"; };
 		771772CB1ADC4032001A5AC6 /* Pods-edXTests.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "Pods-edXTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-edXTests/Pods-edXTests.debug.xcconfig"; sourceTree = "<group>"; };
 		771772CC1ADC4032001A5AC6 /* Pods-edXTests.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "Pods-edXTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-edXTests/Pods-edXTests.release.xcconfig"; sourceTree = "<group>"; };
+		771FA0151B4588D80067F22D /* CourseDataManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseDataManagerTests.swift; sourceTree = "<group>"; };
+		771FA0171B458C7C0067F22D /* OEXRemovable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXRemovable.m; sourceTree = "<group>"; };
 		772619B51ADDA8ED005BD7E4 /* OEXPushSettingsManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXPushSettingsManager.h; sourceTree = "<group>"; };
 		772619B61ADDA8ED005BD7E4 /* OEXPushSettingsManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXPushSettingsManager.m; sourceTree = "<group>"; };
 		772619B81ADDC68E005BD7E4 /* OEXMockUserDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXMockUserDefaults.h; sourceTree = "<group>"; };
@@ -1766,6 +1770,7 @@
 				772D99961B0E61BF00679572 /* Result.swift */,
 				77503E931B2F1A8200C47229 /* Stream.swift */,
 				77567B711AC9F87300877A7B /* OEXRemovable.h */,
+				771FA0171B458C7C0067F22D /* OEXRemovable.m */,
 			);
 			name = "Base Structures";
 			sourceTree = "<group>";
@@ -2340,6 +2345,7 @@
 		BECB7B331924C0C3009C77F1 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				771FA0151B4588D80067F22D /* CourseDataManagerTests.swift */,
 				7772BE8B1AF8389F0081CA7A /* Array+FunctionalTests.swift */,
 				775DF4141AFAA36100F96B2F /* CourseContentPageViewControllerTests.swift */,
 				46CECC431B055B0F0073C63A /* CourseDashboardViewControllerTests.swift */,
@@ -2938,6 +2944,7 @@
 				8FE04B4D1A1E2637007F88B8 /* OEXFBSocial.m in Sources */,
 				9EDB10B41B0C732300C760C6 /* CourseGenericBlockTableViewCell.swift in Sources */,
 				B4D5C7EC1A6FBAA300427D1D /* OEXPersistentCredentialStorage.m in Sources */,
+				771FA0181B458C7C0067F22D /* OEXRemovable.m in Sources */,
 				7713DFBF1AC3C16C005A1756 /* OEXRegisteringUserDetails.m in Sources */,
 				77FDF40F1AFBAE7700E8C639 /* OEXRouter+Swift.swift in Sources */,
 				77056C3E1B3F320800D9DB4A /* DetailToolbarButton.swift in Sources */,
@@ -3107,6 +3114,7 @@
 				B4B6D6441A95335C000F44E8 /* OEXRegistrationAgreementController.m in Sources */,
 				773B1D491B1F818300B861DF /* XCTestCase+Timeouts.swift in Sources */,
 				775434971AD8635200635A40 /* OEXUserDetails+OEXTestDataFactory.m in Sources */,
+				771FA0161B4588D80067F22D /* CourseDataManagerTests.swift in Sources */,
 				770A27AA1A70261F00DFC6FF /* NSObject+OEXReplaceNullTests.m in Sources */,
 				77864DD51B0FF12800182FC2 /* NetworkManagerTests.swift in Sources */,
 				77000A471A77555B007D306C /* OEXDateFormattingTests.m in Sources */,


### PR DESCRIPTION
We weren't clearing the CourseDataManager on log out, so it was
returning stale queriers.