### PR TITLE
Add standard logging class. Use with analytics.

### DIFF
--- a/Source/Logger+OEXObjC.h
+++ b/Source/Logger+OEXObjC.h
@@ -1,0 +1,13 @@
+//
+//  Logger+OEXObjC.h
+//  edX
+//
+//  Created by Akiva Leffert on 9/15/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import "edX-Swift.h"
+
+#define OEXLogDebug(domain, message) [Logger logError:domain :message file: @"" __FILE__ line:__LINE__]
+#define OEXLogInfo(domain, message) [Logger logInfo:domain :message file: @"" __FILE__ line:__LINE__]
+#define OEXLogError(domain, message) [Logger logError:domain :message file: @"" __FILE__ line:__LINE__]

--- a/Source/Logger+OEXObjC.h
+++ b/Source/Logger+OEXObjC.h
@@ -8,6 +8,14 @@
 
 #import "edX-Swift.h"
 
-#define OEXLogDebug(domain, message) [Logger logError:domain :message file: @"" __FILE__ line:__LINE__]
-#define OEXLogInfo(domain, message) [Logger logInfo:domain :message file: @"" __FILE__ line:__LINE__]
-#define OEXLogError(domain, message) [Logger logError:domain :message file: @"" __FILE__ line:__LINE__]
+#define OEXLogDebug(_domain, _format, ...) [Logger logDebug:_domain file: @"" __FILE__ line:__LINE__ format:_format, ##__VA_ARGS__]
+#define OEXLogInfo(_domain, _format, ...) [Logger logInfo:_domain file: @"" __FILE__ line:__LINE__ format:_format, ##__VA_ARGS__]
+#define OEXLogError(_domain, _format, ...) [Logger logError:_domain file: @"" __FILE__ line:__LINE__ format:_format, ##__VA_ARGS__]
+
+@interface Logger (OEXObjC)
+
++ (void)logDebug:(NSString*)domain file:(NSString*)file line:(NSUInteger)line format:(NSString*)format, ... NS_FORMAT_FUNCTION(4, 5);
++ (void)logInfo:(NSString*)domain file:(NSString*)file line:(NSUInteger)line format:(NSString*)format, ... NS_FORMAT_FUNCTION(4, 5);
++ (void)logError:(NSString*)domain file:(NSString*)file line:(NSUInteger)line format:(NSString*)format, ... NS_FORMAT_FUNCTION(4, 5);
+
+@end

--- a/Source/Logger+OEXObjC.m
+++ b/Source/Logger+OEXObjC.m
@@ -1,0 +1,10 @@
+//
+//  Logger+OEXObjC.m
+//  edX
+//
+//  Created by Akiva Leffert on 9/15/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+#import "Logger+OEXObjC.h"
+

--- a/Source/Logger+OEXObjC.m
+++ b/Source/Logger+OEXObjC.m
@@ -8,3 +8,27 @@
 
 #import "Logger+OEXObjC.h"
 
