### PR TITLE
Choose a Topic functionality matches the spec now

### DIFF
--- a/Source/DiscussionNewPostViewController.swift
+++ b/Source/DiscussionNewPostViewController.swift
@@ -192,7 +192,7 @@ public class DiscussionNewPostViewController: UIViewController, UITextViewDelega
             self?.contentTextView.resignFirstResponder()
             self?.titleTextField.resignFirstResponder()
         }
-        self.view.addGestureRecognizer(tapGesture)
+        self.backgroundView.addGestureRecognizer(tapGesture)
 
         self.growingTextController.setupWithScrollView(scrollView, textView: contentTextView, bottomView: postButton)
         self.insetsController.setupInController(self, scrollView: scrollView)

--- a/Source/PostsViewController.swift
+++ b/Source/PostsViewController.swift
@@ -144,7 +144,7 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
         
         var topic : DiscussionTopic? {
             switch self {
-            case let Topic(topic): return topic
+            case let Topic(topic): return topic.depth == 0 ? nil : topic
             case Search(_): return nil
             case Following(_): return nil
             case AllPosts(_): return nil


### PR DESCRIPTION
Also has a bug fix with the tap gesture recogniser

#### As quoted by Leslie 
"we should match the defaulting behavior on desktop. Right now, it looks like it defaults to the first coursewide discussion topic, which is ordinarily "General". We do not force students to select a topic, we default one for them. Please check the code for desktop discussions and match the exact logic. Let me know if you have questions."