### PR TITLE
iOS - Update how posts show

### DIFF
--- a/QLearnSDK/DiscussionObjectModel.swift
+++ b/QLearnSDK/DiscussionObjectModel.swift
@@ -79,6 +79,11 @@ public enum PostThreadType : String {
     case Discussion = "discussion"
 }
 
+public enum AuthorLabelType : String {
+    case Staff = "staff"
+    case CommunityTA = "community_ta"
+}
+
 struct DiscussionThread {
     var identifier: String?
     var type: PostThreadType?
@@ -90,7 +95,7 @@ struct DiscussionThread {
     var rawBody: String?
     var renderedBody: String?
     var author: String?
-    var authorLabel: String?
+    var authorLabel: AuthorLabelType?
     var commentCount = 0
     var commentListUrl: String?
     var hasEndorsed = false
@@ -119,7 +124,9 @@ struct DiscussionThread {
             rawBody = json["raw_body"].string
             renderedBody = json["rendered_body"].string
             author = json["author"].string
-            authorLabel = json["author_label"].string
+            if let authorLabelString = json["author_label"].string {
+                authorLabel = AuthorLabelType(rawValue: authorLabelString)
+            }
             commentCount = json["comment_count"].intValue
             commentListUrl = json["comment_list_url"].string
             hasEndorsed = json["has_endorsed"].boolValue

--- a/QLearnSDK/DiscussionObjectModel.swift
+++ b/QLearnSDK/DiscussionObjectModel.swift
@@ -82,6 +82,15 @@ public enum PostThreadType : String {
 public enum AuthorLabelType : String {
     case Staff = "staff"
     case CommunityTA = "community_ta"
+    
+    var localizedString : String {
+        switch self {
+        case .Staff:
+            return OEXLocalizedString("STAFF", nil)
+        case .CommunityTA:
+            return OEXLocalizedString("COMMUNITY_TA", nil)
+        }
+    }
 }
 
 struct DiscussionThread {

--- a/QLearnSDK/DiscussionObjectModel.swift
+++ b/QLearnSDK/DiscussionObjectModel.swift
@@ -105,6 +105,7 @@ struct DiscussionThread {
     var updatedAt: NSDate?
     var editableFields: String?
     var read = false
+    var unreadCommentCount = 0
     
     init?(json: JSON) {
         if let identifier = json["id"].string {
@@ -130,6 +131,8 @@ struct DiscussionThread {
             voted = json["voted"].boolValue
             voteCount = json["vote_count"].intValue
             read = json["read"].boolValue
+            unreadCommentCount = json["unread_comment_count"].intValue
+            
             if let dateStr = json["created_at"].string {
                 createdAt = OEXDateFormatting.dateWithServerString(dateStr)
             }

--- a/Source/DiscussionCommentsViewController.swift
+++ b/Source/DiscussionCommentsViewController.swift
@@ -137,9 +137,7 @@ class DiscussionCommentsViewController: UIViewController, UITableViewDataSource,
         addCommentButton.backgroundColor = OEXStyles.sharedStyles().primaryXDarkColor()
         
         let style = OEXTextStyle(weight : .Normal, size: .Small, color: OEXStyles.sharedStyles().neutralWhite())
-        let buttonTitle = NSAttributedString.joinInNaturalLayout(
-            before: Icon.Create.attributedTextWithStyle(style.withSize(.XSmall)),
-            after: style.attributedStringWithText(OEXLocalizedString("ADD_A_COMMENT", nil)))
+        let buttonTitle = NSAttributedString.joinInNaturalLayout([Icon.Create.attributedTextWithStyle(style.withSize(.XSmall)), style.attributedStringWithText(OEXLocalizedString("ADD_A_COMMENT", nil))])
         addCommentButton.setAttributedTitle(buttonTitle, forState: .Normal)
         addCommentButton.contentVerticalAlignment = .Center
         
@@ -244,9 +242,9 @@ class DiscussionCommentsViewController: UIViewController, UITableViewDataSource,
             cell.authorLabel.attributedText = smallTextStyle.attributedStringWithText(responseItem.author)
             cell.dateTimeLabel.attributedText = smallTextStyle.attributedStringWithText(responseItem.createdAt.timeAgoSinceNow())
             
-            let buttonTitle = NSAttributedString.joinInNaturalLayout(
-                before: Icon.Comment.attributedTextWithStyle(commentInfoStyle.withSize(.XSmall)),
-                after: commentInfoStyle.attributedStringWithText(NSString.oex_stringWithFormat(OEXLocalizedStringPlural("COMMENT", Float(comments.count), nil), parameters: ["count": Float(comments.count)])))
+            let buttonTitle = NSAttributedString.joinInNaturalLayout([
+                Icon.Comment.attributedTextWithStyle(commentInfoStyle.withSize(.XSmall)),
+                commentInfoStyle.attributedStringWithText(NSString.oex_stringWithFormat(OEXLocalizedStringPlural("COMMENT", Float(comments.count), nil), parameters: ["count": Float(comments.count)]))])
             cell.commentCountOrReportIconButton.setAttributedTitle(buttonTitle, forState: .Normal)
             return cell
         case .Some(.Comments):
@@ -258,9 +256,9 @@ class DiscussionCommentsViewController: UIViewController, UITableViewDataSource,
             }
             cell.backgroundColor = OEXStyles.sharedStyles().neutralXLight()
             
-            let buttonTitle = NSAttributedString.joinInNaturalLayout(
-                before: Icon.ReportFlag.attributedTextWithStyle(commentInfoStyle.withSize(.XSmall)),
-                after: commentInfoStyle.attributedStringWithText(OEXLocalizedString("DISCUSSION_REPORT", nil)))
+            let buttonTitle = NSAttributedString.joinInNaturalLayout([
+                Icon.ReportFlag.attributedTextWithStyle(commentInfoStyle.withSize(.XSmall)),
+                commentInfoStyle.attributedStringWithText(OEXLocalizedString("DISCUSSION_REPORT", nil))])
             cell.commentCountOrReportIconButton.setAttributedTitle(buttonTitle, forState: .Normal)
             cell.commentCountOrReportIconButton.row = indexPath.row
             cell.commentCountOrReportIconButton.oex_removeAllActions()

--- a/Source/DiscussionNewCommentViewController.swift
+++ b/Source/DiscussionNewCommentViewController.swift
@@ -120,12 +120,11 @@ public class DiscussionNewCommentViewController: UIViewController, UITextViewDel
             self.navigationItem.title = OEXLocalizedString("RESPONSE", nil)
             
         case let .Response(response):
-            answerTitle.attributedText = NSAttributedString.joinInNaturalLayout(
-                before: Icon.Answered.attributedTextWithStyle(answerStyle),
-                after: answerStyle.attributedStringWithText(OEXLocalizedString("ANSWER", nil)))
+            answerTitle.attributedText = NSAttributedString.joinInNaturalLayout([
+                Icon.Answered.attributedTextWithStyle(answerStyle),
+                answerStyle.attributedStringWithText(OEXLocalizedString("ANSWER", nil))])
             addCommentButton.applyButtonStyle(OEXStyles.sharedStyles().filledPrimaryButtonStyle, withTitle: OEXLocalizedString("ADD_COMMENT", nil))
 
-            // add place holder for the textview
             contentTextView.placeholder = addYourComment
             self.navigationItem.title = OEXLocalizedString("COMMENT", nil) 
         }

--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -126,9 +126,8 @@ class DiscussionPostCell: UITableViewCell {
             (reportButton, Icon.ReportFlag, OEXLocalizedString("DISCUSSION_REPORT", nil))
             ]
         {
-            let buttonText = NSAttributedString.joinInNaturalLayout(
-                before: icon.attributedTextWithStyle(cellButtonStyle),
-                after: cellButtonStyle.attributedStringWithText(text ?? ""))
+            let buttonText = NSAttributedString.joinInNaturalLayout([icon.attributedTextWithStyle(cellButtonStyle),
+                cellButtonStyle.attributedStringWithText(text ?? "")])
             button.setAttributedTitle(buttonText, forState:.Normal)
         }
     }
@@ -154,9 +153,8 @@ class DiscussionResponseCell: UITableViewCell {
             (reportButton, Icon.ReportFlag, OEXLocalizedString("DISCUSSION_REPORT", nil))]
         {
             let iconString = icon.attributedTextWithStyle(cellButtonStyle)
-            let buttonText = NSAttributedString.joinInNaturalLayout(
-                before: iconString,
-                after: cellButtonStyle.attributedStringWithText(text))
+            let buttonText = NSAttributedString.joinInNaturalLayout([iconString,
+                cellButtonStyle.attributedStringWithText(text)])
             button.setAttributedTitle(buttonText, forState:.Normal)
         }
 
@@ -221,9 +219,8 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         addResponseButton.backgroundColor = OEXStyles.sharedStyles().primaryXDarkColor()
 
         let footerStyle = OEXTextStyle(weight: .Normal, size: .Small, color: OEXStyles.sharedStyles().neutralWhite())
-        let buttonTitle = NSAttributedString.joinInNaturalLayout(
-            before: Icon.Create.attributedTextWithStyle(footerStyle.withSize(.XSmall)),
-            after: footerStyle.attributedStringWithText(OEXLocalizedString("ADD_A_RESPONSE", nil)))
+        let buttonTitle = NSAttributedString.joinInNaturalLayout([Icon.Create.attributedTextWithStyle(footerStyle.withSize(.XSmall)),
+            footerStyle.attributedStringWithText(OEXLocalizedString("ADD_A_RESPONSE", nil))])
         addResponseButton.setAttributedTitle(buttonTitle, forState: .Normal)
                 
         addResponseButton.contentVerticalAlignment = .Center
@@ -326,7 +323,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         
         let icon = Icon.Comment.attributedTextWithStyle(responseCountStyle)
         let countLabelText = NSAttributedString(string: NSString.oex_stringWithFormat(OEXLocalizedStringPlural("RESPONSE", Float(responses.count), nil), parameters: ["count": Float(responses.count)]))
-        let labelText = NSAttributedString.joinInNaturalLayout(before: icon, after: countLabelText)
+        let labelText = NSAttributedString.joinInNaturalLayout([icon,countLabelText])
         
         cell.responseCountLabel.attributedText = labelText
         
@@ -403,7 +400,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         let iconText = Icon.Comment.attributedTextWithStyle(responseMessageStyle)
         let styledPrompt = responseMessageStyle.attributedStringWithText(prompt)
         let title =
-        NSAttributedString.joinInNaturalLayout(before: iconText, after: styledPrompt)
+        NSAttributedString.joinInNaturalLayout([iconText,styledPrompt])
         UIView.performWithoutAnimation {
             cell.commentButton.setAttributedTitle(title, forState: .Normal)
         }
@@ -470,9 +467,8 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
 
     private func updateVoteText(button: DiscussionCellButton, voteCount: Int, voted: Bool) {
         // TODO: show upvote and downvote depending on voted?
-        let buttonText = NSAttributedString.joinInNaturalLayout(
-            before: Icon.UpVote.attributedTextWithStyle(cellButtonStyle),
-            after: cellButtonStyle.attributedStringWithText(NSString.oex_stringWithFormat(OEXLocalizedStringPlural("VOTE", Float(voteCount), nil), parameters: ["count": Float(voteCount)])))
+        let buttonText = NSAttributedString.joinInNaturalLayout([Icon.UpVote.attributedTextWithStyle(cellButtonStyle),
+            cellButtonStyle.attributedStringWithText(NSString.oex_stringWithFormat(OEXLocalizedStringPlural("VOTE", Float(voteCount), nil), parameters: ["count": Float(voteCount)]))])
         
         UIView.performWithoutAnimation {
             button.setAttributedTitle(buttonText, forState:.Normal)
@@ -480,9 +476,8 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
     }
     
     private func updateFollowText(button: DiscussionCellButton, following: Bool) {
-        let buttonText = NSAttributedString.joinInNaturalLayout(
-            before: Icon.FollowStar.attributedTextWithStyle(cellButtonStyle),
-            after: cellButtonStyle.attributedStringWithText(OEXLocalizedString(following ? "DISCUSSION_UNFOLLOW" : "DISCUSSION_FOLLOW", nil)))
+        let buttonText = NSAttributedString.joinInNaturalLayout([Icon.FollowStar.attributedTextWithStyle(cellButtonStyle),
+            cellButtonStyle.attributedStringWithText(OEXLocalizedString(following ? "DISCUSSION_UNFOLLOW" : "DISCUSSION_FOLLOW", nil))])
         button.setAttributedTitle(buttonText, forState:.Normal)
     }
 

--- a/Source/NSAttributedString+Combination.swift
+++ b/Source/NSAttributedString+Combination.swift
@@ -9,13 +9,20 @@
 import UIKit
 
 extension NSAttributedString {
-    class func joinInNaturalLayout(#before : NSAttributedString, after : NSAttributedString) -> NSAttributedString {
-        let params = ["before" : before, "after" : after]
-        switch UIApplication.sharedApplication().userInterfaceLayoutDirection {
-        case .LeftToRight:
-            return NSAttributedString(string: "{before} {after}").oex_formatWithParameters(params)
-        case .RightToLeft:
-            return NSAttributedString(string: "{after} {before}").oex_formatWithParameters(params)
+    
+    class func joinInNaturalLayout(var attributedStrings : [NSAttributedString]) -> NSAttributedString {
+        
+        if UIApplication.sharedApplication().userInterfaceLayoutDirection == .RightToLeft {
+            attributedStrings = attributedStrings.reverse()
         }
+        
+        let blankSpace = NSAttributedString(string : " ")
+        var resultString = NSMutableAttributedString()
+        
+        for (index,attrString) in enumerate(attributedStrings) {
+            if index != 0 { resultString.appendAttributedString(blankSpace) }
+            resultString.appendAttributedString(attrString)
+        }
+        return resultString
     }
 }

--- a/Source/PostTitleByTableViewCell.swift
+++ b/Source/PostTitleByTableViewCell.swift
@@ -115,7 +115,7 @@ class PostTitleByTableViewCell: UITableViewCell {
         self.titleText = post.title
         var options = [NSAttributedString]()
         if post.pinned {
-            if let authorLabelString = post.authorLabel?.rawValue, pinnedAttributedString = styledCellTextWithIcon(.Pinned, text: authorLabelString) {
+            if let authorLabelString = post.authorLabel?.localizedString, pinnedAttributedString = styledCellTextWithIcon(.Pinned, text: authorLabelString) {
                 options.append(pinnedAttributedString)
             }
         }

--- a/Source/PostTitleByTableViewCell.swift
+++ b/Source/PostTitleByTableViewCell.swift
@@ -115,7 +115,7 @@ class PostTitleByTableViewCell: UITableViewCell {
         self.titleText = post.title
         var options = [NSAttributedString]()
         if post.pinned {
-            if let pinnedAttributedString = styledCellTextWithIcon(.Pinned, text: post.authorLabel) {
+            if let authorLabelString = post.authorLabel?.rawValue, pinnedAttributedString = styledCellTextWithIcon(.Pinned, text: authorLabelString) {
                 options.append(pinnedAttributedString)
             }
         }

--- a/Source/PostsViewController.swift
+++ b/Source/PostsViewController.swift
@@ -8,12 +8,14 @@
 
 import UIKit
 
+
+
 public struct DiscussionPostItem {
 
     public let title: String
     public let body: String
     public let author: String
-    public let authorLabel : String?
+    public let authorLabel : AuthorLabelType?
     public let createdAt: NSDate
     public let count: Int
     public let threadID: String
@@ -31,7 +33,7 @@ public struct DiscussionPostItem {
         title: String,
         body: String,
         author: String,
-        authorLabel: String?,
+        authorLabel: AuthorLabelType?,
         createdAt: NSDate,
         count: Int,
         threadID: String,
@@ -373,12 +375,12 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
                     
                     for discussionThread in threads {
                         if let item = self?.postItem(fromDiscussionThread: discussionThread) {
-                            self?.posts.append(item)
-                        }
+                            self?.posts.append(item)                        }
                     }
                 }
-                self?.tableView.reloadData()
                 self?.loadController.state = .Loaded
+                self?.tableView.reloadData()
+                
             }
         }
     }

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -218,6 +218,8 @@
 "FLOATING_ERROR_LOGIN_TITLE"="Sign-in Error";
 /* Title of overlay message shown when reset password fails */
 "FLOATING_ERROR_TITLE"="Reset Password Error";
+/* Text used when a user is following a post on the posts screen */
+"FOLLOWING"="Following";
 /* Google login method */
 "GOOGLE"="Google";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -116,6 +116,8 @@
 "COMMENTS_TO_RESPONSE##{one}"="{count} Comment";
 /* Discussion comment (Posts screen) - {count} is a number of comments */
 "COMMENTS_TO_RESPONSE##{other}"="{count} Comments";
+/* Label for posts pinned by Community TA(s)"
+"COMMUNITY_TA"="Community TA";
 /* Back bar button title of course */
 "COURSE"="Course";
 /* Title of tab showing course content */
@@ -380,6 +382,8 @@
 "SIGN_IN_BUTTON_TEXT_ON_SIGINING"="Signing in...";
 /* Label for date when course starts */
 "STARTING"="Starting";
+/* Label for posts pinned by Staff */
+"STAFF"="Staff";
 /* Button allowing user to submit feedback about the app via email */
 "SUBMIT_FEEDBACK" = "Submit Feedback";
 /* Alert dialog title shown when network request takes too long to complete */

--- a/Test/DiscussionNewCommentViewControllerTests.swift
+++ b/Test/DiscussionNewCommentViewControllerTests.swift
@@ -20,15 +20,18 @@ class DiscussionNewCommentViewControllerTests: SnapshotTestCase {
             title: "Some Post",
             body: "Lorem ipsum dolor sit amet",
             author: "Test Person",
+            authorLabel: AuthorLabelType.Staff,
             createdAt: NSDate(timeIntervalSince1970: 12345),
             count: 3,
             threadID: "123",
             following: false,
             flagged: false,
+            pinned: false,
             voted: true,
             voteCount: 4,
             type : .Discussion,
-            read : true
+            read : true,
+            unreadCommentCount: 0
         )
         let controller = DiscussionNewCommentViewController(environment: environment, courseID: courseID, item : DiscussionItem.Post(post))
         inScreenNavigationContext(controller, action: {


### PR DESCRIPTION
1a) Flagged would not show up on this screen 
1b) Pinned first then following 
1c) If you are following a pinned post show both
2) Let me clarify that we shouldn't be showing author information on this screen. I believe you're referring to pinning. If a post is pinned it can only be pinned by a staff or TA and that's the label we're sharing. Who pinned the post not the author. So there shouldn't be a case that a label appears without an icon.