### PR TITLE
Turn localizable.strings into a statically checkable file

### DIFF
--- a/Source/DiscussionCommentsViewController.swift
+++ b/Source/DiscussionCommentsViewController.swift
@@ -85,9 +85,10 @@ class DiscussionCommentCell: UITableViewCell {
         
         self.backgroundColor = OEXStyles.sharedStyles().neutralWhiteT()
         
+        let message = Strings.comment(count: Float(response.commentCount))
         let buttonTitle = NSAttributedString.joinInNaturalLayout([
             Icon.Comment.attributedTextWithStyle(smallIconStyle),
-            smallTextStyle.attributedStringWithText(NSString.oex_stringWithFormat(OEXLocalizedStringPlural("COMMENT", Float(response.commentCount), nil), parameters: ["count": Float(response.commentCount)]))])
+            smallTextStyle.attributedStringWithText(message)])
         self.commentCountOrReportIconButton.setAttributedTitle(buttonTitle, forState: .Normal)
     }
     

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -10,8 +10,6 @@
 
 /* Alert dialog confirmation button when user chooses to download a large video */
 "ACCEPT_LARGE_VIDEO_DOWNLOAD"="Download";
-/* Add a comment button title used in discussion's comements screen */
-
 /* Label for check box when it's checked. */
 "ACCESSIBILITY_CHECKBOX_CHECKED" = "Checked";
 /* Label for check box when it's checked. */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -92,6 +92,7 @@
 "ANSWER"="Answer";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR" = "By {author_name}";
+/* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR_LOWER_CASE" = "by {author_name}";
 /* Title of course announcements section */
 "COURSE_ANNOUNCEMENTS"="Announcements";

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -121,8 +121,6 @@
 "COURSE_ANNOUNCEMENT_NOTIFICATION_BODY"="New Announcement: {course_name}";
 /* Alert dialog button text */
 "CLOSE"="Close";
-/* Comment back title in adding a new comment */
-"COMMENT"="Comment";
 /* Discussion response comment - {count} is a number of comments */
 "COMMENT##{one}"="{count} comment";
 /* Discussion response comment - {count} is a number of comments */

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -2905,7 +2905,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/script/Localizations.swift\" \"${SRCROOT}/Source/en.lproj/Localizable.strings\" \"${BUILT_PRODUCTS_DIR}/Strings.swift\"\nchmod -w \"${BUILT_PRODUCTS_DIR}/Strings.swift\"";
+			shellScript = "rm -f \"${BUILT_PRODUCTS_DIR}/Strings.swift\"\n\"${SRCROOT}/script/Localizations.swift\" \"${SRCROOT}/Source/en.lproj/Localizable.strings\" \"${BUILT_PRODUCTS_DIR}/Strings.swift\"\nchmod -w \"${BUILT_PRODUCTS_DIR}/Strings.swift\"";
 		};
 		D65420B131C0029BCF6EE6E4 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -2905,7 +2905,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/script/Localizations.swift\" \"${SRCROOT}/Source/en.lproj/Localizable.strings\" \"${BUILT_PRODUCTS_DIR}/Strings.swift\"";
+			shellScript = "\"${SRCROOT}/script/Localizations.swift\" \"${SRCROOT}/Source/en.lproj/Localizable.strings\" \"${BUILT_PRODUCTS_DIR}/Strings.swift\"\nchmod -w \"${BUILT_PRODUCTS_DIR}/Strings.swift\"";
 		};
 		D65420B131C0029BCF6EE6E4 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		77BECB081B0A771700894276 /* OfflineModeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BECB071B0A771700894276 /* OfflineModeViewTests.swift */; };
 		77BECB0A1B0A8AD800894276 /* UIEdgeInsets+GeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BECB091B0A8AD800894276 /* UIEdgeInsets+GeometryTests.swift */; };
 		77BECB0D1B0A8BBD00894276 /* UIEdgeInsets+Geometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BECB051B0A668000894276 /* UIEdgeInsets+Geometry.swift */; };
+		77BFD86A1BB9E15B001D7BE5 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BFD8691BB9E15B001D7BE5 /* Strings.swift */; settings = {ASSET_TAGS = (); }; };
 		77C1CB2A1B3353D400E9DB99 /* DetachedStreamOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C1CB291B3353D400E9DB99 /* DetachedStreamOperation.swift */; };
 		77D705FA1B79573800ABCB70 /* OEXHTTPStatusCode+Groups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D705F91B79573800ABCB70 /* OEXHTTPStatusCode+Groups.swift */; };
 		77D705FC1B7C0DEC00ABCB70 /* OEXCourseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D705FB1B7C0DEC00ABCB70 /* OEXCourseTests.swift */; };