+@implementation Logger (OEXObjC)
+
++ (void)logDebug:(NSString *)domain file:(NSString *)file line:(NSUInteger)line format:(NSString *)format, ... {
+    va_list vaArguments;
+    va_start(vaArguments, format);
+    NSString* message = [[NSString alloc] initWithFormat:format arguments:vaArguments];
+    [self logDebug:domain :message file:file line:line];
+}
+
++ (void)logInfo:(NSString *)domain file:(NSString *)file line:(NSUInteger)line format:(NSString *)format, ... {
+    va_list vaArguments;
+    va_start(vaArguments, format);
+    NSString* message = [[NSString alloc] initWithFormat:format arguments:vaArguments];
+    [self logInfo:domain :message file:file line:line];
+}
+
++ (void)logError:(NSString *)domain file:(NSString *)file line:(NSUInteger)line format:(NSString *)format, ... {
+    va_list vaArguments;
+    va_start(vaArguments, format);
+    NSString* message = [[NSString alloc] initWithFormat:format arguments:vaArguments];
+    [self logError:domain :message file:file line:line];
+}
+
+@end

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -1,0 +1,117 @@
+//
+//  Logger.swift
+//  edX
+//
+//  Created by Akiva Leffert on 9/11/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+import UIKit
+
+public protocol LoggerSink {
+    func log(level : Logger.Level, domain : String, message : String)
+}
+
+private class ConsoleLogger : LoggerSink {
+    private func log(level: Logger.Level, domain: String, message: String) {
+        NSLog("[\(level.rawValue)|\(domain)] \(message)")
+    }
+}
+
+public class Logger : NSObject {
+    private let printAllKey = "OEXLoggerPrintAll"
+    private let domainsKey = "OEXLoggerDomains"
+    
+    public static var sharedLogger : Logger = Logger()
+    
+    public enum Level : String {
+        case Debug = "DEBUG" // Never commit anything with this. Easy way to add logs that are obviously meant to be removed
+        case Info = "INFO" // For l
+        case Error = "ERROR" // For errors that should *always* be printed
+        
+        private var alwaysPrinted : Bool {
+            switch self {
+            case .Debug, .Error: return true
+            case .Info: return false
+            }
+        }
+    }
+    
+    public override init() {
+        printAll = NSUserDefaults.standardUserDefaults().boolForKey(printAllKey)
+        activeDomains = Set(NSUserDefaults.standardUserDefaults().objectForKey(domainsKey) as? [String] ?? [])
+        super.init()
+    }
+    
+    private var sinks : [LoggerSink] = [ConsoleLogger()]
+    
+    public func addSink(sink : LoggerSink) {
+        sinks.append(sink)
+    }
+    
+    public var printAll : Bool
+        {
+        didSet {
+            NSUserDefaults.standardUserDefaults().setBool(printAll, forKey: printAllKey)
+        }
+    }
+    
+    private var activeDomains : Set<String> {
+        didSet {
+            domainsChanged()
+        }
+    }
+    
+    private func domainsChanged() {
+        NSUserDefaults.standardUserDefaults().setObject(Array(activeDomains) as NSArray, forKey: domainsKey)
+    }
+    
+    public func addDomain(domain : String) {
+        activeDomains.insert(domain)
+        domainsChanged()
+    }
+    
+    public func removeDomain(domain : String) {
+        activeDomains.remove(domain)
+        domainsChanged()
+    }
+   
+    // Domains are filtered out by default. To enable, hit pause in the debugger and do
+    // lldb> call Logger.addDomain(domain)
+    public func log(_ level : Level = .Info, _ domain : String, _ message : String) {
+        if (activeDomains.contains(domain) || level.alwaysPrinted) || printAll {
+            for sink in sinks {
+                sink.log(level, domain: domain, message: message)
+            }
+        }
+    }
+    
+}
+
+// MARK: Static conveniences
+extension Logger {
+
+    public static func addDomain(domain : String) {
+        sharedLogger.addDomain(domain)
+    }
+    
+    public static func removeDomain(domain : String) {
+        sharedLogger.removeDomain(domain)
+    }
+    
+    private static func log(level : Level = .Info, _ domain : String, _ message : String) {
+        sharedLogger.log(level, domain, message)
+    }
+    
+    public static func logDebug(domain : String, _ message : String) {
+        sharedLogger.log(.Debug, domain, message)
+    }
+    
+    public static func logInfo(domain : String, _ message : String) {
+        sharedLogger.log(.Info, domain, message)
+    }
+    
+    public static func logError(domain : String, _ message : String) {
+        sharedLogger.log(.Error, domain, message)
+    }
+}

