### PR TITLE
Posts screen Cell details now match spec

### DIFF
--- a/Source/PostTitleByTableViewCell.swift
+++ b/Source/PostTitleByTableViewCell.swift
@@ -119,16 +119,16 @@ class PostTitleByTableViewCell: UITableViewCell {
         self.titleText = post.title
         var options = [NSAttributedString]()
         if post.pinned {
-            //TODO : Refactor this when the API changes to always return authorLabel when Pinned is true
             options.append(Icon.Pinned.attributedTextWithStyle(cellDetailTextStyle))
-            options.append(cellDetailTextStyle.attributedStringWithText(post.authorLabel?.localizedString))
         }
         
         if post.following {
-            if let followingAttributedString = styledCellTextWithIcon(.FollowStar, text: OEXLocalizedString("FOLLOWING", nil)) {
-                options.append(followingAttributedString)
-            }
-            
+            options.append(Icon.FollowStar.attributedTextWithStyle(cellDetailTextStyle))
+        }
+        
+        if let authorLabel = post.authorLabel?.localizedString {
+            let authorLabelText = NSString.oex_stringWithFormat(OEXLocalizedString("BY", nil), parameters: ["authorName" : authorLabel])
+            options.append(cellDetailTextStyle.attributedStringWithText(authorLabelText))
         }
         
         self.hasByText = post.hasByText

--- a/Source/PostsViewController.swift
+++ b/Source/PostsViewController.swift
@@ -64,7 +64,7 @@ public struct DiscussionPostItem {
     }
     
     var hasByText : Bool {
-        return following || pinned
+        return following || pinned || self.authorLabel != nil
     }
 
 }

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -92,6 +92,8 @@
 "ANNOUNCEMENT_UNAVAILABLE"="There are currently no announcements for this course.";
 /* Label indicating the response answer in Discussion Add comment screen */
 "ANSWER"="Answer";
+/* Prefix used with Staff of Community TA on the posts screen */
+"BY" = "By {authorName}";
 /* Title of course announcements section */
 "COURSE_ANNOUNCEMENTS"="Announcements";
 /* Title of course handouts section */
@@ -234,8 +236,6 @@
 "FLOATING_ERROR_LOGIN_TITLE"="Sign-in Error";
 /* Title of overlay message shown when reset password fails */
 "FLOATING_ERROR_TITLE"="Reset Password Error";
-/* Text used when a user is following a post on the posts screen */
-"FOLLOWING"="Following";
 /* Google login method */
 "GOOGLE"="Google";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */


### PR DESCRIPTION
Alright, here's the implementation we'll go with:
For the labels, we should show them as follows, in the marked orders:
1st (if present): "Pinned" should just show the "Pinned" icon (no text label).
2nd (if present): "Following" should show the star icon (no text label). (This is different than currently implemented – right now there is a text label.)
3rd (if present): Author label ("By Staff", "By Community TA", "By Admin") with no icon. Note that I've added the word "By" to further clarify that this label indicates authorship.