### PR TITLE
iOS - Assessment - "courseware page" link in announcement section navigates user to unknown page

### DIFF
--- a/Source/CourseAnnouncementsViewController.swift
+++ b/Source/CourseAnnouncementsViewController.swift
@@ -28,7 +28,7 @@ class CourseAnnouncementsViewControllerEnvironment : NSObject {
     }
 }
 
-class CourseAnnouncementsViewController: UIViewController {
+class CourseAnnouncementsViewController: UIViewController, UIWebViewDelegate {
     let environment: CourseAnnouncementsViewControllerEnvironment
     let course: OEXCourse
     var announcements: [OEXAnnouncement]
@@ -64,6 +64,8 @@ class CourseAnnouncementsViewController: UIViewController {
             if let owner = self {
                 owner.environment.pushSettingsManager.setPushDisabled(!owner.notificationSwitch.on, forCourseID: owner.course.course_id)
             }}, forEvents: UIControlEvents.ValueChanged)
+        
+        self.webView.delegate = self
     }
     
     override func viewWillAppear(animated: Bool) {
@@ -177,5 +179,17 @@ class CourseAnnouncementsViewController: UIViewController {
         var displayHTML = self.environment.styles.styleHTMLContent(html)
         let baseURL = self.environment.config?.apiHostURL().flatMap { NSURL(string: $0 ) }
         self.webView?.loadHTMLString(displayHTML, baseURL: baseURL)
+    }
+    
+    //MARK: - UIWebViewDeleagte
+    
+    func webView(webView: UIWebView, shouldStartLoadWithRequest request: NSURLRequest, navigationType: UIWebViewNavigationType) -> Bool {
+        if (navigationType != UIWebViewNavigationType.Other) {
+            if let URL = request.URL {
+                UIApplication.sharedApplication().openURL(URL)
+                return false
+            }
+        }
+        return true
     }
 }


### PR DESCRIPTION
A redirect is now done, just like `CourseHandoutsViewController`