### PR TITLE
Bug Fix : iOS - Assessment - Submit Feedback - Color issue with 'Cancel' and 'Send' buttons

### DIFF
--- a/Source/OEXRearTableViewController.m
+++ b/Source/OEXRearTableViewController.m
@@ -111,13 +111,16 @@ typedef NS_ENUM (NSUInteger, OEXRearViewOptions)
     else {
         MFMailComposeViewController* mailComposer = [[MFMailComposeViewController alloc] init];
         [mailComposer setMailComposeDelegate:self];
+        [mailComposer.navigationBar setTintColor: [[OEXStyles sharedStyles] navigationItemTintColor]];
         [mailComposer setSubject:OEXLocalizedString(@"CUSTOMER_FEEDBACK", nil)];
         [mailComposer setMessageBody:@"" isHTML:NO];
         NSString* feedbackAddress = [OEXConfig sharedConfig].feedbackEmailAddress;
         if(feedbackAddress != nil) {
             [mailComposer setToRecipients:@[feedbackAddress]];
         }
-        [self presentViewController:mailComposer animated:YES completion:nil];
+        [self presentViewController:mailComposer animated:YES completion:^{
+            [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
+        }];
     }
 }
 

--- a/Source/OEXRearTableViewController.m
+++ b/Source/OEXRearTableViewController.m
@@ -118,9 +118,7 @@ typedef NS_ENUM (NSUInteger, OEXRearViewOptions)
         if(feedbackAddress != nil) {
             [mailComposer setToRecipients:@[feedbackAddress]];
         }
-        [self presentViewController:mailComposer animated:YES completion:^{
-            [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
-        }];
+        [self presentViewController:mailComposer animated:YES completion:nil];
     }
 }
 


### PR DESCRIPTION
Fixed. 

Forcing the MailComposeViewController to pick up TintColor