--- a/Source/Logger.swift
+++ b/Source/Logger.swift
@@ -9,12 +9,12 @@
 import UIKit
 
 public protocol LoggerSink {
-    func log(level : Logger.Level, domain : String, message : String)
+    func log(level : Logger.Level, domain : String, message : String, file : String, line : UInt)
 }
 
 private class ConsoleLogger : LoggerSink {
-    private func log(level: Logger.Level, domain: String, message: String) {
-        NSLog("[\(level.rawValue)|\(domain)] \(message)")
+    private func log(level: Logger.Level, domain: String, message: String, file : String, line : UInt) {
+        NSLog("[\(level.rawValue)|\(domain)] @ \(file.lastPathComponent):\(line) - \(message)")
     }
 }
 
@@ -78,10 +78,10 @@ public class Logger : NSObject {
    
     // Domains are filtered out by default. To enable, hit pause in the debugger and do
     // lldb> call Logger.addDomain(domain)
-    public func log(_ level : Level = .Info, _ domain : String, _ message : String) {
+    public func log(_ level : Level = .Info, _ domain : String, _ message : String, file : String = __FILE__, line : UInt = __LINE__ ) {
         if (activeDomains.contains(domain) || level.alwaysPrinted) || printAll {
             for sink in sinks {
-                sink.log(level, domain: domain, message: message)
+                sink.log(level, domain: domain, message: message, file:file, line:line)
             }
         }
     }
@@ -99,19 +99,19 @@ extension Logger {
         sharedLogger.removeDomain(domain)
     }
     
-    private static func log(level : Level = .Info, _ domain : String, _ message : String) {
-        sharedLogger.log(level, domain, message)
+    private static func log(level : Level = .Info, _ domain : String, _ message : String, file : String = __FILE__, line : UInt = __LINE__) {
+        sharedLogger.log(level, domain, message, file:file, line:line)
     }
     
-    public static func logDebug(domain : String, _ message : String) {
-        sharedLogger.log(.Debug, domain, message)
+    public static func logDebug(domain : String, _ message : String, file : String = __FILE__, line : UInt = __LINE__) {
+        sharedLogger.log(.Debug, domain, message, file:file, line:line)
     }
     
-    public static func logInfo(domain : String, _ message : String) {
-        sharedLogger.log(.Info, domain, message)
+    public static func logInfo(domain : String, _ message : String, file : String = __FILE__, line : UInt = __LINE__) {
+        sharedLogger.log(.Info, domain, message, file:file, line:line)
     }
     
-    public static func logError(domain : String, _ message : String) {
-        sharedLogger.log(.Error, domain, message)
+    public static func logError(domain : String, _ message : String, file : String = __FILE__, line : UInt = __LINE__) {
+        sharedLogger.log(.Error, domain, message, file:file, line:line)
     }
 }

--- a/Source/LoggingAnalyticsTracker.swift
+++ b/Source/LoggingAnalyticsTracker.swift
@@ -1,0 +1,29 @@
+//
+//  LoggingAnalyticsTracker.swift
+//  edX
+//
+//  Created by Akiva Leffert on 9/11/15.
+//  Copyright (c) 2015 edX. All rights reserved.
+//
+
+import UIKit
+
+class LoggingAnalyticsTracker: NSObject, OEXAnalyticsTracker {
+    private let ANALYTICS = "ANALYTICS"
+    
+    func identifyUser(user: OEXUserDetails) {
+        Logger.logInfo(ANALYTICS, "Identified User: \(user)")
+    }
+    
+    func clearIdentifiedUser() {
+        Logger.logInfo(ANALYTICS, "Clear Identified User")
+    }
+    
+    func trackEvent(event: OEXAnalyticsEvent, forComponent component: String?, withProperties properties: [NSObject : AnyObject]) {
+        Logger.logInfo(ANALYTICS, "Track Event: \(event), component: \(component), properties: \(properties)")
+    }
+    
+    func trackScreenWithName(screenName: String) {
+        Logger.logInfo(ANALYTICS, "Track Screen Named: \(screenName)")
+    }
+}

--- a/Source/OEXAnalyticsTracker.h
+++ b/Source/OEXAnalyticsTracker.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class OEXAnalyticsEvent;
 @class OEXUserDetails;
 
@@ -16,8 +18,10 @@
 - (void)identifyUser:(OEXUserDetails*)user;
 - (void)clearIdentifiedUser;
 
-- (void)trackEvent:(OEXAnalyticsEvent*)event forComponent:(NSString*)component withProperties:(NSDictionary*)properties;
+- (void)trackEvent:(OEXAnalyticsEvent*)event forComponent:(nullable NSString*)component withProperties:(NSDictionary*)properties;
 
 - (void)trackScreenWithName:(NSString*)screenName;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/OEXEnvironment.h
+++ b/Source/OEXEnvironment.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @class DataManager;
+@class Logger;
 @class NetworkManager;
 @class OEXAnalytics;
 @class OEXConfig;
@@ -22,6 +23,7 @@
 
 - (void)setupEnvironment;
 
+@property (strong, nonatomic) Logger* (^ loggerBuilder)(OEXEnvironment* env);
 @property (strong, nonatomic) OEXAnalytics* (^ analyticsBuilder)(OEXEnvironment* env);
 @property (strong, nonatomic) OEXConfig* (^ configBuilder)(OEXEnvironment* env);
 @property (strong, nonatomic) DataManager* (^ dataManagerBuilder)(OEXEnvironment* env);

--- a/Source/OEXEnvironment.m
+++ b/Source/OEXEnvironment.m
@@ -27,6 +27,7 @@
 @property (strong, nonatomic) OEXAnalytics* analytics;
 @property (strong, nonatomic) OEXConfig* config;
 @property (strong, nonatomic) DataManager* dataManager;
+@property (strong, nonatomic) Logger* logger;
 @property (strong, nonatomic) NetworkManager* networkManager;
 @property (strong, nonatomic) OEXPushNotificationManager* pushNotificationManager;
 @property (strong, nonatomic) OEXRouter* router;
@@ -55,12 +56,17 @@
     if(self != nil) {
         self.postSetupActions = [[NSMutableArray alloc] init];
         
+        self.loggerBuilder = ^(OEXEnvironment* env) {
+            return Logger.sharedLogger;
+        };
+        
         self.analyticsBuilder = ^(OEXEnvironment* env){
             NSCAssert(env.config != nil, @"Config should be enabled before analytics are set up");
             OEXAnalytics* analytics = [[OEXAnalytics alloc] init];
             OEXSegmentConfig* segmentConfig = [env.config segmentConfig];
             if(segmentConfig.apiKey != nil && segmentConfig.isEnabled) {
                 [analytics addTracker:[[OEXSegmentAnalyticsTracker alloc] init]];
+                [analytics addTracker:[[LoggingAnalyticsTracker alloc] init]];
             }
             return analytics;
         };
@@ -129,6 +135,8 @@
 - (void)setupEnvironment {
     // TODO: automatically order by dependencies
     // For now, make sure this is the right order for dependencies
+    self.logger = self.loggerBuilder(self);
+    
     self.config = self.configBuilder(self);
     self.analytics = self.analyticsBuilder(self);
     self.pushNotificationManager = self.pushNotificationManagerBuilder(self);

--- a/Source/edX-Bridging-Header.h
+++ b/Source/edX-Bridging-Header.h
@@ -17,6 +17,7 @@
 
 #import "OEXAccessToken.h"
 #import "OEXAnalytics.h"
+#import "OEXAnalyticsTracker.h"
 #import "OEXAnnouncement.h"
 #import "OEXConfig.h"
 #import "OEXConstants.h"

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		770C514D1B1685F5009B9696 /* AuthenticatedWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770C514C1B1685F5009B9696 /* AuthenticatedWebViewController.swift */; };
 		771273271BA36B76008BA397 /* LoggingAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771273261BA36B76008BA397 /* LoggingAnalyticsTracker.swift */; };
 		771273291BA37115008BA397 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771273281BA37115008BA397 /* Logger.swift */; };
+		7712732C1BA8885F008BA397 /* Logger+OEXObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 7712732B1BA8885F008BA397 /* Logger+OEXObjC.m */; };
 		7713DFBF1AC3C16C005A1756 /* OEXRegisteringUserDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = 7713DFBE1AC3C16C005A1756 /* OEXRegisteringUserDetails.m */; };
 		7713DFC51AC45408005A1756 /* icon_facebook_white.png in Resources */ = {isa = PBXBuildFile; fileRef = 7713DFC11AC45408005A1756 /* icon_facebook_white.png */; };
 		7713DFC71AC45408005A1756 /* icon_google_white.png in Resources */ = {isa = PBXBuildFile; fileRef = 7713DFC31AC45408005A1756 /* icon_google_white.png */; };
@@ -724,6 +725,8 @@
 		770C514C1B1685F5009B9696 /* AuthenticatedWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewController.swift; sourceTree = "<group>"; };
 		771273261BA36B76008BA397 /* LoggingAnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggingAnalyticsTracker.swift; sourceTree = "<group>"; };
 		771273281BA37115008BA397 /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		7712732A1BA8885E008BA397 /* Logger+OEXObjC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Logger+OEXObjC.h"; sourceTree = "<group>"; };
+		7712732B1BA8885F008BA397 /* Logger+OEXObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Logger+OEXObjC.m"; sourceTree = "<group>"; };
 		7713DFBD1AC3C16C005A1756 /* OEXRegisteringUserDetails.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXRegisteringUserDetails.h; sourceTree = "<group>"; };
 		7713DFBE1AC3C16C005A1756 /* OEXRegisteringUserDetails.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXRegisteringUserDetails.m; sourceTree = "<group>"; };
 		7713DFC11AC45408005A1756 /* icon_facebook_white.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon_facebook_white.png; sourceTree = "<group>"; };
@@ -2045,6 +2048,8 @@
 		9EAFFA211B2F00B600B100AB /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				7712732A1BA8885E008BA397 /* Logger+OEXObjC.h */,
+				7712732B1BA8885F008BA397 /* Logger+OEXObjC.m */,
 				771273281BA37115008BA397 /* Logger.swift */,
 				77691FA11B3B4596003922F2 /* UIColor+OEXHex.h */,
 				77691FA21B3B4596003922F2 /* UIColor+OEXHex.m */,
@@ -3069,6 +3074,7 @@
 				7754200A1AA763CE006FAF5B /* NSString+OEXFormatting.m in Sources */,
 				9EF5A2061B9F417D008A5BCD /* ResizeHelper.swift in Sources */,
 				B4B6D62B1A949F1B000F44E8 /* OEXRegistrationFieldTextController.m in Sources */,
+				7712732C1BA8885F008BA397 /* Logger+OEXObjC.m in Sources */,
 				7772BEAC1AFA68330081CA7A /* View+SnapKit.swift in Sources */,
 				774B393B1B5EEF8A00595D33 /* PSTAlertController+Selection.swift in Sources */,
 				775DF4181AFAAC8C00F96B2F /* DataManager.swift in Sources */,

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -151,6 +151,8 @@
 		770A3D451AF0167A008F09D9 /* UIControl+OEXBlockActions.m in Sources */ = {isa = PBXBuildFile; fileRef = 770A3D441AF0167A008F09D9 /* UIControl+OEXBlockActions.m */; };
 		770C514B1B1685E3009B9696 /* HTMLBlockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770C514A1B1685E3009B9696 /* HTMLBlockViewController.swift */; };
 		770C514D1B1685F5009B9696 /* AuthenticatedWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770C514C1B1685F5009B9696 /* AuthenticatedWebViewController.swift */; };
+		771273271BA36B76008BA397 /* LoggingAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771273261BA36B76008BA397 /* LoggingAnalyticsTracker.swift */; };
+		771273291BA37115008BA397 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771273281BA37115008BA397 /* Logger.swift */; };
 		7713DFBF1AC3C16C005A1756 /* OEXRegisteringUserDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = 7713DFBE1AC3C16C005A1756 /* OEXRegisteringUserDetails.m */; };
 		7713DFC51AC45408005A1756 /* icon_facebook_white.png in Resources */ = {isa = PBXBuildFile; fileRef = 7713DFC11AC45408005A1756 /* icon_facebook_white.png */; };
 		7713DFC71AC45408005A1756 /* icon_google_white.png in Resources */ = {isa = PBXBuildFile; fileRef = 7713DFC31AC45408005A1756 /* icon_google_white.png */; };
