### PR TITLE
Check access info in enrollments before showing course content

### DIFF
--- a/Source/CourseDashboardViewController.swift
+++ b/Source/CourseDashboardViewController.swift
@@ -158,7 +158,9 @@ public class CourseDashboardViewController: UIViewController, UITableViewDataSou
     }
     
     func showHandouts() {
-            self.environment.router?.showHandouts(self.course?.course_handouts, fromViewController: self)
+        if let course = self.course, courseID = course.course_id {
+            self.environment.router?.showHandoutsFromController(self, courseID: courseID)
+        }
     }
     
     func showAnnouncements() {

--- a/Source/CourseInfoAPI.swift
+++ b/Source/CourseInfoAPI.swift
@@ -15,10 +15,10 @@ public struct CourseInfoAPI {
         return json["handouts_html"].string.toResult(NSError.oex_courseContentLoadError())
     }
     
-    public static func getHandoutsFromURLString(URLString: String = "/api") -> NetworkRequest<String> {
+    public static func getHandoutsForCourseWithID(courseID : String, overrideURL: String? = nil) -> NetworkRequest<String> {
         return NetworkRequest(
             method: HTTPMethod.GET,
-            path : URLString,
+            path : overrideURL ?? "api/mobile/v0.5/course_info/\(courseID)/handouts",
             requiresAuth : true,
             deserializer: .JSONResponse(handoutsDeserializer)
         )

--- a/Source/CourseOutlineQuerier.swift
+++ b/Source/CourseOutlineQuerier.swift
@@ -84,9 +84,18 @@ public class CourseOutlineQuerier : NSObject {
     
     private func loadOutlineIfNecessary() {
         if courseOutline.value == nil && !courseOutline.active {
-            let request = CourseOutlineAPI.requestWithCourseID(courseID)
-            if let loader = networkManager?.streamForRequest(request, persistResponse: true) {
-                courseOutline.backWithStream(loader)
+            if let course = self.interface?.courseWithID(courseID),
+                access = course.courseware_access
+                where !access.has_access
+            {
+                let stream = Stream<CourseOutline>(error: OEXCoursewareAccessError(coursewareAccess: access, displayInfo: course.start_display_info))
+                courseOutline.backWithStream(stream)
+            }
+            else {
+                let request = CourseOutlineAPI.requestWithCourseID(courseID)
+                if let loader = networkManager?.streamForRequest(request, persistResponse: true) {
+                    courseOutline.backWithStream(loader)
+                }
             }
         }
     }

--- a/Source/LoadStateViewController.swift
+++ b/Source/LoadStateViewController.swift
@@ -162,6 +162,10 @@ class LoadStateViewController : UIViewController, OEXStatusMessageControlling {
                     if let error = info.error where error.oex_isNoInternetConnectionError() {
                         self.messageView.showNoConnectionError()
                     }
+                    else if let error = info.error as? OEXAttributedErrorMessageCarrying {
+                        self.messageView.attributedMessage = error.attributedDescriptionWithBaseStyle(self.messageStyle)
+                        self.messageView.icon = info.icon ?? .UnknownError
+                    }
                     else {
                         if let message = info.attributedMessage {
                             self.messageView.attributedMessage = message

--- a/Source/NSError+OEXKnownErrors.h
+++ b/Source/NSError+OEXKnownErrors.h
@@ -11,6 +11,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class OEXCoursewareAccess;
+@class OEXCourseStartDisplayInfo;
+@class OEXTextStyle;
 
 extern NSString* const OEXErrorDomain;
 
@@ -26,9 +28,22 @@ typedef NS_ENUM(NSUInteger, OEXErrorCode) {
 + (instancetype)oex_unknownError;
 + (instancetype)oex_courseContentLoadError;
 + (instancetype)oex_invalidURLError;
-+ (instancetype)oex_errorWithCoursewareAccess:(OEXCoursewareAccess*)access;
 
 - (BOOL)oex_isNoInternetConnectionError;
+
+@end
+
+@protocol OEXAttributedErrorMessageCarrying <NSObject>
+
+- (NSAttributedString*)attributedDescriptionWithBaseStyle:(OEXTextStyle*)style;
+
+@end
+
+@interface OEXCoursewareAccessError : NSError <OEXAttributedErrorMessageCarrying>
+
+- (id)initWithCoursewareAccess:(OEXCoursewareAccess*)access displayInfo:(nullable OEXCourseStartDisplayInfo*)info;
+
+@property (readonly, nonatomic) OEXCoursewareAccessError* error;
 
 @end
 

--- a/Source/NSError+OEXKnownErrors.m
+++ b/Source/NSError+OEXKnownErrors.m
@@ -10,6 +10,10 @@
 
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #import "OEXCoursewareAccess.h"
+#import "OEXCourse.h"
+#import "OEXDateFormatting.h"
+#import "OEXTextStyle.h"
+#import "NSAttributedString+OEXFormatting.h"
 
 NSString* const OEXErrorDomain = @"org.edx.error";
 
@@ -39,17 +43,62 @@ NSString* const OEXErrorDomain = @"org.edx.error";
                                    }];
 }
 
-+ (NSError*)oex_errorWithCoursewareAccess:(OEXCoursewareAccess*)access {
-    return [[self alloc] initWithDomain: OEXErrorDomain
-                                   code:OEXErrorCodeCoursewareAccess
-                               userInfo:@{
-                                          NSLocalizedDescriptionKey : access.user_message ?: OEXLocalizedString(@"UNABLE_TO_LOAD_COURSE_CONTENT", nil)
-                                          }];
-}
-
 - (BOOL)oex_isNoInternetConnectionError {
     return ([self.domain isEqualToString:NSURLErrorDomain] &&
             (self.code == kCFURLErrorNotConnectedToInternet || self.code == kCFURLErrorNetworkConnectionLost)) ||
     ([self.domain isEqual:FBSDKErrorDomain] && self.code == FBSDKNetworkErrorCode);
 }
+
+@end
+
+@interface OEXCoursewareAccessError ()
+
+@property (strong, nonatomic) OEXCoursewareAccess* access;
+@property (strong, nonatomic) OEXCourseStartDisplayInfo* displayInfo;
+
+@end
+
+@implementation OEXCoursewareAccessError
+
+- (id)initWithCoursewareAccess:(OEXCoursewareAccess*)access displayInfo:(nullable OEXCourseStartDisplayInfo*)displayInfo {
+    self = [super initWithDomain: OEXErrorDomain
+            code:OEXErrorCodeCoursewareAccess
+            userInfo:@{
+                       NSLocalizedDescriptionKey : access.user_message ?: OEXLocalizedString(@"UNABLE_TO_LOAD_COURSE_CONTENT", nil)
+                       }];
+    if(self != nil) {
+        self.access = access;
+        self.displayInfo = displayInfo;
+    }
+    return self;
+}
+
+- (NSAttributedString*)attributedDescriptionWithBaseStyle:(OEXTextStyle*)style {
+
+    switch (self.access.error_code) {
+        case OEXStartDateError:
+            if(self.displayInfo.type == OEXStartTypeString && self.displayInfo.displayDate.length > 0) {
+                NSAttributedString* template = [style attributedStringWithText: OEXLocalizedString(@"COURSE_WILL_START_AT", nil)];
+                NSAttributedString* styledDate = [style.withWeight(OEXTextWeightBold) attributedStringWithText:self.displayInfo.displayDate];
+                NSAttributedString* message = [template oex_formatWithParameters:@{@"date" : styledDate}];
+                return message;
+            }
+            else if(self.displayInfo.type == OEXStartTypeTimestamp && self.displayInfo.date != nil) {
+                NSAttributedString* template = [style attributedStringWithText: OEXLocalizedString(@"COURSE_WILL_START_AT", nil)];
+                NSString* displayDate = [OEXDateFormatting formatAsMonthDayString: self.displayInfo.date];
+                NSAttributedString* styledDate = [style.withWeight(OEXTextWeightBold) attributedStringWithText:displayDate];
+                NSAttributedString* message = [template oex_formatWithParameters:@{@"date" : styledDate}];
+                return message;
+            }
+            else {
+                return [style attributedStringWithText: OEXLocalizedString(@"COURSE_NOT_STARTED", nil)];
+            }
+        case OEXMilestoneError:
+        case OEXVisibilityError:
+        case OEXUnknownError:
+            return [style attributedStringWithText: OEXLocalizedString(@"COURSEWARE_UNAVAILABLE", nil)];
+    }
+
+}
+
 @end

--- a/Source/NetworkManager.swift
+++ b/Source/NetworkManager.swift
@@ -278,7 +278,7 @@ extension NetworkManager {
             if let statusCode = OEXHTTPStatusCode(rawValue: response.statusCode) where statusCode.is4xx {
                 if json["has_access"].bool == false {
                     let access = OEXCoursewareAccess(dictionary : json.dictionaryObject)
-                    return Failure(NSError.oex_errorWithCoursewareAccess(access))
+                    return Failure(OEXCoursewareAccessError(coursewareAccess: access, displayInfo: nil))
                 }
                 return Success(json)
             }

--- a/Source/OEXCourse.h
+++ b/Source/OEXCourse.h
@@ -13,9 +13,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface OEXCourse : NSObject
-
-- (id)initWithDictionary:(NSDictionary*)info;
 
 typedef enum {
     OEXStartTypeString,
@@ -23,12 +20,22 @@ typedef enum {
     OEXStartTypeNone
 } OEXStartType;
 
+@interface OEXCourseStartDisplayInfo : NSObject
+
+- (id)initWithDate:(nullable NSDate*)date displayDate:(nullable NSString*)displayDate type:(OEXStartType)type;
+
+@property (readonly, nonatomic, strong, nullable) NSDate* date;
+@property (readonly, copy, nonatomic, nullable) NSString* displayDate;
+@property (readonly, assign, nonatomic) OEXStartType type;
+@end
+
+@interface OEXCourse : NSObject
+
+- (id)initWithDictionary:(NSDictionary*)info;
 // TODO: Rename these to CamelCase
 @property (readonly, nonatomic, strong, nullable) OEXLatestUpdates* latest_updates;
-@property (readonly, nonatomic, strong, nullable) NSDate* start;
 @property (readonly, nonatomic, strong, nullable) NSDate* end;
-@property (readonly, nonatomic, copy) NSString* start_display;
-@property (readonly, nonatomic) OEXStartType start_type;
+@property (readonly, nonatomic, strong) OEXCourseStartDisplayInfo* start_display_info;
 @property (readonly, nonatomic, copy, nullable) NSString* course_image_url;
 @property (readonly, nonatomic, copy, nullable) NSString* name;
 @property (readonly, nonatomic, copy, nullable) NSString* org;

--- a/Source/OEXCourse.m
+++ b/Source/OEXCourse.m
@@ -13,13 +13,34 @@
 #import "OEXLatestUpdates.h"
 #import "OEXCoursewareAccess.h"
 
+@interface OEXCourseStartDisplayInfo ()
+
+@property (strong, nonatomic) NSDate* date;
+@property (copy, nonatomic) NSString* displayDate;
+@property (assign, nonatomic) OEXStartType type;
+
+@end
+
+@implementation OEXCourseStartDisplayInfo
+
+- (id)initWithDate:(NSDate *)date displayDate:(NSString *)displayDate type:(OEXStartType)type {
+    self = [super init];
+    if(self != nil) {
+        self.date = date;
+        self.displayDate = displayDate;
+        self.type = type;
+    }
+    return self;
+}
+
+@end
+
 @interface OEXCourse ()
 
 @property (nonatomic, strong) OEXLatestUpdates* latest_updates;
 @property (nonatomic, strong) NSDate* start;
 @property (nonatomic, strong) NSDate* end;
-@property (nonatomic, copy) NSString* start_display;
-@property (nonatomic) OEXStartType start_type;
+@property (nonatomic, strong) OEXCourseStartDisplayInfo* start_display_info;
 @property (nonatomic, copy) NSString* course_image_url;
 @property (nonatomic, copy) NSString* name;
 @property (nonatomic, copy) NSString* org;
@@ -38,23 +59,20 @@
 
 - (id)initWithDictionary:(NSDictionary *)info {
     NSDictionary* types = @{
-                             @"string" : [NSNumber numberWithInt:OEXStartTypeString],
-                             @"timestamp" : [NSNumber numberWithInt:OEXStartTypeTimestamp],
-                             @"empty" : [NSNumber numberWithInt:OEXStartTypeNone]
+                             @"string" : @(OEXStartTypeString),
+                             @"timestamp" : @(OEXStartTypeTimestamp),
+                             @"empty" : @(OEXStartTypeNone)
                              };
     self = [super init];
     if(self != nil) {
-        self.start = [OEXDateFormatting dateWithServerString:[info objectForKey:@"start"]];
         self.end = [OEXDateFormatting dateWithServerString:[info objectForKey:@"end"]];
-        self.start_display = [info objectForKey:@"start_display"];
-        NSString* start_type = [info objectForKey:@"start_type"];
-        NSString* type = [types objectForKey:start_type];
-        if(type != nil) {
-            self.start_type = [type intValue];
-        }
-        else {
-            self.start_type = OEXStartTypeNone;
-        }
+        
+        NSDate* start = [OEXDateFormatting dateWithServerString:[info objectForKey:@"start"]];
+        NSNumber* type = [types objectForKey:[info objectForKey:@"start_type"]] ?: @(OEXStartTypeNone);
+        self.start_display_info = [[OEXCourseStartDisplayInfo alloc]
+                                   initWithDate:start
+                                   displayDate:[info objectForKey:@"start_display"]
+                                   type:type.integerValue];
         self.course_image_url = [info objectForKey:@"course_image"];
         self.name = [info objectForKey:@"name"];
         self.org = [info objectForKey:@"org"];

--- a/Source/OEXCourseInfoTabViewController.m
+++ b/Source/OEXCourseInfoTabViewController.m
@@ -116,8 +116,8 @@ static const CGFloat OEXCourseInfoBlurRadius = 5;
                 }
             }
             else {
-                if(self.course.start) {
-                    NSString* formattedStartDate = [OEXDateFormatting formatAsMonthDayString:self.course.start];
+                if(self.course.start_display_info.date) {
+                    NSString* formattedStartDate = [OEXDateFormatting formatAsMonthDayString:self.course.start_display_info.date];
                     if(formattedStartDate) {
                         startEndDateString = [NSString stringWithFormat:@"%@ - %@", [OEXLocalizedString(@"STARTING", nil) oex_uppercaseStringInCurrentLocale], formattedStartDate];
                     }

--- a/Source/OEXCustomTabBarViewViewController.m
+++ b/Source/OEXCustomTabBarViewViewController.m
@@ -134,13 +134,13 @@
 }
 
 - (NSAttributedString*)msgFutureCourses {
-    NSString* strStartMessage = self.course.start_display;
+    NSString* displayDate = self.course.start_display_info.displayDate;
     NSMutableAttributedString* msgFutureCourses;
-    if(self.course.courseware_access.error_code == OEXStartDateError && self.course.start_type != OEXStartTypeNone) {
+    if(self.course.courseware_access.error_code == OEXStartDateError && self.course.start_display_info.type != OEXStartTypeNone && displayDate != nil) {
         NSString* localizedString = OEXLocalizedString(@"COURSE_WILL_START_AT", nil);
-        NSString* lblCourseMsg = [NSString oex_stringWithFormat:localizedString parameters:@{@"date" : strStartMessage}];
+        NSString* lblCourseMsg = [NSString oex_stringWithFormat:localizedString parameters:@{@"date" : displayDate}];
         msgFutureCourses = [[NSMutableAttributedString alloc] initWithString:lblCourseMsg];
-        NSRange range = [lblCourseMsg rangeOfString:strStartMessage];
+        NSRange range = [lblCourseMsg rangeOfString:displayDate];
         [msgFutureCourses setAttributes:@{NSFontAttributeName:[UIFont fontWithName:@"OpenSans-Semibold" size:self.lbl_NoCourseware.font.pointSize], NSForegroundColorAttributeName:[UIColor blackColor]} range:range];
     }
     else {
@@ -282,7 +282,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     // set Back button name to blank.
-    if(!self.course.isStartDateOld && self.course.start) {
+    if(!self.course.isStartDateOld && self.course.start_display_info.date) {
         self.lbl_NoCourseware.attributedText = [self msgFutureCourses];
     }
     else {

--- a/Source/OEXFrontCourseViewController.m
+++ b/Source/OEXFrontCourseViewController.m
@@ -355,7 +355,7 @@
             cell.btn_NewCourseContent.hidden = YES;
 
             // If both start and end dates are blank then show nothing.
-            if(obj_course.start == nil && obj_course.end == nil) {
+            if(obj_course.start_display_info.date == nil && obj_course.end == nil) {
                 cell.img_Starting.hidden = YES;
                 cell.lbl_Starting.hidden = YES;
             }
@@ -382,14 +382,14 @@
                 }
                 else {  // Start date is newer than current date
                     OEXAccessError error_code = obj_course.courseware_access.error_code;
-                    if(obj_course.start == nil || (error_code == OEXStartDateError && obj_course.start_type != OEXStartTypeTimestamp)) {
+                    if(obj_course.start_display_info.date == nil || (error_code == OEXStartDateError && obj_course.start_display_info.type != OEXStartTypeTimestamp)) {
                         cell.img_Starting.hidden = YES;
                         cell.img_NewCourse.hidden = YES;
                         cell.btn_NewCourseContent.hidden = YES;
                         cell.lbl_Starting.hidden = YES;
                     }
                     else {
-                        NSString* formattedStartDate = [OEXDateFormatting formatAsMonthDayString:obj_course.start];
+                        NSString* formattedStartDate = [OEXDateFormatting formatAsMonthDayString:obj_course.start_display_info.date];
                         cell.lbl_Starting.text = [NSString stringWithFormat:@"%@ - %@", [OEXLocalizedString(@"STARTING", nil) oex_uppercaseStringInCurrentLocale], formattedStartDate];
                     }
                 }

--- a/Source/OEXInterface+Swift.swift
+++ b/Source/OEXInterface+Swift.swift
@@ -21,4 +21,13 @@ extension OEXInterface : LastAccessedProvider {
     public func setLastAccessedSubSectionWithID(subsectionID: String, subsectionName: String, courseID: String?, timeStamp: String) {
         self.storage.setLastAccessedSubsection(subsectionID, andSubsectionName: subsectionName, forCourseID: courseID, onTimeStamp: timeStamp)
     }
+
+    public func courseStreamWithID(courseID : String) -> Stream<OEXCourse> {
+        if let course = self.courseWithID(courseID) {
+            return Stream(value: course)
+        }
+        else {
+            return Stream(error: NSError.oex_unknownError())
+        }
+    }
 }

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -167,9 +167,12 @@ extension OEXRouter {
         controller.presentViewController(navigationController, animated: true, completion: nil)
     }
     
-    func showHandouts(handoutsURLString : String?, fromViewController controller : UIViewController) {
-        let environment = CourseHandoutsViewControllerEnvironment(styles: self.environment.styles, networkManager: self.environment.networkManager)
-        let handoutsViewController = CourseHandoutsViewController(environment: environment, handoutsURLString: handoutsURLString)
+    func showHandoutsFromController(controller : UIViewController, courseID : String) {
+        let environment = CourseHandoutsViewController.Environment(
+            dataManager : self.environment.dataManager,
+            networkManager: self.environment.networkManager,
+            styles: self.environment.styles)
+        let handoutsViewController = CourseHandoutsViewController(environment: environment, courseID: courseID)
         controller.navigationController?.pushViewController(handoutsViewController, animated: true)
     }
 

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -152,8 +152,10 @@
 "COURSE_MODE_PICKER_DESCRIPTION" = "Mode Picker";
 /* Text displayed when Don't see one of your courses is tapped on My Courses screen */
 "COURSE_NOT_LISTED" = "We're working hard to make all of our courses mobile-friendly. If you don't see your course yet, it will be available soon - we're adding more every day!";
+/* Message shown on a course when it hasn't started yet.*/
+"COURSE_NOT_STARTED"="This course hasn't started yet.";
 /* Message shown on a course when it hasn't started yet. {date} will be a localized date string */
-"COURSE_WILL_START_AT"="This course hasn't started yet. Come back on {date} to see your videos.";
+"COURSE_WILL_START_AT"="This course hasn't started yet. Come back {date} to see your videos.";
 /* Create a new post button title used in discussions' posts screen */
 "CREATE_A_NEW_POST"="Create a new post";
 /* Support message email title */


### PR DESCRIPTION
- Groups course start date info separate from course for easier passing
  around.
- Introduces mechanism for automatically displaying styled errors.
- Checks course info before making request so we don't have to make
  requests we know are going to fail.

TODO: Precheck in announcements and discussions

JIRA: https://openedx.atlassian.net/browse/MA-841
JIRA: https://openedx.atlassian.net/browse/MA-698