### PR TITLE
Fix issues with setting up listeners in video block and handouts.

### DIFF
--- a/Source/CourseHandoutsViewController.swift
+++ b/Source/CourseHandoutsViewController.swift
@@ -34,6 +34,8 @@ public class CourseHandoutsViewController: UIViewController, UIWebViewDelegate {
         self.loadController = LoadStateViewController(styles: self.environment.styles)
         
         super.init(nibName: nil, bundle: nil)
+        
+        addListener()
     }
 
     required public init?(coder aDecoder: NSCoder) {
@@ -85,13 +87,11 @@ public class CourseHandoutsViewController: UIViewController, UIWebViewDelegate {
         
             self.handouts.backWithStream(handoutStream)
         }
-
-        addListener()
         
     }
     
     private func addListener() {
-        handouts.listenOnce(self, fireIfAlreadyLoaded: true, success: { [weak self] courseHandouts in
+        handouts.listen(self, success: { [weak self] courseHandouts in
             if let
                 displayHTML = OEXStyles.sharedStyles().styleHTMLContent(courseHandouts),
                 apiHostUrl = OEXConfig.sharedConfig().apiHostURL()

--- a/Source/VideoBlockViewController.swift
+++ b/Source/VideoBlockViewController.swift
@@ -50,6 +50,7 @@ class VideoBlockViewController : UIViewController, CourseBlockViewController, OE
         addChildViewController(videoController)
         videoController.didMoveToParentViewController(self)
         videoController.delegate = self
+        addLoadListener()
     }
     
     var courseID : String {
@@ -60,6 +61,21 @@ class VideoBlockViewController : UIViewController, CourseBlockViewController, OE
         // required by the compiler because UIViewController implements NSCoding,
         // but we don't actually want to serialize these things
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    func addLoadListener() {
+        loader.listen (self,
+            success : { [weak self] block in
+                if let video = self?.environment.interface?.stateForVideoWithID(self?.blockID, courseID : self?.courseID) {
+                    self?.showLoadedBlock(block, forVideo: video)
+                }
+                else {
+                    self?.showError(nil)
+                }
+            }, failure : {[weak self] error in
+                self?.showError(error)
+            }
+        )
     }
     
     override func viewDidLoad() {
@@ -100,18 +116,6 @@ class VideoBlockViewController : UIViewController, CourseBlockViewController, OE
     private func loadVideoIfNecessary() {
         if !loader.hasBacking {
             loader.backWithStream(courseQuerier.blockWithID(self.blockID).firstSuccess())
-            loader.listen (self,
-                success : { [weak self] block in
-                    if let video = self?.environment.interface?.stateForVideoWithID(self?.blockID, courseID : self?.courseID) {
-                        self?.showLoadedBlock(block, forVideo: video)
-                    }
-                    else {
-                        self?.showError(nil)
-                    }
-                }, failure : {[weak self] error in
-                    self?.showError(error)
-                }
-            )
         }
     }
     


### PR DESCRIPTION
In handouts we were only setting the listener to listenOnce which means
it will only send the cached version.

In the video block code we were adding a listener each time we reloaded
the stream. In practice we were only loading the stream once so it
didn't matter, but if we wanted to add a refresh feature this could lead
to a bug.