@@ -932,6 +933,7 @@
 		77BECB051B0A668000894276 /* UIEdgeInsets+Geometry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIEdgeInsets+Geometry.swift"; sourceTree = "<group>"; };
 		77BECB071B0A771700894276 /* OfflineModeViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OfflineModeViewTests.swift; sourceTree = "<group>"; };
 		77BECB091B0A8AD800894276 /* UIEdgeInsets+GeometryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIEdgeInsets+GeometryTests.swift"; sourceTree = "<group>"; };
+		77BFD8691BB9E15B001D7BE5 /* Strings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = BUILT_PRODUCTS_DIR; };
 		77C1CB291B3353D400E9DB99 /* DetachedStreamOperation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetachedStreamOperation.swift; sourceTree = "<group>"; };
 		77D705F91B79573800ABCB70 /* OEXHTTPStatusCode+Groups.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OEXHTTPStatusCode+Groups.swift"; sourceTree = "<group>"; };
 		77D705FB1B7C0DEC00ABCB70 /* OEXCourseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OEXCourseTests.swift; sourceTree = "<group>"; };
@@ -1844,6 +1846,7 @@
 		7772BEAE1AFA69770081CA7A /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				77BFD8691BB9E15B001D7BE5 /* Strings.swift */,
 				193B502D19459AEF0038E11C /* Custom Fonts */,
 				198826DB1952DBCA005D4D8A /* App Icons & Splash */,
 				193B501119407B2C0038E11C /* Assets */,
@@ -2619,6 +2622,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BECB7B3D1924C0C3009C77F1 /* Build configuration list for PBXNativeTarget "edX" */;
 			buildPhases = (
+				77BFD8641BB637DB001D7BE5 /* Compile Localizations */,
 				E17EDB3D9BEEE2E6D22FFA4D /* Check Pods Manifest.lock */,
 				BECB7B071924C0C3009C77F1 /* Sources */,
 				BECB7B081924C0C3009C77F1 /* Frameworks */,
@@ -2886,6 +2890,23 @@
 			shellPath = /bin/sh;
 			shellScript = "${SRCROOT}/gradlew applyConfig --stacktrace --info";
 		};
+		77BFD8641BB637DB001D7BE5 /* Compile Localizations */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Source/en.lproj/Localizable.strings",
+				"${SRCROOT}/script/Localizations.swift",
+			);
+			name = "Compile Localizations";
+			outputPaths = (
+				"${BUILT_PRODUCTS_DIR}/Strings.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/script/Localizations.swift\" \"${SRCROOT}/Source/en.lproj/Localizable.strings\" \"${BUILT_PRODUCTS_DIR}/Strings.swift\"";
+		};
 		D65420B131C0029BCF6EE6E4 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2952,6 +2973,7 @@
 				7778F0981ABB1A6C00B4CDA0 /* NSError+OEXKnownErrors.m in Sources */,
 				772BF2141B0E5305008FB89D /* Box.swift in Sources */,
 				B4B6D6041A949EFC000F44E8 /* OEXRegistrationRestriction.m in Sources */,
+				77BFD86A1BB9E15B001D7BE5 /* Strings.swift in Sources */,
 				9C9B7F6F1A8CC68400A857B2 /* OEXEnrollmentConfig.m in Sources */,
 				773B1D441B1F77D400B861DF /* ViewController+SnapKit.swift in Sources */,
 				B4B285E81A9A662600DD603A /* OEXZeroRatingConfig.m in Sources */,

--- a/script/Localizations.swift
+++ b/script/Localizations.swift
@@ -50,11 +50,6 @@ let source = arguments[1]
 let dest = arguments[2]
 print("Loading \(source) into \(dest)")
 
