### PR TITLE
iOS - Assessment - Discrepancies in announcement screens

### DIFF
--- a/Source/CourseAnnouncementsViewController.swift
+++ b/Source/CourseAnnouncementsViewController.swift
@@ -118,6 +118,7 @@ class CourseAnnouncementsViewController: UIViewController {
     }
     
     func setStyles() {
+        self.navigationItem.title = OEXLocalizedString("COURSE_ANNOUNCEMENTS", nil)
         notificationBar.backgroundColor = OEXStyles.sharedStyles().standardBackgroundColor()
         switchStyle.applyToSwitch(notificationSwitch)
         notificationLabel.attributedText = fontStyle.attributedStringWithText(OEXLocalizedString("NOTIFICATIONS_ENABLED", nil))

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -211,7 +211,7 @@
 /* Text shown when examining part of a course in video only mode, but that part of the course has no videos. {mode_switcher} will be replaced with a name or icon for the mode switch button */
 "NO_VIDEOS_TRY_MODE_SWITCHER" = "There are no videos in this section. To view other section content, select {mode_switcher} above and switch to full course mode.";
 /* Label of switch that toggles push notification support */
-"NOTIFICATIONS_ENABLED" = "Notifications Enabled";
+"NOTIFICATIONS_ENABLED" = "Allow Notifications";
 /* Label indicating user has on internet connection and is in offline mode */
 "OFFLINE_MODE" = "Offline Mode";
 /* Alert dialog okay button */


### PR DESCRIPTION
Below are the observations/discrepancies in announcement screen:
1- In iOS top header there is no label. However, in android it is showing 'edX'. We should show "Announcements"
2- In iOS course card, Course name and course run is missing. However in android these information appearing. Currently behaves correctly
3- 'Announcement' text under course card is missing in iOS. Currently behaves correctly
4- The text infront of toggle button is 'Notification Enabled' in iOS. However, android is showing only 'Notifications'. We should show "Allow Notifications"

![ios simulator screen shot 09-jul-2015 2 53 55 pm](https://cloud.githubusercontent.com/assets/10597112/8592624/5b8bde4c-264a-11e5-8daa-47c2e96aee1b.png)
