### PR TITLE
Add a way to check whether a stream is live.

### DIFF
--- a/Source/CourseOutlineQuerier.swift
+++ b/Source/CourseOutlineQuerier.swift
@@ -83,7 +83,7 @@ public class CourseOutlineQuerier : NSObject {
     }
     
     private func loadOutlineIfNecessary() {
-        if courseOutline.value == nil && !courseOutline.hasBacking {
+        if courseOutline.value == nil && !courseOutline.active {
             let request = CourseOutlineAPI.requestWithCourseID(courseID)
             if let loader = networkManager?.streamForRequest(request, persistResponse: true) {
                 courseOutline.backWithStream(loader)

--- a/Test/StreamTests.swift
+++ b/Test/StreamTests.swift
@@ -228,7 +228,7 @@ class StreamTests: XCTestCase {
         let sink = Sink<String>()
         
         // Cache has no value so it will never fire
-        let cache = Stream<String>(dependencies: [])
+        let cache = Stream<String>()
         
         let backedStream = sink.cachedByStream(cache)
         sink.send("success")
@@ -267,5 +267,31 @@ class StreamTests: XCTestCase {
         
         sink.send("after")
         XCTAssertEqual(backedStream.value!, "after")
+        
+        cache.close()
+        XCTAssertTrue(backedStream.active)
+        
+        sink.close()
+        XCTAssertFalse(backedStream.active)
+    }
+    
+    func testActiveSink() {
+        let sink = Sink<String>()
+        XCTAssertTrue(sink.active)
+        sink.close()
+        XCTAssertFalse(sink.active)
+    }
+    
+    func testActiveBacked() {
+        let sink = Sink<String>()
+        let backedStream = BackedStream<String>()
+        
+        XCTAssertFalse(backedStream.active)
+        
+        backedStream.backWithStream(sink)
+        XCTAssertTrue(backedStream.active)
+        
+        backedStream.removeBacking()
+        XCTAssertFalse(backedStream.active)
     }
 }


### PR DESCRIPTION
This makes it easier to check if the data can be refreshed or if it
already has a refresh in the pipeline.

For example, a network request will stop being active after the request
is over.