-guard let content = try? NSString(contentsOfFile:source, encoding: NSUTF8StringEncoding) else {
-    print("error: Unable to open \(source). Aborting.", toStream: &errorStream)
-    exit(1)
-}
-
 guard let pairs = NSDictionary(contentsOfFile: source) else {
     print("error: Unable to load strings file: \(source)", toStream: &errorStream)
     exit(1)

--- a/script/Localizations.swift
+++ b/script/Localizations.swift
@@ -2,6 +2,8 @@
 
 import Foundation
 
+//MARK: Helpers
+
 // Stream that writes to stderr.
 class StandardErrorOutputStream: OutputStreamType {
     func write(string: String) {
@@ -37,6 +39,7 @@ class FileOutputStream : OutputStreamType {
     }
 }
 
+// MARK: Load
 
 let arguments = Process.arguments
 guard arguments.count > 2 else {
@@ -55,41 +58,76 @@ guard let pairs = NSDictionary(contentsOfFile: source) else {
     exit(1)
 }
 
+// MARK: Types
+
 // Whether the string needs multiple representations based on a numeric parameter
 enum Plurality {
     case Single
     case Multi
 }
 
+func == (left : Key, right : Key) -> Bool {
+    return left.path == right.path && left.name == right.name
+}
+
+struct Key : Hashable, Equatable {
+    let path : [String]
+    let name : String
+    let original : String
+    
+    var hashValue : Int {
+        return name.hashValue ^ path.reduce(0) {$0 ^ $1.hashValue}
+    }
+}
+
+class Group {
+    let name : String
+    var children : [String:Group] = [:]
+    var items : [Item] = []
+    
+    init(name : String) {
+        self.name = name
+    }
+}
+
 // A localization item
 class Item {
-    let key : String
+    let key : Key
     var values : [String]
     let arguments : [String]
     let plurality : Plurality
     
-    init(key : String, values: [String], arguments: [String], plurality: Plurality) {
+    init(key : Key, values: [String], arguments: [String], plurality: Plurality) {
         self.key = key
         self.values = values
         self.arguments = arguments
         self.plurality = plurality
     }
-    
-    func variableName(string : String) -> String {
-        let parts = string.componentsSeparatedByString("_")
-        var formattedParts : [String] = []
-        var first = true
-        for part in parts {
-            if first {
-               formattedParts.append(part.lowercaseString)
-            }
-            else {
-                formattedParts.append(part.capitalizedString)
-            }
-            first = false
+}
+
+enum ArgumentError : ErrorType {
+    case Unterminated
+}
+
+// MARK: Formatting
+
+func variableName(string : String) -> String {
+    let parts = string.componentsSeparatedByString("_")
+    var formattedParts : [String] = []
+    var first = true
+    for part in parts {
+        if first {
+            formattedParts.append(part.lowercaseString)
         }
-        return formattedParts.joinWithSeparator("")
+        else {
+            formattedParts.append(part.capitalizedString)
+        }
+        first = false
     }
+    return formattedParts.joinWithSeparator("")
+}
+
+extension Item {
     
     var code : String {
         if arguments.count > 0 {
@@ -102,33 +140,28 @@ class Item {
             
             switch plurality {
             case .Single:
-                return "\tstatic func \(variableName(key))(\(args)) -> String { return OEXLocalizedString(\"\(key)\", nil).oex_formatWithParameters([\(formatParams)]) }"
+                return "static func \(variableName(key.name))(\(args)) -> String { return OEXLocalizedString(\"\(key.name)\", nil).oex_formatWithParameters([\(formatParams)]) }"
             case .Multi:
                 if arguments.count == 1 {
                     let arg = arguments[0]
                     let name = variableName(arg)
-                    return "\t static func \(variableName(key))(\(name) \(name) : Float) -> String { return OEXLocalizedStringPlural(\"\(key)\", \(name), nil).oex_formatWithParameters([\"\(arg)\": \(name)]) }"
+                    return "static func \(variableName(key.name))(\(name) \(name) : Float) -> String { return OEXLocalizedStringPlural(\"\(key.name)\", \(name), nil).oex_formatWithParameters([\"\(arg)\": \(name)]) }"
                 }
                 else {
-                    return "\tstatic func \(variableName(key))(pluralizingCount : Float)(\(args)) -> String { return OEXLocalizedStringPlural(\"\(key)\", pluralizingCount, nil).oex_formatWithParameters([\(formatParams)]) }"
+                    return "static func \(variableName(key.name))(pluralizingCount : Float)(\(args)) -> String { return OEXLocalizedStringPlural(\"\(key.name)\", pluralizingCount, nil).oex_formatWithParameters([\(formatParams)]) }"
                 }
             }
         }
         else {
             switch plurality {
             case .Single:
-                return "\tstatic var \(variableName(key)) = OEXLocalizedString(\"\(key)\", nil)"
+                return "static var \(variableName(key.name)) = OEXLocalizedString(\"\(key.name)\", nil)"
             case .Multi:
-                return "\tstatic func \(variableName(key))(count : Float) -> String { return OEXLocalizedStringPlural(\"\(key)\", count, nil) } "
+                return "static func \(variableName(key.name))(count : Float) -> String { return OEXLocalizedStringPlural(\"\(key.name)\", count, nil) } "
             }
         }
     }
 }
-
-enum ArgumentError : ErrorType {
-    case Unterminated
-}
-
 
 func getArguments(string : String) throws -> [String] {
     var arguments : [String] = []
@@ -152,35 +185,74 @@ func getArguments(string : String) throws -> [String] {
     return arguments
 }
 
-func parseKey(key : String) -> (String, Plurality) {
-    let parts = key.componentsSeparatedByString("##")
+
+/// Takes a string key of the form A.B.C##count and returns a parsed Key and the plurality
+/// For example, FOO.BAR.BAZ##other would return (Key(path:[FOO, BAR], name:BAZ), .Multi)
+func parseKey(key : String) -> (Key, Plurality) {
+    let components = key.componentsSeparatedByString(".")
+    let path = Array(components[0 ..< components.count - 1])
+
+    guard let base = components.last else {
+        print("error: Invalid Key \(key)", toStream:&errorStream)
+        exit(1)
+    }
+    let parts = base.componentsSeparatedByString("##")
     if parts.count > 1 {
-        return (parts[0], .Multi)
+        return (Key(path: path, name: parts[0], original:key), .Multi)
     }
     else {
-        return (key, .Single)
+        return (Key(path:path, name: base, original:key), .Single)
     }
 }
 
-var items : [String:Item] = [:]
+//MARK: Process Items
+
+// Check that all items have a comment
+func verifyItems(items : [Item]) {
+    var foundError = false
+    guard let content = NSString(contentsOfFile: source) else {
+        print("error: Could not open file \(source).", toStream: &errorStream)
+        exit(1)
+    }
+    for item in items {
+        let key = "\"\(item.key.original)\""
+        let range = content.rangeOfString(key)
+        guard range.location != NSNotFound else {
+            print("error: Couldn't find key: \(key)", toStream:&errorStream)
+            continue
+        }
+        // This is super hacky. Just look for the original key and make sure there's a comment close marker a little bit before it.
+        let commentClose = content.rangeOfString("*/", options:NSStringCompareOptions(), range:NSRange(location: max(range.location, 20) - 20, length:20))
+        if commentClose.location == NSNotFound {
+            print("error: Missing comment for string \(item.key.original). This information is needed by translators.")
+            foundError = true
+        }
+    }
+    if foundError {
+        exit(1)
+    }
+}
+
+// First pass get the items and verify they're okay
+var items : [Key : Item] = [:]
 for pair in pairs {
-    let key = pair.key as! String
+    let stringKey = pair.key as! String
     let value = pair.value as! String
     
-    let (base, plurality) = parseKey(key)
+    let (key, plurality) = parseKey(stringKey)
     
     do {
         let arguments = try getArguments(value)
-        if let existing = items[base] {
+        if let existing = items[key] {
             if Set(existing.arguments) != Set(arguments) {
-                print("error: Plural cases have different arguments. Key: \(base). Arguments: \(existing.arguments) & \(arguments)", toStream: &errorStream)
+                print("error: Plural cases have different arguments. Key: \(key.name). Arguments: \(existing.arguments) & \(arguments)", toStream: &errorStream)
                 exit(1)
             }
             existing.values.append(value)
         }
         else {
-            let item = Item(key: base, values: [value], arguments: arguments, plurality: plurality)
-            items[base] = item
+            let item = Item(key: key, values: [value], arguments: arguments, plurality: plurality)
+            items[key] = item
         }
     }
     catch {
@@ -189,23 +261,66 @@ for pair in pairs {
     }
 }
 
+verifyItems(Array(items.values))
+
+// Second pass. Group them by path so we get nested structures
+var topLevel = Group(name:"Strings")
+for item in items.values {
+    var currentGroup = topLevel
+    for segment in item.key.path {
+        if let child = currentGroup.children[segment] {
+            currentGroup = child
+        }
+        else {
+            let child = Group(name:segment)
+            currentGroup.children[segment] = child
+            currentGroup = child
+        }
+    }
+    currentGroup.items.append(item)
+}
+
+//MARK: Output
+
+func tabs(number : UInt) -> String {
+    var result : String = ""
+    for _ in 0..<number {
+        result += "\t"
+    }
+    return result
+}
+
 guard var output = FileOutputStream(path:dest) else {
     print("error: Couldn't open file \(dest) for writing", toStream: &errorStream)
     exit(1)
 }
 
-print("// This file is autogenerated. Do not modify.", toStream: &output)
-print("\n", toStream: &output)
-print("struct Strings {", toStream: &output)
-print("", toStream: &output)
-
-for key in items.keys.sort() {
-    if let item = items[key] {
-        print("\(item.code)", toStream: &output)
+func printGroup(group : Group, depth : UInt = 0) {
+    let indent = tabs(depth)
+    print("\(indent)struct \(variableName(group.name).capitalizedString) {", toStream: &output)
+    if group.children.count > 0 {
+        print("", toStream: &output)
+        for name in group.children.keys.sort() {
+            let child = group.children[name]!
+            printGroup(child, depth: depth + 1)
+        }
+        print("", toStream: &output)
     }
+    
+    if group.items.count > 0 {
+        let childIndent = tabs(depth + 1)
+        print("", toStream: &output)
+        for item in (group.items.sort {$0.key.name < $1.key.name}) {
+            print("\(childIndent)\(item.code)", toStream: &output)
+        }
+        print("", toStream: &output)
+    }
+    print("\(indent)}", toStream: &output)
 }
 
-print("", toStream: &output)
-print("}", toStream: &output)
+print("// This file is autogenerated. Do not modify.", toStream: &output)
+print("\n", toStream: &output)
+
+printGroup(topLevel)
 
 print("", toStream: &output)

--- a/script/Localizations.swift
+++ b/script/Localizations.swift
@@ -1,0 +1,216 @@
+#!/usr/bin/swift
+
+import Foundation
+
+// Stream that writes to stderr.
+class StandardErrorOutputStream: OutputStreamType {
+    func write(string: String) {
+        fputs(string, stderr)
+    }
+}
+
+var errorStream = StandardErrorOutputStream()
+
+// This makes it easy to ``print`` to a file
+class FileOutputStream : OutputStreamType {
+    let handle : NSFileHandle
+    init?(path : String) {
+        if !NSFileManager.defaultManager().createFileAtPath(path, contents:nil, attributes:nil) {
+            self.handle = NSFileHandle.fileHandleWithNullDevice()
+            return nil
+        }
+        if let handle = NSFileHandle(forWritingAtPath:path) {
+            self.handle = handle
+        }
+        else {
+            self.handle = NSFileHandle.fileHandleWithNullDevice()
+            return nil
+        }
+    }
+    
+    func write(string: String) {
+        handle.writeData(string.dataUsingEncoding(NSUTF8StringEncoding)!)
+    }
+    
+    deinit {
+        handle.closeFile()
+    }
+}
+
+
+let arguments = Process.arguments
+guard arguments.count > 2 else {
+    print("error: Not enough arguments. Aborting")
+    print("Usage: ")
+    print("Localizations.swift <source_file> <dest_file>")
+    exit(1)
+}
+
+let source = arguments[1]
+let dest = arguments[2]
+print("Loading \(source) into \(dest)")
+
+guard let content = try? NSString(contentsOfFile:source, encoding: NSUTF8StringEncoding) else {
+    print("error: Unable to open \(source). Aborting.", toStream: &errorStream)
+    exit(1)
+}
+
+guard let pairs = NSDictionary(contentsOfFile: source) else {
+    print("error: Unable to load strings file: \(source)", toStream: &errorStream)
+    exit(1)
+}
+
+// Whether the string needs multiple representations based on a numeric parameter
+enum Plurality {
+    case Single
+    case Multi
+}
+
+// A localization item
+class Item {
+    let key : String
+    var values : [String]
+    let arguments : [String]
+    let plurality : Plurality
+    
+    init(key : String, values: [String], arguments: [String], plurality: Plurality) {
+        self.key = key
+        self.values = values
+        self.arguments = arguments
+        self.plurality = plurality
+    }
+    
+    func variableName(string : String) -> String {
+        let parts = string.componentsSeparatedByString("_")
+        var formattedParts : [String] = []
+        var first = true
+        for part in parts {
+            if first {
+               formattedParts.append(part.lowercaseString)
+            }
+            else {
+                formattedParts.append(part.capitalizedString)
+            }
+            first = false
+        }
+        return formattedParts.joinWithSeparator("")
+    }
+    
+    var code : String {
+        if arguments.count > 0 {
+            let args = arguments.map {
+                return "\(variableName($0)) : String"
+                }.joinWithSeparator(", ")
+            let formatParams = arguments.map {
+                return "\"\($0)\" : \(variableName($0))"
+                }.joinWithSeparator(", ")
+            
+            switch plurality {
+            case .Single:
+                return "\tstatic func \(variableName(key))(\(args)) -> String { return OEXLocalizedString(\"\(key)\", nil).oex_formatWithParameters([\(formatParams)]) }"
+            case .Multi:
+                if arguments.count == 1 {
+                    let arg = arguments[0]
+                    let name = variableName(arg)
+                    return "\t static func \(variableName(key))(\(name) \(name) : Float) -> String { return OEXLocalizedStringPlural(\"\(key)\", \(name), nil).oex_formatWithParameters([\"\(arg)\": \(name)]) }"
+                }
+                else {
+                    return "\tstatic func \(variableName(key))(pluralizingCount : Float)(\(args)) -> String { return OEXLocalizedStringPlural(\"\(key)\", pluralizingCount, nil).oex_formatWithParameters([\(formatParams)]) }"
+                }
+            }
+        }
+        else {
+            switch plurality {
+            case .Single:
+                return "\tstatic var \(variableName(key)) = OEXLocalizedString(\"\(key)\", nil)"
+            case .Multi:
+                return "\tstatic func \(variableName(key))(count : Float) -> String { return OEXLocalizedStringPlural(\"\(key)\", count, nil) } "
+            }
+        }
+    }
+}
+
+enum ArgumentError : ErrorType {
+    case Unterminated
+}
+
+
+func getArguments(string : String) throws -> [String] {
+    var arguments : [String] = []
+    var current = string.startIndex
+
+    while current < string.endIndex {
+        if let start = string.rangeOfString("{", options:NSStringCompareOptions(), range:Range(start:current, end:string.endIndex)) {
+            if let end = string.rangeOfString("}", options:NSStringCompareOptions(), range:Range(start:start.startIndex, end:string.endIndex)) {
+                let argument = string[start.startIndex.successor()..<end.endIndex.predecessor()]
+                arguments.append(argument)
+                current = end.endIndex
+            }
+            else {
+                throw ArgumentError.Unterminated
+            }
+        }
+        else {
+            break
+        }
+    }
+    return arguments
+}
+
+func parseKey(key : String) -> (String, Plurality) {
+    let parts = key.componentsSeparatedByString("##")
+    if parts.count > 1 {
+        return (parts[0], .Multi)
+    }
+    else {
+        return (key, .Single)
+    }
+}
+
+var items : [String:Item] = [:]
+for pair in pairs {
+    let key = pair.key as! String
+    let value = pair.value as! String
+    
+    let (base, plurality) = parseKey(key)
+    
+    do {
+        let arguments = try getArguments(value)
+        if let existing = items[base] {
+            if Set(existing.arguments) != Set(arguments) {
+                print("error: Plural cases have different arguments. Key: \(base). Arguments: \(existing.arguments) & \(arguments)", toStream: &errorStream)
+                exit(1)
+            }
+            existing.values.append(value)
+        }
+        else {
+            let item = Item(key: base, values: [value], arguments: arguments, plurality: plurality)
+            items[base] = item
+        }
+    }
+    catch {
+        print("error: Invalid string \(value)", toStream: &errorStream)
+        exit(1)
+    }
+}
+
+guard var output = FileOutputStream(path:dest) else {
+    print("error: Couldn't open file \(dest) for writing", toStream: &errorStream)
+    exit(1)
+}
+
+print("// This file is autogenerated. Do not modify.", toStream: &output)
+print("\n", toStream: &output)
+print("struct Strings {", toStream: &output)
+print("", toStream: &output)
+
+for key in items.keys.sort() {
+    if let item = items[key] {
+        print("\(item.code)", toStream: &output)
+    }
+}
+
+print("", toStream: &output)
+print("}", toStream: &output)
+
+print("", toStream: &output)


### PR DESCRIPTION
Instead of going through horribly error prone strings tables directly, you can now just
do Strings.whatever. If the string has parameters, then it generates a
function. This should be way safer than passing format dictionaries
around.

All you need to do is update Localizable.strings and rebuild. Strings
will be generated automatically. The generation script will not run if
that file hasn't changed so it shouldn't significantly affect build
times.

It also does basic linting and found a string that had a non plural
version and a plural version. Fortunately, we weren't using the non
plural one so I removed it.