@@ -720,6 +722,8 @@
 		770A3D441AF0167A008F09D9 /* UIControl+OEXBlockActions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIControl+OEXBlockActions.m"; sourceTree = "<group>"; };
 		770C514A1B1685E3009B9696 /* HTMLBlockViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLBlockViewController.swift; sourceTree = "<group>"; };
 		770C514C1B1685F5009B9696 /* AuthenticatedWebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewController.swift; sourceTree = "<group>"; };
+		771273261BA36B76008BA397 /* LoggingAnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggingAnalyticsTracker.swift; sourceTree = "<group>"; };
+		771273281BA37115008BA397 /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		7713DFBD1AC3C16C005A1756 /* OEXRegisteringUserDetails.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXRegisteringUserDetails.h; sourceTree = "<group>"; };
 		7713DFBE1AC3C16C005A1756 /* OEXRegisteringUserDetails.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXRegisteringUserDetails.m; sourceTree = "<group>"; };
 		7713DFC11AC45408005A1756 /* icon_facebook_white.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon_facebook_white.png; sourceTree = "<group>"; };
@@ -1426,6 +1430,7 @@
 		1972E3B619BF474900085F08 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
+				771273261BA36B76008BA397 /* LoggingAnalyticsTracker.swift */,
 				77FFAB9B1A8ABDB200F91F08 /* OEXAnalyticsTracker.h */,
 				19DC02011A1E13AA00A874D3 /* OEXAnalyticsData.h */,
 				77EC889D1AB787630050F9CF /* OEXAnalyticsData.m */,
