### PR TITLE
iOS - Discussions - Closed post functionality do not work

### DIFF
--- a/Source/DiscussionCommentsViewController.swift
+++ b/Source/DiscussionCommentsViewController.swift
@@ -143,11 +143,12 @@ class DiscussionCommentsViewController: UIViewController, UITableViewDataSource,
             addCommentButton.backgroundColor = commentsClosed ? styles.neutralBase() : styles.primaryXDarkColor()
             
             let textStyle = OEXTextStyle(weight : .Normal, size: .Small, color: OEXStyles.sharedStyles().neutralWhite())
-            let icon = iconOrClosedIconIfClosed(Icon.Create).attributedTextWithStyle(textStyle.withSize(.XSmall))
+            let icon = commentsClosed ? Icon.Closed : Icon.Create
             let buttonText = commentsClosed ? OEXLocalizedString("COMMENTS_CLOSED", nil) : OEXLocalizedString("ADD_A_COMMENT", nil)
-            let buttonTitle = NSAttributedString.joinInNaturalLayout([icon, textStyle.attributedStringWithText(buttonText)])
+            let buttonTitle = NSAttributedString.joinInNaturalLayout([icon.attributedTextWithStyle(textStyle.withSize(.XSmall)), textStyle.attributedStringWithText(buttonText)])
             
             addCommentButton.setAttributedTitle(buttonTitle, forState: .Normal)
+            addCommentButton.enabled = !commentsClosed
             
             if (!commentsClosed) {
                 addCommentButton.oex_addAction({[weak self] (action : AnyObject!) -> Void in
@@ -329,9 +330,5 @@ class DiscussionCommentsViewController: UIViewController, UITableViewDataSource,
             assert(false, "Unknown table section")
             return UITableViewCell()
         }
-    }
-    
-    private func iconOrClosedIconIfClosed(icon : Icon) -> Icon {
-        return commentsClosed ? Icon.Closed : icon
     }
 }

--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -222,7 +222,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
             let styles = OEXStyles.sharedStyles()
             let footerStyle = OEXTextStyle(weight: .Normal, size: .Small, color: OEXStyles.sharedStyles().neutralWhite())
             
