### PR TITLE
Replace "This video's transcript is not..." placeholder in portrait video player

### DIFF
--- a/Source/Icon.swift
+++ b/Source/Icon.swift
@@ -34,6 +34,7 @@ public enum Icon {
     case InternetError
     case OpenURL
     case Pinned
+    case Mobile
     case Question
     case ReportFlag
     case Sort
@@ -85,6 +86,8 @@ public enum Icon {
             return .Film
         case .ContentDownload:
             return .ArrowDown
+        case .Mobile:
+            return .Mobile
         case .ReportFlag:
             return .Flag
         case .UpVote:

--- a/Source/VideoBlockViewController.swift
+++ b/Source/VideoBlockViewController.swift
@@ -74,7 +74,7 @@ class VideoBlockViewController : UIViewController, CourseBlockViewController, OE
         videoController.view.setTranslatesAutoresizingMaskIntoConstraints(false)
         videoController.fadeInOnLoad = false
         
-        noTranscriptMessageView = IconMessageView(icon: .Transcript, message: OEXLocalizedString("NO_TRANSCRIPT", nil), styles: self.environment.styles)
+        noTranscriptMessageView = IconMessageView(icon: .Mobile, message: OEXLocalizedString("ROTATE_DEVICE", nil), styles: self.environment.styles)
         contentView!.addSubview(noTranscriptMessageView!)
         
         view.backgroundColor = self.environment.styles?.standardBackgroundColor()

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -282,6 +282,8 @@
 "RESPONSE##{one}"="{count} response";
 /* Discussion response - {count} is a number of responses */
 "RESPONSE##{other}"="{count} responses";
+/* Text shown below the video, in portrait mode */
+"ROTATE_DEVICE"="Rotate your device to view this video in full screen";
 /* Label shown when user attempts to view a course section that hasn't been synced  */
 "SECTION_UNAVAILABLE_OFFLINE"="This section is not available in offline mode.\nIf you've downloaded content for a different section, go to that section to view the content.";
 /* Screen title showing a user's settings */


### PR DESCRIPTION
In the portrait video mode, we currently fill the whitespace with a "This video's transcript is not available yet." image and text.
Until we have a chance to implement the rolling subtitle, I'd suggest we change this to some graphic along with text "Rotate your device to view this video in full screen".
#### Screenshot
![ios simulator screen shot 14-jul-2015 1 52 36 pm](https://cloud.githubusercontent.com/assets/10597112/8669680/017b7dba-2a30-11e5-8882-abcfd6c4f28a.png)