@@ -2040,6 +2045,7 @@
 		9EAFFA211B2F00B600B100AB /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				771273281BA37115008BA397 /* Logger.swift */,
 				77691FA11B3B4596003922F2 /* UIColor+OEXHex.h */,
 				77691FA21B3B4596003922F2 /* UIColor+OEXHex.m */,
 				77AB8C791B33770800AB3FC0 /* Operation.swift */,
@@ -2953,6 +2959,7 @@
 				19EA0F5D1965CB3700B684B0 /* OEXCustomEditingView.m in Sources */,
 				1913DD4419502E5D00573977 /* OEXVideoSummary.m in Sources */,
 				9EAB5BE91B564C2F00CA9F3C /* ProgressController.swift in Sources */,
+				771273271BA36B76008BA397 /* LoggingAnalyticsTracker.swift in Sources */,
 				7772BEA91AFA68330081CA7A /* EdgeInsets.swift in Sources */,
 				9EF8A6FF1B2852BB005E0042 /* FullScreenMessageViewController.swift in Sources */,
 				9E4E6C411B4BDB5C0034F7EB /* MockLastAccessedProvider.swift in Sources */,
@@ -3140,6 +3147,7 @@
 				77FFAB9A1A8AB65300F91F08 /* OEXSegmentAnalyticsTracker.m in Sources */,
 				BE45DA8919260604003BD39B /* OEXCustomTabBarViewViewController.m in Sources */,
 				5D836DCA1B2FA12E00411CAB /* DiscussionNewCommentViewController.swift in Sources */,
+				771273291BA37115008BA397 /* Logger.swift in Sources */,
 				19321F651961698B00B7D75C /* OEXDownloadTableCell.m in Sources */,
 				1A5AC5801B94ED0D00885187 /* CourseCardViewModel.swift in Sources */,
 				77FFA2CC1AC35CE800B4D69B /* OEXRegistrationStyles.m in Sources */,


### PR DESCRIPTION
- Introduces a standard logger with control over levels and which areas
  (domains) of logs you're interested in.

  To use: Just call ``Logger.log("SOME DOMAIN", "Some message")``

  Note that all domains are filtered out by default. To read one just
  pause Xcode and type ``call Logger.addDomain("SOME DOMAIN")`` into the
  debug console.

  This way we can have leave in logs, but not have them clutter up the
  console unless you're interested in some particular area. For random
  debug printing, you can feel free to keep using println or use
  ``Logger.logDebug("SOME DOMAIN", "SOME MESSAGE")``

- Takes advantage of the new logger to print out analytics messages when
  the ANALYTICS domain is enabled.