### PR TITLE
hide G+ login on screen if no api key is provided MA-1154

### DIFF
--- a/Source/OEXGoogleConfig.m
+++ b/Source/OEXGoogleConfig.m
@@ -8,6 +8,12 @@
 
 #import "OEXGoogleConfig.h"
 
+@interface OEXGoogleConfig () {
+    BOOL _enabled;
+}
+
+@end
+
 @implementation OEXGoogleConfig
 
 - (instancetype)initWithDictionary:(NSDictionary*)dictionary {
@@ -17,6 +23,12 @@
         _apiKey = dictionary[@"GOOGLE_PLUS_KEY"];
     }
     return self;
+}
+
+- (BOOL)isEnabled
+{
+    //In order for Google+ To work, the API Key must also be set. 
+    return _enabled && _apiKey != nil;
 }
 
 @end


### PR DESCRIPTION
like all good 3p login libraries, our g+ crashes if no key is provided. This fix just keeps the g+ login disabled while no key is provided.