### PR TITLE
Refactor discussion topics and posts to follow best practices

### DIFF
--- a/Source/Array+Functional.swift
+++ b/Source/Array+Functional.swift
@@ -31,6 +31,17 @@ extension Array {
         })
     }
     
+    /// Performs a map, but skips any items that return nil
+    func mapSkippingNils<U>(@noescape f : T -> U?) -> [U] {
+        var result : [U] = []
+        for v in self {
+            if let t = f(v) {
+                result.append(t)
+            }
+        }
+        return result
+    }
+    
     /// Returns the index of the first object in the array where the given predicate returns true.
     /// Returns nil if no object is found.
     func firstIndexMatching(@noescape predicate : T -> Bool) -> Int? {

--- a/Source/CourseDashboardViewController.swift
+++ b/Source/CourseDashboardViewController.swift
@@ -100,9 +100,9 @@ public class CourseDashboardViewController: UIViewController, UITableViewDataSou
             self?.showCourseware()
         }
         cellItems.append(item)
-        if shouldEnableDiscussions() {
+        if let courseID = course?.course_id where shouldEnableDiscussions() {
             item = CourseDashboardItem(title: OEXLocalizedString("COURSE_DASHBOARD_DISCUSSION", nil), detail: OEXLocalizedString("COURSE_DASHBOARD_DISCUSSION_DETAIL", nil), icon: .Discussions) {[weak self] () -> Void in
-                self?.showDiscussions()
+                self?.showDiscussionsForCourseID(courseID)
             }
             cellItems.append(item)
         }
@@ -160,12 +160,9 @@ public class CourseDashboardViewController: UIViewController, UITableViewDataSou
         }
     }
     