-            let icon = iconOrClosedIconIfClosed(Icon.Create)
+            let icon = postClosed ? Icon.Closed : Icon.Create
             let text = postClosed ? OEXLocalizedString("RESPONSES_CLOSED", nil) : OEXLocalizedString("ADD_A_RESPONSE", nil)
             
             let buttonTitle = NSAttributedString.joinInNaturalLayout([icon.attributedTextWithStyle(footerStyle.withSize(.XSmall)),
@@ -230,6 +230,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
             
             addResponseButton.setAttributedTitle(buttonTitle, forState: .Normal)
             addResponseButton.backgroundColor = postClosed ? styles.neutralBase() : styles.primaryXDarkColor()
+            addResponseButton.enabled = !postClosed
             
             if !postClosed {
                 addResponseButton.oex_addAction({ [weak self] (action : AnyObject!) -> Void in
@@ -480,7 +481,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         
         if commentCount == 0 {
             prompt = postClosed ? OEXLocalizedString("COMMENTS_CLOSED", nil) : OEXLocalizedString("ADD_A_COMMENT", nil)
-            icon = iconOrClosedIconIfClosed(Icon.Comment)
+            icon = postClosed ? Icon.Closed : Icon.Comment
         }
         else {
             prompt = NSString.oex_stringWithFormat(OEXLocalizedStringPlural("COMMENTS_TO_RESPONSE", Float(commentCount), nil), parameters: ["count": commentCount])
@@ -607,10 +608,6 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
     
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         // TODO
-    }
-    
-    private func iconOrClosedIconIfClosed(icon : Icon) -> Icon {
-        return postClosed ? Icon.Closed : icon
     }
     
 }

--- a/Source/Icon.swift
+++ b/Source/Icon.swift
@@ -114,6 +114,8 @@ class FontAwesomeRenderer : IconRenderer {
             return .History
         case .VideoShrink:
             return .Compress
+        case .Closed:
+            return .Lock
         }
     }
     
@@ -189,6 +191,7 @@ public enum Icon {
     case ArrowDown
     case CircleO
     case CheckCircleO
+    case Closed
     case Comment
     case Comments
     case Courseware

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -115,11 +115,11 @@ extension OEXRouter {
         controller.navigationController?.pushViewController(responsesViewController, animated: true)
     }
     
-    func showDiscussionCommentsFromViewController(controller: UIViewController, courseID : String, item : DiscussionResponseItem) {
+    func showDiscussionCommentsFromViewController(controller: UIViewController, courseID : String, item : DiscussionResponseItem, closed : Bool) {
         let environment = DiscussionCommentsViewController.Environment(
             courseDataManager: self.environment.dataManager.courseDataManager,
             router: self, networkManager : self.environment.networkManager)
-        let commentsVC = DiscussionCommentsViewController(environment: environment, courseID : courseID, responseItem: item)
+        let commentsVC = DiscussionCommentsViewController(environment: environment, courseID : courseID, responseItem: item, closed: closed)
         controller.navigationController?.pushViewController(commentsVC, animated: true)
     }
     

--- a/Source/PostTitleByTableViewCell.swift
+++ b/Source/PostTitleByTableViewCell.swift
@@ -118,6 +118,10 @@ class PostTitleByTableViewCell: UITableViewCell {
         self.typeText = iconForType(post.type).attributedTextWithStyle(cellTextStyle)
         self.titleText = post.title
         var options = [NSAttributedString]()
+        
+        if post.closed {
+            options.append(Icon.Closed.attributedTextWithStyle(cellDetailTextStyle))
+        }
         if post.pinned {
             //TODO : Refactor this when the API changes to always return authorLabel when Pinned is true
             options.append(Icon.Pinned.attributedTextWithStyle(cellDetailTextStyle))

--- a/Source/PostsViewController.swift
+++ b/Source/PostsViewController.swift
@@ -27,6 +27,7 @@ public struct DiscussionPostItem {
     public var type : PostThreadType
     public var read = false
     public let unreadCommentCount : Int
+    public var closed = false
     
     // Unfortunately there's no way to make the default constructor public
     public init(
@@ -44,7 +45,8 @@ public struct DiscussionPostItem {
         voteCount: Int,
         type : PostThreadType,
         read : Bool,
-        unreadCommentCount : Int
+        unreadCommentCount : Int,
+        closed : Bool
         ) {
             self.title = title
             self.body = body
@@ -61,6 +63,7 @@ public struct DiscussionPostItem {
             self.type = type
             self.read = read
             self.unreadCommentCount = unreadCommentCount
+            self.closed = closed
     }
     
     var hasByText : Bool {
@@ -414,7 +417,8 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
                     voteCount: thread.voteCount,
                     type : thread.type ?? .Discussion,
                     read : thread.read,
-                    unreadCommentCount : thread.unreadCommentCount)
+                    unreadCommentCount : thread.unreadCommentCount,
+                    closed : thread.closed)
         }
         return nil
     }

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -126,11 +126,13 @@
 "COMMENT##{other}"="{count} comments";
 /* Discussion comments */
 "COMMENTS"="Comments";
+/* Text displayed when comments are disabled for a Response */
+"COMMENTS_CLOSED" = "Comments are closed for this response";
 /* Discussion comment (Posts screen) - {count} is a number of comments */
 "COMMENTS_TO_RESPONSE##{one}"="{count} Comment";
 /* Discussion comment (Posts screen) - {count} is a number of comments */
 "COMMENTS_TO_RESPONSE##{other}"="{count} Comments";
-/* Label for posts pinned by Community TA(s)"
+/* Label for posts pinned by Community TA(s)" */
 "COMMUNITY_TA"="Community TA";
 /* Back bar button title of course */
 "COURSE"="Course";
@@ -344,6 +346,8 @@
 "REDIRECT_TEXT" = "By signing in to this app, you agree to the";
 /* Label before Sort and Filter buttons on Posts Screen */
 "REFINE" = "Refine:";
+/* Button title when responses are closed for a thread */
+"RESPONSES_CLOSED"="Responses are closed for this post";
 /* Title of registration agreement */
 "REGISTRATION_AGREEMENT_BUTTON_TITLE"="edX Terms of Service and Honor Code";
 /* Create account agreement. Followed by list of agreement names like "End User License Agreement" */

--- a/Test/DiscussionNewCommentViewControllerTests.swift
+++ b/Test/DiscussionNewCommentViewControllerTests.swift
@@ -31,7 +31,8 @@ class DiscussionNewCommentViewControllerTests: SnapshotTestCase {
             voteCount: 4,
             type : .Discussion,
             read : true,
-            unreadCommentCount: 0
+            unreadCommentCount: 0,
+            closed : false
         )
         let controller = DiscussionNewCommentViewController(environment: environment, courseID: courseID, item : DiscussionItem.Post(post))
         inScreenNavigationContext(controller, action: {


### PR DESCRIPTION
Closed functionality is implemented, however ACCESS CONTROL (cases where a previllaged role can override the closed status) is pending.

#### Posts Screen
![ios simulator screen shot 08-sep-2015 5 49 38 pm](https://cloud.githubusercontent.com/assets/10597112/9735230/b992dce2-5652-11e5-9158-f8f6b30d9cc4.png)

#### Responses Screen
![ios simulator screen shot 08-sep-2015 5 49 45 pm](https://cloud.githubusercontent.com/assets/10597112/9735243/ce1beda2-5652-11e5-8913-2335f1baf208.png)

#### Comments Screen
![ios simulator screen shot 08-sep-2015 5 49 52 pm](https://cloud.githubusercontent.com/assets/10597112/9735236/c4045ba6-5652-11e5-9ca5-3eab9279eb40.png)