-    func showDiscussions() {
-        if let course = self.course {
-            self.navigationItem.backBarButtonItem = UIBarButtonItem(title: OEXLocalizedString("COURSE", nil), style: .Plain, target: nil, action: nil)
-            
-            self.environment.router?.showDiscussionTopicsForCourse(course, fromController: self)
-        }
+    func showDiscussionsForCourseID(courseID: String) {
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: OEXLocalizedString("COURSE", nil), style: .Plain, target: nil, action: nil)
+        self.environment.router?.showDiscussionTopicsFromController(self, courseID: courseID)
     }
     
     func showHandouts() {

--- a/Source/CourseDataManager.swift
+++ b/Source/CourseDataManager.swift
@@ -17,6 +17,8 @@ public class CourseDataManager: NSObject, CourseOutlineModeControllerDataSource 
     
     private let interface : OEXInterface?
     private let networkManager : NetworkManager?
+    private var outlineQueriers : [String:CourseOutlineQuerier] = [:]
+    private var discussionTopicManagers : [String:DiscussionTopicsManager] = [:]
     
     public init(interface : OEXInterface?, networkManager : NetworkManager?) {
         self.interface = interface
@@ -25,21 +27,31 @@ public class CourseDataManager: NSObject, CourseOutlineModeControllerDataSource 
         super.init()
         
         NSNotificationCenter.defaultCenter().oex_addObserver(self, name: OEXSessionEndedNotification) { (_, observer, _) -> Void in
-            observer.queriers = [:]
+            observer.outlineQueriers = [:]
+            observer.discussionTopicManagers = [:]
             NSUserDefaults.standardUserDefaults().setObject(DefaultCourseMode.rawValue, forKey: CurrentCourseOutlineModeKey)
         }
     }
     
-    private var queriers : [String:CourseOutlineQuerier] = [:]
-    
     public func querierForCourseWithID(courseID : String) -> CourseOutlineQuerier {
-        if let querier = queriers[courseID] {
+        if let querier = outlineQueriers[courseID] {
             return querier
         }
         else {
             let querier = CourseOutlineQuerier(courseID: courseID, interface : interface, networkManager : networkManager)
-            queriers[courseID] = querier
+            outlineQueriers[courseID] = querier
             return querier
+        }
+    }
+    
+    public func discussionTopicManagerForCourseWithID(courseID : String) -> DiscussionTopicsManager {
+        if let manager = discussionTopicManagers[courseID] {
+            return manager
+        }
+        else {
+            let manager = DiscussionTopicsManager(courseID: courseID, networkManager: self.networkManager)
+            discussionTopicManagers[courseID] = manager
+            return manager
         }
     }
     

--- a/Source/CourseOutlineModeController.swift
+++ b/Source/CourseOutlineModeController.swift
@@ -87,7 +87,7 @@ class CourseOutlineModeController : NSObject {
             (title : OEXLocalizedString("COURSE_MODE_VIDEO", nil), value : CourseOutlineMode.Video)
         ]
         
-        let controller = actionSheetWithItems(items, currentSelection: currentMode) {[weak self] mode in
+        let controller = PSTAlertController.actionSheetWithItems(items, currentSelection: self.currentMode) {[weak self] mode in
             self?.dataSource.currentOutlineMode = mode
         }
         

--- a/Source/DiscussionAPI.swift
+++ b/Source/DiscussionAPI.swift
@@ -8,6 +8,33 @@
 
 import Foundation
 
+public enum DiscussionPostsFilter {
+    case AllPosts
+    case Unread
+    case Unanswered
+    
+    private var apiRepresentation : String? {
+        switch self {
+        case AllPosts: return nil // default
+        case Unread: return "unread"
+        case Unanswered: return "unanswered"
+        }
+    }
+}
+
+public enum DiscussionPostsSort {
+    case RecentActivity
+    case LastActivityAt
+    case VoteCount
+    
+    private var apiRepresentation : String? {
+        switch self {
+        case RecentActivity: return nil // default
+        case LastActivityAt: return "last_activity_at"
+        case VoteCount: return "vote_count"
+        }
+    }
+}
 
 public class DiscussionAPI {
     static func createNewThread(newThread: DiscussionNewThread) -> NetworkRequest<DiscussionThread> {
@@ -117,12 +144,12 @@ public class DiscussionAPI {
         })
     }    
     
-    static func getThreads(#courseID: String, topicID: String, viewFilter: DiscussionPostsFilter?, orderBy: DiscussionPostsSort?) -> NetworkRequest<[DiscussionThread]> {
+    static func getThreads(#courseID: String, topicID: String, filter: DiscussionPostsFilter, orderBy: DiscussionPostsSort) -> NetworkRequest<[DiscussionThread]> {
         var query = ["course_id" : JSON(courseID), "topic_id": JSON(topicID)]
-        if let view = viewFilter?.rawValue {
+        if let view = filter.apiRepresentation {
             query["view"] = JSON(view)
         }
-        if let order = orderBy?.rawValue {
+        if let order = orderBy.apiRepresentation {
             query["order_by"] = JSON(order)
         }        
         

--- a/Source/DiscussionTopicsCell.swift
+++ b/Source/DiscussionTopicsCell.swift
@@ -16,15 +16,12 @@ class DiscussionTopicsCell: UITableViewCell {
     private let ICON_SIZE_WIDTH = 20.0
     private let LABEL_SIZE_HEIGHT = 20.0
     private let SEPARATORLINE_SIZE_HEIGHT = 1.0
-    private let TEXT_MARGIN = 10.0
     private let ICON_MARGIN_LEFT = 15.0
     
-    private let container = UIView()
-    let iconImageView = UIImageView()
-    let titleLabel = UILabel()
+    private let titleLabel = UILabel()
     private let separatorLine = UIView()
     
-    var titleTextStyle : OEXTextStyle {
+    private var titleTextStyle : OEXTextStyle {
         return OEXTextStyle(weight: .Normal, size: .XSmall, color : OEXStyles.sharedStyles().neutralBlack())
     }
     
@@ -38,22 +35,25 @@ class DiscussionTopicsCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    var titleText : String? {
-        get {
-            return self.titleLabel.text
+    private var margin : CGFloat {
+        return OEXStyles.sharedStyles().standardHorizontalMargin()
+    }
+    
+    var topic : DiscussionTopic? = nil {
+        didSet {
+            self.titleLabel.attributedText = titleTextStyle.attributedStringWithText(topic?.name)
+            self.depth = topic?.depth ?? 0
         }
-        set {
-            self.titleLabel.attributedText = titleTextStyle.attributedStringWithText(newValue)
-        }
+    }
+    
+    private var indent : CGFloat {
+        return self.margin * CGFloat((self.depth + 1))
     }
     
     func configureViews() {
         self.separatorLine.backgroundColor = OEXStyles.sharedStyles().neutralXLight()
         
-        self.container.addSubview(iconImageView)
-        self.container.addSubview(titleLabel)
-        
-        self.contentView.addSubview(container)
+        self.contentView.addSubview(titleLabel)
         self.contentView.addSubview(separatorLine)
         
         self.separatorLine.snp_makeConstraints { (make) -> Void in
@@ -62,25 +62,19 @@ class DiscussionTopicsCell: UITableViewCell {
             make.top.equalTo(self.contentView)
             make.height.equalTo(SEPARATORLINE_SIZE_HEIGHT)
         }
-        
-        self.container.snp_makeConstraints { make -> Void in
-            make.leading.equalTo(self.contentView)
-            make.trailing.equalTo(self.contentView)
-            make.top.equalTo(self.separatorLine.snp_bottom)
-            make.bottom.equalTo(self.contentView)
-        }
-        
-        self.iconImageView.snp_makeConstraints { (make) -> Void in
-            make.leading.equalTo(self.container).offset(ICON_MARGIN_LEFT)
-            make.centerY.equalTo(self.container)
-            make.width.equalTo(ICON_SIZE_WIDTH)
-            make.height.equalTo(ICON_SIZE_WIDTH)
-        }
         self.titleLabel.snp_makeConstraints { (make) -> Void in
-            make.leading.equalTo(self.iconImageView.snp_right).offset(TEXT_MARGIN)
-            make.trailing.equalTo(self.contentView).offset(-TEXT_MARGIN)
-            make.centerY.equalTo(self.container)
+            make.trailing.equalTo(self.contentView).offset(margin)
+            make.centerY.equalTo(self.contentView)
             make.height.equalTo(LABEL_SIZE_HEIGHT)
+            make.leading.equalTo(self.contentView).offset(indent)
+        }
+    }
+    
+    private var depth : UInt = 0 {
+        didSet {
+            self.titleLabel.snp_updateConstraints { make in
+                make.leading.equalTo(self.contentView).offset(self.indent)
+            }
         }
     }
 

--- a/Source/DiscussionTopicsManager.swift
+++ b/Source/DiscussionTopicsManager.swift
@@ -1,0 +1,36 @@
+//
+//  DiscussionTopicsManager.swift
+//  edX
+//
+//  Created by Akiva Leffert on 7/29/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+import Foundation
+
+public class DiscussionTopicsManager {
+    private let topicStream = BackedStream<[DiscussionTopic]>()
+    private let courseID : String
+    private let networkManager : NetworkManager?
+    
+    init(courseID : String, networkManager : NetworkManager?) {
+        self.courseID = courseID
+        self.networkManager = networkManager
+    }
+    
+    init(courseID : String, topics : [DiscussionTopic]) {
+        self.courseID = courseID
+        self.networkManager = nil
+        self.topicStream.backWithStream(Stream(value: topics))
+    }
+    
+    public var topics : Stream<[DiscussionTopic]> {
+        if topicStream.value == nil && !topicStream.active {
+            let request = DiscussionAPI.getCourseTopics(courseID)
+            if let stream = networkManager?.streamForRequest(request, persistResponse: true, autoCancel: false) {
+                topicStream.backWithStream(stream)
+            }
+        }
+        return topicStream
+    }
+}

--- a/Source/MenuOptionsViewController.swift
+++ b/Source/MenuOptionsViewController.swift
@@ -9,12 +9,13 @@
 import UIKit
 
 protocol MenuOptionsViewControllerDelegate : class {
-    func menuOptionsController(controller : MenuOptionsViewController, selectedOptionAtIndex: Int)
+    func menuOptionsController(controller : MenuOptionsViewController, selectedOptionAtIndex index: Int)
+    func menuOptionsController(controller : MenuOptionsViewController, canSelectOptionAtIndex index: Int) -> Bool
 }
 
 
 class MenuOptionsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
-    let identifier = "reuseIdentifier"
+    private let identifier = "reuseIdentifier"
     var menuWidth: CGFloat = 120.0
     var menuHeight: CGFloat = 90.0
     static let menuItemHeight: CGFloat = 30.0
@@ -24,7 +25,7 @@ class MenuOptionsViewController: UIViewController, UITableViewDataSource, UITabl
     var selectedOptionIndex: Int?
     weak var delegate : MenuOptionsViewControllerDelegate?
     
-    var titleTextStyle : OEXTextStyle {
+    private var titleTextStyle : OEXTextStyle {
         let style = OEXTextStyle(weight: .Normal, size: .XSmall, color: OEXStyles.sharedStyles().neutralDark())
         return style
     }
@@ -72,6 +73,15 @@ class MenuOptionsViewController: UIViewController, UITableViewDataSource, UITabl
         cell.textLabel?.attributedText = style.attributedStringWithText(options[indexPath.row])
         
         return cell
+    }
+    
+    func tableView(tableView: UITableView, willSelectRowAtIndexPath indexPath: NSIndexPath) -> NSIndexPath? {
+        if delegate?.menuOptionsController(self, canSelectOptionAtIndex:indexPath.row) ?? false {
+            return indexPath
+        }
+        else {
+            return nil
+        }
     }
     
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -129,18 +129,36 @@ extension OEXRouter {
         controller.navigationController?.pushViewController(newCommentVC, animated: true)
     }
     
-    func showPostsViewController(controller: DiscussionTopicsViewController) {
+    func showPostsFromController(controller : UIViewController, courseID : String, topic : DiscussionTopic) {
         let environment = PostsViewControllerEnvironment(networkManager: self.environment.networkManager, router: self)
-        let postsVC = PostsViewController(env: environment, course: controller.course, selectedTopic: controller.selectedTopic, searchResults: controller.searchResults, topics: controller.topics, topicsArray: controller.topicsArray)
-        controller.navigationController?.pushViewController(postsVC, animated: true)
+        let postsController = PostsViewController(environment: environment, courseID: courseID, topic: topic)
+        controller.navigationController?.pushViewController(postsController, animated: true)
     }
     
-    func showDiscussionNewPostFromController(controller: PostsViewController) {
-        let environment = DiscussionNewPostViewControllerEnvironment(networkManager: self.environment.networkManager, router: self)
-        if let topic = controller.selectedTopic {
-            let newPostVC = DiscussionNewPostViewController(env: environment, course: controller.course, selectedTopic: topic, topics: controller.topics, topicsArray: controller.topicsArray)
-            controller.navigationController?.pushViewController(newPostVC, animated: true)
-        }
+    func showPostsFromController(controller : UIViewController, courseID : String, searchResults : [DiscussionThread]) {
+        let environment = PostsViewControllerEnvironment(networkManager: self.environment.networkManager, router: self)
+        let postsController = PostsViewController(environment: environment, courseID: courseID, searchResults: searchResults)
+        controller.navigationController?.pushViewController(postsController, animated: true)
+    }
+    
+    func showDiscussionTopicsFromController(controller: UIViewController, courseID : String) {
+        let environment = DiscussionTopicsViewController.Environment(
+            config: self.environment.config,
+            courseDataManager: self.environment.dataManager.courseDataManager,
+            networkManager: self.environment.networkManager,
+            router: self)
+        let topicsController = DiscussionTopicsViewController(environment: environment, courseID: courseID)
+        controller.navigationController?.pushViewController(topicsController, animated: true)
+    }
+
+    
+    func showDiscussionNewPostFromController(controller: UIViewController, courseID : String, initialTopic : DiscussionTopic) {
+        let environment = DiscussionNewPostViewController.Environment(
+            courseDataManager : self.environment.dataManager.courseDataManager,
+            networkManager: self.environment.networkManager,
+            router: self)
+        let newPostController = DiscussionNewPostViewController(environment: environment, courseID: courseID, selectedTopic: initialTopic)
+        controller.navigationController?.pushViewController(newPostController, animated: true)
     }
     
     func showHandouts(handoutsURLString : String?, fromViewController controller : UIViewController) {

--- a/Source/OEXRouter.h
+++ b/Source/OEXRouter.h
@@ -77,7 +77,6 @@
 #pragma mark Course Structure
 - (void)showAnnouncementsForCourseWithID:(NSString*)courseID;
 - (void)showCourse:(OEXCourse*)course fromController:(UIViewController*)controller;
-- (void)showDiscussionTopicsForCourse:(OEXCourse*)course fromController:(UIViewController*)controller;
 
 #pragma mark Videos
 - (void)showDownloadsFromViewController:(UIViewController*)controller;

--- a/Source/OEXRouter.m
+++ b/Source/OEXRouter.m
@@ -186,13 +186,6 @@ OEXRegistrationViewControllerDelegate
     }
 }
 
-- (void)showDiscussionTopicsForCourse:(OEXCourse *)course fromController:(UIViewController *)controller
-{
-    DiscussionTopicsViewControllerEnvironment *environment = [[DiscussionTopicsViewControllerEnvironment alloc] initWithConfig:self.environment.config networkManager:self.environment.networkManager router:self];
-    DiscussionTopicsViewController *discussionTopicsController = [[DiscussionTopicsViewController alloc] initWithEnvironment:environment course:course];
-    [controller.navigationController pushViewController:discussionTopicsController animated:YES];
-}
-
 - (void)showCourse:(OEXCourse*)course fromController:(UIViewController*)controller {
     UIViewController* courseController = [self controllerForCourse:course];
     [controller.navigationController pushViewController:courseController animated:YES];

--- a/Source/PSTAlertController+Selection.swift
+++ b/Source/PSTAlertController+Selection.swift
@@ -7,19 +7,20 @@
 //
 
 import Foundation
-
-func actionSheetWithItems<A : Equatable>(items : [(title : String, value : A)], currentSelection : A? = nil, action : A -> Void) -> PSTAlertController {
-    let controller = PSTAlertController(title: nil, message: nil, preferredStyle: .ActionSheet)
-    for (var title, value) in items {
-        if let selection = currentSelection where value == selection {
-            // Note that checkmark and space have a neutral text flow direction so this is correct for RTL
-            title = "✔︎ " + title
-        }
-        controller.addAction(
-            PSTAlertAction(title : title) {_ in
-                action(value)
+extension PSTAlertController {
+    static func actionSheetWithItems<A : Equatable>(items : [(title : String, value : A)], currentSelection : A? = nil, action : A -> Void) -> PSTAlertController {
+        let controller = PSTAlertController(title: nil, message: nil, preferredStyle: .ActionSheet)
+        for (var title, value) in items {
+            if let selection = currentSelection where value == selection {
+                // Note that checkmark and space have a neutral text flow direction so this is correct for RTL
+                title = "✔︎ " + title
             }
-        )
+            controller.addAction(
+                PSTAlertAction(title : title) {_ in
+                    action(value)
+                }
+            )
+        }
+        return controller
     }
-    return controller
 }

--- a/Source/PostsViewController.swift
+++ b/Source/PostsViewController.swift
@@ -16,16 +16,6 @@ enum CellType {
     case TitleAndBy, TitleOnly
 }
 
-enum DiscussionPostsFilter: String {
-    case Unread = "unread"
-    case Unanswered = "unanswered"
-}
-
-enum DiscussionPostsSort: String {
-    case LastActivityAt = "last_activity_at"
-    case VoteCount = "vote_count"
-}
-
 struct DiscussionPostItem {
     let cellType: CellType
     let title: String
@@ -51,6 +41,27 @@ class PostsViewControllerEnvironment: NSObject {
 }
 
 class PostsViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+
+    private enum Context {
+        case Topic(DiscussionTopic)
+        case SearchResults([DiscussionThread])
+        
+        var allowsPosting : Bool {
+            switch self {
+            case Topic: return true
+            case SearchResults: return false
+            }
+        }
+        
+        var topic : DiscussionTopic? {
+            switch self {
+            case let Topic(topic): return topic
+            case let SearchResults(results): return nil
+            }
+        }
+    }
+
+    
     let environment: PostsViewControllerEnvironment
     
     private let identifierTitleAndByCell = "TitleAndByCell"
@@ -59,40 +70,36 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
     private var tableView: UITableView!
     private var viewSeparator: UIView!
     
-    private let postsButton = UIButton.buttonWithType(.System) as! UIButton
-    private let activityButton = UIButton.buttonWithType(.System) as! UIButton
+    private let filterButton = UIButton.buttonWithType(.System) as! UIButton
+    private let sortButton = UIButton.buttonWithType(.System) as! UIButton
     private let newPostButton = UIButton.buttonWithType(.System) as! UIButton
-    let course: OEXCourse
+    private let courseID: String
     
-    private var viewOption: UIView!
-    private var viewControllerOption: MenuOptionsViewController!
-    private let sortByOptions = [OEXLocalizedString("RECENT_ACTIVITY", nil) as String, OEXLocalizedString("MOST_ACTIVITY", nil) as String, OEXLocalizedString("MOST_VOTES", nil) as String]
-    private let filteringOptions = [OEXLocalizedString("ALL_POSTS", nil) as String, OEXLocalizedString("UNREAD", nil) as String, OEXLocalizedString("UNANSWERED", nil) as String]
+    private let context : Context
     
-    var isFilteringOptionsShowing: Bool?
+    private var posts: [DiscussionPostItem] = []
+    private var selectedFilter: DiscussionPostsFilter = .AllPosts
+    private var selectedOrderBy: DiscussionPostsSort = .RecentActivity
     
-    var posts: [DiscussionPostItem] = []
-    let selectedTopic: DiscussionTopic?
-    var selectedViewFilter: DiscussionPostsFilter?
-    var selectedOrderBy: DiscussionPostsSort?
-    let searchResults: [DiscussionThread]?
-    let topics: [DiscussionTopic]
-    let topicsArray: [String]
-    
-    var filterTextStyle : OEXTextStyle {
+    private var filterTextStyle : OEXTextStyle {
         return OEXTextStyle(weight : .Normal, size: .XSmall, color: OEXStyles.sharedStyles().primaryBaseColor())
     }
     
-    init(env: PostsViewControllerEnvironment, course: OEXCourse, selectedTopic: DiscussionTopic?, searchResults: [DiscussionThread]?, topics: [DiscussionTopic], topicsArray: [String]) {
-        self.environment = env
-        self.course = course
-        self.selectedTopic = selectedTopic
-        self.topics = topics
-        self.topicsArray = topicsArray
-        self.searchResults = searchResults
+    init(environment: PostsViewControllerEnvironment, courseID: String, topic : DiscussionTopic) {
+        self.environment = environment
+        self.courseID = courseID
+        self.context = Context.Topic(topic)
         super.init(nibName: nil, bundle: nil)
     }
-
+    
+    init(environment: PostsViewControllerEnvironment, courseID: String, searchResults : [DiscussionThread]) {
+        self.environment = environment
+        self.courseID = courseID
+        self.context = Context.SearchResults(searchResults)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    
     required init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -102,39 +109,30 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
         
         view.backgroundColor = OEXStyles.sharedStyles().standardBackgroundColor()
         
-        if let topic = selectedTopic {
-            // if the topic.name is long, the back button title will show as "Back"
-            self.navigationItem.backBarButtonItem = UIBarButtonItem(title: topic.name, style: .Plain, target: nil, action: nil)
-        }
-        
         var buttonTitle = NSAttributedString.joinInNaturalLayout(
             before: Icon.Filter.attributedTextWithStyle(filterTextStyle.withSize(.XSmall)),
-            after: filterTextStyle.attributedStringWithText(OEXLocalizedString("ALL_POSTS", nil)))
-        postsButton.setAttributedTitle(buttonTitle, forState: .Normal)
+            after: filterTextStyle.attributedStringWithText(self.titleForFilter(self.selectedFilter)))
+        filterButton.setAttributedTitle(buttonTitle, forState: .Normal)
         
-        postsButton.addTarget(self,
-            action: "postsTapped:", forControlEvents: .TouchUpInside)
-        view.addSubview(postsButton)
+        view.addSubview(filterButton)
         
-        postsButton.snp_makeConstraints{ (make) -> Void in
+        filterButton.snp_makeConstraints{ (make) -> Void in
             make.leading.equalTo(view).offset(20)
             make.top.equalTo(view).offset(10)
-            make.height.equalTo(searchResults==nil ? 20 : 0)
+            make.height.equalTo(context.allowsPosting ? 20 : 0)
             make.width.equalTo(103)
         }
         
         buttonTitle = NSAttributedString.joinInNaturalLayout(
             before: Icon.Recent.attributedTextWithStyle(filterTextStyle.withSize(.XSmall)),
             after: filterTextStyle.attributedStringWithText(OEXLocalizedString("RECENT_ACTIVITY", nil)))
-        activityButton.setAttributedTitle(buttonTitle, forState: .Normal)
-        activityButton.addTarget(self,
-            action: "activityTapped:", forControlEvents: .TouchUpInside)
-        view.addSubview(activityButton)
+        sortButton.setAttributedTitle(buttonTitle, forState: .Normal)
+        view.addSubview(sortButton)
         
-        activityButton.snp_makeConstraints{ (make) -> Void in
+        sortButton.snp_makeConstraints{ (make) -> Void in
             make.trailing.equalTo(view).offset(-20)
             make.top.equalTo(view).offset(10)
-            make.height.equalTo(searchResults==nil ? 20 : 0)
+            make.height.equalTo(context.allowsPosting ? 20 : 0)
             make.width.equalTo(103)
         }
         
@@ -147,18 +145,12 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
         newPostButton.setAttributedTitle(buttonTitle, forState: .Normal)
         
         newPostButton.contentVerticalAlignment = .Center
-
-        newPostButton.oex_addAction({ [weak self] (action : AnyObject!) -> Void in
-            if let owner = self {
-                owner.environment.router?.showDiscussionNewPostFromController(owner)
-            }
-        }, forEvents: UIControlEvents.TouchUpInside)
         
         view.addSubview(newPostButton)
         newPostButton.snp_makeConstraints{ (make) -> Void in
             make.leading.equalTo(view)
             make.trailing.equalTo(view)
-            make.height.equalTo(searchResults==nil ? DiscussionStyleConstants.standardFooterHeight : 0)
+            make.height.equalTo(context.allowsPosting ? DiscussionStyleConstants.standardFooterHeight : 0)
             make.bottom.equalTo(view.snp_bottom)
         }
         
@@ -171,11 +163,10 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
             view.addSubview(theTableView)
         }
         
-        if searchResults == nil {
-            
+        if context.allowsPosting {
             tableView.snp_makeConstraints { (make) -> Void in
                 make.leading.equalTo(view)
-                make.top.equalTo(postsButton).offset(30)
+                make.top.equalTo(filterButton).offset(30)
                 make.trailing.equalTo(view)
                 make.bottom.equalTo(newPostButton.snp_top)
             }
@@ -187,7 +178,7 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
                 make.leading.equalTo(view)
                 make.trailing.equalTo(view)
                 make.height.equalTo(OEXStyles.dividerSize())
-                make.top.equalTo(postsButton.snp_bottom).offset(searchResults==nil ? 12 : 0)
+                make.top.equalTo(filterButton.snp_bottom).offset(context.allowsPosting ? 12 : 0)
             }
         }
         else {
@@ -199,57 +190,75 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
             }
         }
         
-        if let threads = searchResults {
-            self.navigationItem.title = OEXLocalizedString("SEARCH_RESULTS", nil)
-        }
-        else if let topic = selectedTopic {
+        if let topic = context.topic {
+            filterButton.oex_addAction(
+                {[weak self] _ in
+                    self?.showFilterPickerWithTopic(topic)
+                }, forEvents: .TouchUpInside)
+            sortButton.oex_addAction(
+                {[weak self] _ in
+                    self?.showSortPickerWithTopic(topic)
+                }, forEvents: .TouchUpInside)
+            newPostButton.oex_addAction(
+                {[weak self] _ in
+                    if let owner = self {
+                        owner.environment.router?.showDiscussionNewPostFromController(owner, courseID: owner.courseID, initialTopic: topic)
+                    }
+            }, forEvents: .TouchUpInside)
             self.navigationItem.title = topic.name
         }
+        else {
+            self.navigationItem.title = OEXLocalizedString("SEARCH_RESULTS", nil)
+        }
     }
-    
+
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         tableView.indexPathForSelectedRow().map { tableView.deselectRowAtIndexPath($0, animated: false) }
     }
-    
+
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
         
-        if let threads = searchResults {
-            self.posts.removeAll(keepCapacity: true)
-            
-            for discussionThread in threads {
-                if let rawBody = discussionThread.rawBody,
-                    author = discussionThread.author,
-                    createdAt = discussionThread.createdAt,
-                    title = discussionThread.title,
-                    threadID = discussionThread.identifier {
-                        let item = DiscussionPostItem(cellType: CellType.TitleAndBy,
-                            title: title,
-                            body: rawBody,
-                            author: author,
-                            createdAt: createdAt,
-                            count: discussionThread.commentCount,
-                            threadID: threadID,
-                            following: discussionThread.following,
-                            flagged: discussionThread.flagged,
-                            voted: discussionThread.voted,
-                            voteCount: discussionThread.voteCount)
-                        self.posts.append(item)
-                }
-            }
-            
-            self.tableView.reloadData()
-        }
-        else {
-            postsWithFilter(selectedViewFilter, orderBy: selectedOrderBy)
+        switch context {
+        case let .Topic(topic):
+            loadPostsForTopic(topic, filter: selectedFilter, orderBy: selectedOrderBy)
+        case let .SearchResults(threads):
+            showThreads(threads)
         }
         
     }
     
-    private func postsWithFilter(viewFilter: DiscussionPostsFilter?, orderBy: DiscussionPostsSort?) {
-        if let courseID = self.course.course_id, topic = selectedTopic, topicID = topic.id {
-            let apiRequest = DiscussionAPI.getThreads(courseID: courseID, topicID: topicID, viewFilter: viewFilter, orderBy: orderBy)
+    private func showThreads(threads : [DiscussionThread]) {
+        self.posts.removeAll(keepCapacity: true)
+        
+        for discussionThread in threads {
+            if let rawBody = discussionThread.rawBody,
+                author = discussionThread.author,
+                createdAt = discussionThread.createdAt,
+                title = discussionThread.title,
+                threadID = discussionThread.identifier {
+                    let item = DiscussionPostItem(cellType: CellType.TitleAndBy,
+                        title: title,
+                        body: rawBody,
+                        author: author,
+                        createdAt: createdAt,
+                        count: discussionThread.commentCount,
+                        threadID: threadID,
+                        following: discussionThread.following,
+                        flagged: discussionThread.flagged,
+                        voted: discussionThread.voted,
+                        voteCount: discussionThread.voteCount)
+                    self.posts.append(item)
+            }
+        }
+        
+        self.tableView.reloadData()
+    }
+
+    private func loadPostsForTopic(topic : DiscussionTopic, filter: DiscussionPostsFilter, orderBy: DiscussionPostsSort) {
+        if let topic = context.topic, topicID = topic.id {
+            let apiRequest = DiscussionAPI.getThreads(courseID: courseID, topicID: topicID, filter: filter, orderBy: orderBy)
             environment.networkManager?.taskForRequest(apiRequest) { result in
                 if let threads: [DiscussionThread] = result.data {
                     self.posts.removeAll(keepCapacity: true)
@@ -281,29 +290,37 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
         }
     }
     
-    func postsTapped(sender: AnyObject) {
-        
-        let controller = PSTAlertController(title: nil, message: nil, preferredStyle: .ActionSheet)
-        for option in filteringOptions {
-            controller.addAction(PSTAlertAction(title: option) {[weak self] o in
-                if let owner = self {
-                    let buttonTitle = NSAttributedString.joinInNaturalLayout(
-                        before: Icon.Filter.attributedTextWithStyle(owner.filterTextStyle.withSize(.XSmall)),
-                        after: owner.filterTextStyle.attributedStringWithText(o.title))
-                    owner.postsButton.setAttributedTitle(buttonTitle, forState: .Normal)
-                    switch o.title {
-                    case owner.filteringOptions[1]:
-                        owner.selectedViewFilter = DiscussionPostsFilter.Unread
-                        owner.postsWithFilter(owner.selectedViewFilter, orderBy: owner.selectedOrderBy)
-                    case owner.filteringOptions[2]:
-                        owner.selectedViewFilter = DiscussionPostsFilter.Unanswered
-                        owner.postsWithFilter(owner.selectedViewFilter, orderBy: owner.selectedOrderBy)
-                    default:
-                        owner.selectedViewFilter = nil
-                        owner.postsWithFilter(nil, orderBy: owner.selectedOrderBy)
-                    }
-                }
-            })
+    func titleForFilter(filter : DiscussionPostsFilter) -> String {
+        switch filter {
+        case .AllPosts: return OEXLocalizedString("ALL_POSTS", nil)
+        case .Unread: return OEXLocalizedString("UNREAD", nil)
+        case .Unanswered: return OEXLocalizedString("UNANSWERED", nil)
+        }
+    }
+    
+    func titleForSort(filter : DiscussionPostsSort) -> String {
+        switch filter {
+        case .RecentActivity: return OEXLocalizedString("RECENT_ACTIVITY", nil)
+        case .LastActivityAt: return OEXLocalizedString("MOST_ACTIVITY", nil)
+        case .VoteCount: return OEXLocalizedString("MOST_VOTES", nil)
+        }
+    }
+    
+    
+    func showFilterPickerWithTopic(topic : DiscussionTopic) {
+        let options = [.AllPosts, .Unread, .Unanswered].map {
+            return (title : self.titleForFilter($0), value : $0)
+        }
+
+        let controller = PSTAlertController.actionSheetWithItems(options, currentSelection : self.selectedFilter) {filter in
+            self.selectedFilter = filter
+            self.loadPostsForTopic(topic, filter: self.selectedFilter, orderBy: self.selectedOrderBy)
+            
+            let buttonTitle = NSAttributedString.joinInNaturalLayout(
+                before: Icon.Filter.attributedTextWithStyle(self.filterTextStyle.withSize(.XSmall)),
+                after: self.filterTextStyle.attributedStringWithText(self.titleForFilter(filter)))
+            
+            self.filterButton.setAttributedTitle(buttonTitle, forState: .Normal)
         }
         controller.addAction(PSTAlertAction(title: OEXLocalizedString("CANCEL", nil), style: .Cancel) { _ in
             })
@@ -311,29 +328,21 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
         controller.showWithSender(nil, controller: self, animated: true, completion: nil)
     }
     
-    func activityTapped(sender: AnyObject) {
-        let controller = PSTAlertController(title: nil, message: nil, preferredStyle: .ActionSheet)
-        for option in sortByOptions {
-            controller.addAction(PSTAlertAction(title: option) {[weak self] o in
-                if let owner = self {
-                    let buttonTitle = NSAttributedString.joinInNaturalLayout(
-                        before: Icon.Recent.attributedTextWithStyle(owner.filterTextStyle.withSize(.XSmall)),
-                        after: owner.filterTextStyle.attributedStringWithText(o.title))
-                    owner.activityButton.setAttributedTitle(buttonTitle, forState: .Normal)
-                    switch o.title {
-                    case owner.sortByOptions[1]:
-                        owner.selectedOrderBy = DiscussionPostsSort.LastActivityAt
-                        owner.postsWithFilter(owner.selectedViewFilter, orderBy: owner.selectedOrderBy)
-                    case owner.sortByOptions[2]:
-                        owner.selectedOrderBy = DiscussionPostsSort.VoteCount
-                        owner.postsWithFilter(owner.selectedViewFilter, orderBy: owner.selectedOrderBy)
-                    default:
-                        owner.selectedOrderBy = nil
-                        owner.postsWithFilter(nil, orderBy: owner.selectedOrderBy)
-                    }
-                }
-                })
+    func showSortPickerWithTopic(topic: DiscussionTopic) {
+        let options = [.RecentActivity, .LastActivityAt, .VoteCount].map {
+            return (title : self.titleForSort($0), value : $0)
         }
+        
+        let controller = PSTAlertController.actionSheetWithItems(options, currentSelection : self.selectedOrderBy) {sort in
+            self.selectedOrderBy = sort
+            self.loadPostsForTopic(topic, filter: self.selectedFilter, orderBy: self.selectedOrderBy)
+            let buttonTitle = NSAttributedString.joinInNaturalLayout(
+                before: Icon.Sort.attributedTextWithStyle(self.filterTextStyle.withSize(.XSmall)),
+                after: self.filterTextStyle.attributedStringWithText(self.titleForSort(sort)))
+            
+            self.sortButton.setAttributedTitle(buttonTitle, forState: .Normal)
+        }
+        
         controller.addAction(PSTAlertAction(title: OEXLocalizedString("CANCEL", nil), style: .Cancel) { _ in
             })
         

--- a/Test/Array+FunctionalTests.swift
+++ b/Test/Array+FunctionalTests.swift
@@ -31,6 +31,19 @@ class Array_FunctionalTests: XCTestCase {
         }
         XCTAssertNil(result)
     }
+    
+    func testMapSkippingNil() {
+        let list = [1, 2, 3]
+        let result = list.mapSkippingNils {i -> Int? in
+            if i == 2 {
+                return nil
+            }
+            else {
+                return i + 1
+            }
+        }
+        XCTAssertEqual(result, [2, 4])
+    }
 
     func testFirstIndexMatchingSuccess() {
         let list = [1, 2, 3, 2, 4]

--- a/Test/CourseDashboardViewControllerTests.swift
+++ b/Test/CourseDashboardViewControllerTests.swift
@@ -33,7 +33,7 @@ class CourseDashboardViewControllerTests: SnapshotTestCase {
     func discussionsVisibleWhenEnabled(enabled: Bool) -> Bool {
         let config : DashboardStubConfig = DashboardStubConfig(discussionsEnabled: enabled)
         let environment = CourseDashboardViewControllerEnvironment(config: config, router: nil, networkManager: nil)
-        let controller = CourseDashboardViewController(environment: environment, course: nil)
+        let controller = CourseDashboardViewController(environment: environment, course: OEXCourse.freshCourse())
         
         controller.prepareTableViewData()
         

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		7726BD371A38EC0B003B3354 /* GoogleOpenSource.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8F562F891A1F44D700320DB3 /* GoogleOpenSource.framework */; };
 		772BF2141B0E5305008FB89D /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772BF2131B0E5305008FB89D /* Box.swift */; };
 		772D99971B0E61BF00679572 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772D99961B0E61BF00679572 /* Result.swift */; };
+		773181371B697644000CC050 /* DiscussionTopicsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773181361B697644000CC050 /* DiscussionTopicsManager.swift */; };
 		773A04781AF2D5DE0076532C /* CourseOutlineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773A04771AF2D5DE0076532C /* CourseOutlineViewController.swift */; };
 		773A047C1AF2D7BD0076532C /* CourseOutlineTestDataFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773A04791AF2D7690076532C /* CourseOutlineTestDataFactory.swift */; };
 		773A04801AF2E6DA0076532C /* CourseOutlineTableSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773A047F1AF2E6DA0076532C /* CourseOutlineTableSource.swift */; };
@@ -766,6 +767,7 @@
 		7726BD321A38E684003B3354 /* app_icon180.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = app_icon180.png; sourceTree = "<group>"; };
 		772BF2131B0E5305008FB89D /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		772D99961B0E61BF00679572 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		773181361B697644000CC050 /* DiscussionTopicsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscussionTopicsManager.swift; sourceTree = "<group>"; };
 		773A04691AF289650076532C /* edX-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "edX-Bridging-Header.h"; sourceTree = "<group>"; };
 		773A04771AF2D5DE0076532C /* CourseOutlineViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseOutlineViewController.swift; sourceTree = "<group>"; };
 		773A04791AF2D7690076532C /* CourseOutlineTestDataFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseOutlineTestDataFactory.swift; sourceTree = "<group>"; };
@@ -1578,6 +1580,7 @@
 		46D567A51B0292D40068F823 /* Discussion */ = {
 			isa = PBXGroup;
 			children = (
+				773181361B697644000CC050 /* DiscussionTopicsManager.swift */,
 				774BC7F31B4B0D700084F902 /* DiscussionTopic.swift */,
 				5D43B17F1B0C1F9200448B52 /* PostTitleTableViewCell.swift */,
 				5D43B1801B0C1F9200448B52 /* PostTitleByTableViewCell.swift */,
@@ -3130,6 +3133,7 @@
 				772D99971B0E61BF00679572 /* Result.swift in Sources */,
 				7769071E1AD5DAF200F5E7EB /* OEXApplication.m in Sources */,
 				B4D31D351AB1904200C8D45C /* NSJSONSerialization+OEXSafeAccess.m in Sources */,
+				773181371B697644000CC050 /* DiscussionTopicsManager.swift in Sources */,
 				5DE8F73C1B3886AA00F3FCF2 /* UIViewController+OEXKeyboard.swift in Sources */,
 				7772BEAB1AFA68330081CA7A /* SnapKit.swift in Sources */,
 				77ADF4AC1AC1F31200AC8955 /* OEXExternalAuthOptionsView.m in Sources */,


### PR DESCRIPTION
- Makes the router methods only take the data needed to construct a new
  controller, rather than read it from public state of the previous
  controller in hte flow.
    This allows us to significantly reduce local state
    This prepares us to construct controllers within tests.

- Adds a discussion topics manager. This way we no longer need to
  propagate the possible topics through screens that don't care about
  them. This seemed better than changing the code to follow the strategy
  of loading them from the net whenever we need them.

- Use the stream API for topics so we can better cache them. Since
  topics change rarely this seems like a good exception for strategy of
  not caching forums data.

- Move ``DiscussionPostsSort`` and ``DiscussionPostsFilter`` inside the API
  abstraction barrier so clients never have to think of them as strings.
  Make the default case explicit so its more obvious what it means
  instead of just ``nil``.

- Make a lot more things ``private``.

- Delete assorted unused code.

- Properly account for recursivity of DiscussionTopics. The code
  actually gets simpler if you assume arbitrary nesting instead of just
  two levels.

- Rename things to better match their functionality. (e.g. postsButton
  -> filterButton).

- Use an enum for the state in DiscussionPostsViewController to make it
  safer to determine which case we're in. This will probably be further
  factored so loading search results is the responsibility of this
  controller instead of its parent.

- Adopt our standard selected item action sheet API.

JIRA: https://openedx.atlassian.net/browse/MA-1084
JIRA: https://openedx.atlassian.net/browse/MA-1071