### PR TITLE
Assorted changes to Discussion Screens

### DIFF
--- a/Source/CourseOutlineHeaderCell.swift
+++ b/Source/CourseOutlineHeaderCell.swift
@@ -49,7 +49,7 @@ class CourseOutlineHeaderCell : UITableViewHeaderFooterView {
     // Skip autolayout for performance reasons
     override func layoutSubviews() {
         super.layoutSubviews()
-        let margin = OEXStyles.sharedStyles().standardHorizontalMargin() - 5
+        let margin = StandardHorizontalMargin - 5
         self.headerLabel.frame = UIEdgeInsetsInsetRect(self.bounds, UIEdgeInsetsMake(0, margin, 0, margin))
         horizontalTopLine.frame = CGRectMake(0, 0, self.bounds.size.width, OEXStyles.dividerSize())
     }

--- a/Source/CourseOutlineHeaderView.swift
+++ b/Source/CourseOutlineHeaderView.swift
@@ -77,7 +77,7 @@ public class CourseOutlineHeaderView: UIView {
         }
         
         viewButton.snp_makeConstraints { make in
-            make.trailing.equalTo(self.snp_trailing).offset(-styles.standardHorizontalMargin())
+            make.trailing.equalTo(self.snp_trailing).offset(-StandardHorizontalMargin)
             make.centerY.equalTo(self)
             make.top.equalTo(self).offset(5)
             make.bottom.equalTo(self).offset(-5)
@@ -88,7 +88,7 @@ public class CourseOutlineHeaderView: UIView {
         messageView.snp_makeConstraints { make in
             let situationalCenterYOffset = hasSubtitle ? titleLabelCenterYOffset : 0
             make.centerY.equalTo(self).offset(situationalCenterYOffset)
-            make.leading.equalTo(self).offset(styles.standardHorizontalMargin())
+            make.leading.equalTo(self).offset(StandardHorizontalMargin)
         }
         
         subtitleLabel.snp_makeConstraints { (make) -> Void in

--- a/Source/CourseOutlineItemView.swift
+++ b/Source/CourseOutlineItemView.swift
@@ -28,8 +28,6 @@ private let IconFontSize : CGFloat = 15
 public class CourseOutlineItemView: UIView {
     static let detailFontStyle = OEXTextStyle(weight: .Normal, size: .Small, color : OEXStyles.sharedStyles().neutralBase())
     
-    private let horizontalMargin = OEXStyles.sharedStyles().standardHorizontalMargin()
-    
     private let fontStyle = OEXTextStyle(weight: .Normal, size: .Base, color : OEXStyles.sharedStyles().neutralBlack())
     private let titleLabel = UILabel()
     private let subtitleLabel = UILabel()
@@ -108,7 +106,7 @@ public class CourseOutlineItemView: UIView {
         leadingImageButton.snp_updateConstraints { (make) -> Void in
             make.centerY.equalTo(self)
             if hasLeadingImageIcon {
-                make.leading.equalTo(self).offset(horizontalMargin)
+                make.leading.equalTo(self).offset(StandardHorizontalMargin)
             }
             else {
                 make.leading.equalTo(self)
@@ -121,10 +119,10 @@ public class CourseOutlineItemView: UIView {
             let titleOffset = shouldOffsetTitle ? TitleOffsetCenterY : 0
             make.centerY.equalTo(self).offset(titleOffset)
             if hasLeadingImageIcon {
-                make.leading.equalTo(leadingImageButton.snp_trailing).offset(horizontalMargin)
+                make.leading.equalTo(leadingImageButton.snp_trailing).offset(StandardHorizontalMargin)
             }
             else {
-                make.leading.equalTo(self).offset(horizontalMargin)
+                make.leading.equalTo(self).offset(StandardHorizontalMargin)
             }
             make.trailing.lessThanOrEqualTo(trailingContainer.snp_leading).offset(TitleOffsetTrailing)
         }

--- a/Source/DiscussionCommentsViewController.swift
+++ b/Source/DiscussionCommentsViewController.swift
@@ -86,7 +86,7 @@ class DiscussionCommentCell: UITableViewCell {
         containerView.addSubview(endorsedLabel)
         endorsedLabel.snp_makeConstraints { (make) -> Void in
             make.leading.equalTo(bodyTextLabel)
-            make.top.equalTo(containerView).offset(OEXStyles.sharedStyles().standardVerticalMargin)
+            make.top.equalTo(containerView).offset(StandardVerticalMargin)
         }
     
         containerView.addSubview(commentCountOrReportIconButton)

--- a/Source/DiscussionNewCommentViewController.swift
+++ b/Source/DiscussionNewCommentViewController.swift
@@ -177,13 +177,13 @@ public class DiscussionNewCommentViewController: UIViewController, UITextViewDel
         
         switch item {
         case .Post(_):
-            buttonTitle = OEXLocalizedString("ADD_RESPONSE", nil)
-            placeholderText = OEXLocalizedString("ADD_A_RESPONSE", nil)
-            navigationItemTitle = OEXLocalizedString("ADD_A_RESPONSE", nil)
+            buttonTitle = Strings.addResponse
+            placeholderText = Strings.addAResponse
+            navigationItemTitle = Strings.addResponse
         case .Response(_):
-            buttonTitle = OEXLocalizedString("ADD_COMMENT", nil)
-            placeholderText = OEXLocalizedString("ADD_A_COMMENT", nil)
-            navigationItemTitle = OEXLocalizedString("ADD_COMMENT", nil)
+            buttonTitle = Strings.addComment
+            placeholderText = Strings.addAComment
+            navigationItemTitle = Strings.addComment
             responseTitle.snp_makeConstraints{ (make) -> Void in
                 make.height.equalTo(0)
             }

--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -265,8 +265,8 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
     }
 
     enum TableSection : Int {
-        case Post = 0
-        case Responses = 1
+        case Post
+        case Responses
     }
     
     var environment: Environment!

--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -265,8 +265,8 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
     }
 
     enum TableSection : Int {
-        case Post
-        case Responses
+        case Post = 0
+        case Responses = 1
     }
     
     var environment: Environment!

--- a/Source/DiscussionTopicCell.swift
+++ b/Source/DiscussionTopicCell.swift
@@ -47,7 +47,6 @@ class DiscussionTopicCell: UITableViewCell {
             }
             if let discussionTopic = topic {
                 titleAttributedStrings.append(titleTextStyle.attributedStringWithText(discussionTopic.name))
-                titleAttributedStrings.append(titleTextStyle.attributedStringWithText("This text will make the title big so that we can be very sure about the wrapping"))
             }
             
             self.titleLabel.attributedText = NSAttributedString.joinInNaturalLayout(titleAttributedStrings)

--- a/Source/DiscussionTopicCell.swift
+++ b/Source/DiscussionTopicCell.swift
@@ -70,7 +70,7 @@ class DiscussionTopicCell: UITableViewCell {
 
 }
 
-extension String {
+private extension String {
     var userFacingString : String {
         return self.isEmpty ? Strings.untitled : self
     }

--- a/Source/DiscussionTopicCell.swift
+++ b/Source/DiscussionTopicCell.swift
@@ -1,5 +1,5 @@
 //
-//  DiscussionTopicsCell.swift
+//  DiscussionTopicCell.swift
 //  edX
 //
 //  Created by Jianfeng Qiu on 11/05/2015.
@@ -8,9 +8,9 @@
 
 import UIKit
 
-class DiscussionTopicsCell: UITableViewCell {
+class DiscussionTopicCell: UITableViewCell {
 
-    static let identifier = "DiscussionTopicsCellIdentifier"
+    static let identifier = "DiscussionTopicCellIdentifier"
     
     private let titleLabel = UILabel()
     
@@ -28,8 +28,12 @@ class DiscussionTopicsCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private var margin : CGFloat {
+    private var horizontalMargin : CGFloat {
         return OEXStyles.sharedStyles().standardHorizontalMargin()
+    }
+    
+    private var verticalMargin : CGFloat {
+        return OEXStyles.sharedStyles().standardVerticalMargin
     }
     
     var topic : DiscussionTopic? = nil {
@@ -43,6 +47,7 @@ class DiscussionTopicsCell: UITableViewCell {
             }
             if let discussionTopic = topic {
                 titleAttributedStrings.append(titleTextStyle.attributedStringWithText(discussionTopic.name))
+                titleAttributedStrings.append(titleTextStyle.attributedStringWithText("This text will make the title big so that we can be very sure about the wrapping"))
             }
             
             self.titleLabel.attributedText = NSAttributedString.joinInNaturalLayout(titleAttributedStrings)
@@ -56,11 +61,12 @@ class DiscussionTopicsCell: UITableViewCell {
         self.contentView.addSubview(titleLabel)
 
         self.titleLabel.snp_makeConstraints { (make) -> Void in
-            make.trailing.equalTo(self.contentView).offset(margin)
-            make.top.equalTo(self.contentView)
-            make.bottom.equalTo(self.contentView)
+            make.trailing.equalTo(self.contentView).offset(-horizontalMargin)
+            make.top.equalTo(self.contentView).offset(verticalMargin)
+            make.bottom.equalTo(self.contentView).offset(-verticalMargin)
             make.leading.equalTo(self.contentView).offset(self.indentationOffsetForDepth(itemDepth: depth))
         }
+        self.titleLabel.numberOfLines = 0
     }
     
     private var depth : UInt = 0 {

--- a/Source/DiscussionTopicCell.swift
+++ b/Source/DiscussionTopicCell.swift
@@ -45,7 +45,7 @@ class DiscussionTopicCell: UITableViewCell {
                 titleAttributedStrings.append(topicIcon.attributedTextWithStyle(titleTextStyle, inline: true))
             }
             if let discussionTopic = topic {
-                titleAttributedStrings.append(titleTextStyle.attributedStringWithText(discussionTopic.name))
+                titleAttributedStrings.append(titleTextStyle.attributedStringWithText(discussionTopic.name?.userFacingString))
             }
             
             self.titleLabel.attributedText = NSAttributedString.joinInNaturalLayout(titleAttributedStrings)
@@ -76,6 +76,12 @@ class DiscussionTopicCell: UITableViewCell {
         }
     }
 
+}
+
+extension String {
+    var userFacingString : String {
+        return self.isEmpty ? Strings.untitled : self
+    }
 }
 
 extension UITableViewCell {

--- a/Source/DiscussionTopicCell.swift
+++ b/Source/DiscussionTopicCell.swift
@@ -15,12 +15,11 @@ class DiscussionTopicCell: UITableViewCell {
     private let titleLabel = UILabel()
     
     private var titleTextStyle : OEXTextStyle {
-        return OEXTextStyle(weight: .Normal, size: .Base, color : OEXStyles.sharedStyles().neutralBlack())
+        return OEXTextStyle(weight: .Normal, size: .Small, color : OEXStyles.sharedStyles().neutralXDark())
     }
     
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        
         configureViews()
     }
     
@@ -72,6 +71,7 @@ class DiscussionTopicCell: UITableViewCell {
         didSet {
             self.titleLabel.snp_updateConstraints { make in
                 make.leading.equalTo(self.contentView).offset(self.indentationOffsetForDepth(itemDepth: depth))
+                depth == 0 ? self.applyStandardSeparatorInsets() : self.removeStandardSeparatorInsets()
             }
         }
     }

--- a/Source/DiscussionTopicCell.swift
+++ b/Source/DiscussionTopicCell.swift
@@ -27,14 +27,6 @@ class DiscussionTopicCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private var horizontalMargin : CGFloat {
-        return OEXStyles.sharedStyles().standardHorizontalMargin()
-    }
-    
-    private var verticalMargin : CGFloat {
-        return OEXStyles.sharedStyles().standardVerticalMargin
-    }
-    
     var topic : DiscussionTopic? = nil {
         didSet {
             let depth = topic?.depth ?? 0
@@ -59,9 +51,9 @@ class DiscussionTopicCell: UITableViewCell {
         self.contentView.addSubview(titleLabel)
 
         self.titleLabel.snp_makeConstraints { (make) -> Void in
-            make.trailing.equalTo(self.contentView).offset(-horizontalMargin)
-            make.top.equalTo(self.contentView).offset(verticalMargin)
-            make.bottom.equalTo(self.contentView).offset(-verticalMargin)
+            make.trailing.equalTo(self.contentView).offset(-StandardHorizontalMargin)
+            make.top.equalTo(self.contentView).offset(StandardVerticalMargin)
+            make.bottom.equalTo(self.contentView).offset(-StandardVerticalMargin)
             make.leading.equalTo(self.contentView).offset(self.indentationOffsetForDepth(itemDepth: depth))
         }
         self.titleLabel.numberOfLines = 0
@@ -87,6 +79,6 @@ extension String {
 extension UITableViewCell {
     
     private func indentationOffsetForDepth(itemDepth depth : UInt) -> CGFloat {
-        return CGFloat(depth + 1) * OEXStyles.sharedStyles().standardHorizontalMargin()
+        return CGFloat(depth + 1) * StandardHorizontalMargin
     }
 }

--- a/Source/DiscussionTopicsViewController.swift
+++ b/Source/DiscussionTopicsViewController.swift
@@ -45,10 +45,6 @@ public class DiscussionTopicsViewController: UIViewController, UITableViewDataSo
     private let searchBar = UISearchBar()
     private let loadController : LoadStateViewController
     
-    private var searchBarTextStyle : OEXTextStyle {
-        return OEXTextStyle(weight: .Normal, size: .XSmall, color: self.environment.styles.neutralBlack())
-    }
-    
     private let contentView = UIView()
     private let tableView = UITableView()
     
@@ -66,6 +62,7 @@ public class DiscussionTopicsViewController: UIViewController, UITableViewDataSo
         )
         tableView.estimatedRowHeight = 80.0
         tableView.rowHeight = UITableViewAutomaticDimension
+        tableView.tableFooterView = UIView(frame: CGRectZero)
     }
     
     public required init?(coder aDecoder: NSCoder) {
@@ -86,7 +83,6 @@ public class DiscussionTopicsViewController: UIViewController, UITableViewDataSo
         // Set up tableView
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.applyStandardSeparatorInsets()
         self.contentView.addSubview(tableView)
         
         searchBar.placeholder = OEXLocalizedString("SEARCH_ALL_POSTS", nil)

--- a/Source/DiscussionTopicsViewController.swift
+++ b/Source/DiscussionTopicsViewController.swift
@@ -64,6 +64,8 @@ public class DiscussionTopicsViewController: UIViewController, UITableViewDataSo
             return DiscussionTopic.linearizeTopics($0)
             }
         )
+        tableView.estimatedRowHeight = 80.0
+        tableView.rowHeight = UITableViewAutomaticDimension
     }
     
     public required init?(coder aDecoder: NSCoder) {
@@ -104,7 +106,7 @@ public class DiscussionTopicsViewController: UIViewController, UITableViewDataSo
         }
         
         // Register tableViewCell
-        tableView.registerClass(DiscussionTopicsCell.self, forCellReuseIdentifier: DiscussionTopicsCell.identifier)
+        tableView.registerClass(DiscussionTopicCell.classForCoder(), forCellReuseIdentifier: DiscussionTopicCell.identifier)
         
         loadController.setupInController(self, contentView: contentView)
         
@@ -164,13 +166,9 @@ public class DiscussionTopicsViewController: UIViewController, UITableViewDataSo
         }
     }
     
-    public func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        return 50.0
-    }
-    
     public func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         
-        let cell = tableView.dequeueReusableCellWithIdentifier(DiscussionTopicsCell.identifier, forIndexPath: indexPath) as! DiscussionTopicsCell
+        let cell = tableView.dequeueReusableCellWithIdentifier(DiscussionTopicCell.identifier, forIndexPath: indexPath) as! DiscussionTopicCell
         
         var topic : DiscussionTopic? = nil
         

--- a/Source/DiscussionTopicsViewController.swift
+++ b/Source/DiscussionTopicsViewController.swift
@@ -47,6 +47,7 @@ public class DiscussionTopicsViewController: UIViewController, UITableViewDataSo
     
     private let contentView = UIView()
     private let tableView = UITableView()
+    private let searchBarSeparator = UIView()
     
     public init(environment: Environment, courseID: String) {
         self.environment = environment
@@ -78,12 +79,16 @@ public class DiscussionTopicsViewController: UIViewController, UITableViewDataSo
         self.navigationItem.backBarButtonItem = UIBarButtonItem(title: " ", style: .Plain, target: nil, action: nil)
         
         view.backgroundColor = self.environment.styles.standardBackgroundColor()
+        searchBarSeparator.backgroundColor = OEXStyles.sharedStyles().neutralBase()
+        
         self.view.addSubview(contentView)
+        self.contentView.addSubview(tableView)
+        self.contentView.addSubview(searchBar)
+        self.contentView.addSubview(searchBarSeparator)
         
         // Set up tableView
         tableView.dataSource = self
         tableView.delegate = self
-        self.contentView.addSubview(tableView)
         
         searchBar.placeholder = OEXLocalizedString("SEARCH_ALL_POSTS", nil)
         searchBar.delegate = self
@@ -91,14 +96,28 @@ public class DiscussionTopicsViewController: UIViewController, UITableViewDataSo
         searchBar.searchBarStyle = .Minimal
         searchBar.sizeToFit()
         
-        tableView.tableHeaderView = searchBar
-        
         contentView.snp_makeConstraints {make in
             make.edges.equalTo(self.view)
         }
         
+        searchBar.snp_makeConstraints { (make) -> Void in
+            make.top.equalTo(contentView)
+            make.leading.equalTo(contentView)
+            make.trailing.equalTo(contentView)
+            make.bottom.equalTo(searchBarSeparator.snp_top)
+        }
+        
+        searchBarSeparator.snp_makeConstraints { (make) -> Void in
+            make.height.equalTo(OEXStyles.dividerSize())
+            make.leading.equalTo(contentView)
+            make.trailing.equalTo(contentView)
+            make.bottom.equalTo(tableView.snp_top)
+        }
+        
         tableView.snp_makeConstraints { make -> Void in
-            make.edges.equalTo(self.contentView)
+            make.leading.equalTo(contentView)
+            make.trailing.equalTo(contentView)
+            make.bottom.equalTo(contentView)
         }
         
         // Register tableViewCell

--- a/Source/GradedSectionMessageView.swift
+++ b/Source/GradedSectionMessageView.swift
@@ -30,7 +30,7 @@ class GradedSectionMessageView: UIView {
     }
     
     private var textInset : CGFloat {
-        return OEXStyles.sharedStyles().standardHorizontalMargin()
+        return StandardHorizontalMargin
     }
     
     private var textStyle : OEXTextStyle {

--- a/Source/GrowingTextViewController.swift
+++ b/Source/GrowingTextViewController.swift
@@ -61,7 +61,7 @@ public class GrowingTextViewController {
                 // So, wait until the next run loop to update the contentSize.
                 dispatch_async(dispatch_get_main_queue()) {
                     let buttonFrame = scrollView.convertRect(bottomView.bounds, fromView:bottomView)
-                    scrollView.contentSize = CGSizeMake(scrollView.bounds.size.width, buttonFrame.maxY + OEXStyles.sharedStyles().standardHorizontalMargin())
+                    scrollView.contentSize = CGSizeMake(scrollView.bounds.size.width, buttonFrame.maxY + StandardHorizontalMargin)
                 }
             }
 

--- a/Source/MenuOptionsViewController.swift
+++ b/Source/MenuOptionsViewController.swift
@@ -13,7 +13,7 @@ protocol MenuOptionsViewControllerDelegate : class {
     func menuOptionsController(controller : MenuOptionsViewController, canSelectOptionAtIndex index: Int) -> Bool
 }
 
-//TODO: Remove this (duplicate) when swift compiler recognizes this extension from DiscussionTopicsCell.swift
+//TODO: Remove this (duplicate) when swift compiler recognizes this extension from DiscussionTopicCell.swift
 extension UITableViewCell {
     
     private func indentationOffsetForDepth(itemDepth depth : UInt) -> CGFloat {

--- a/Source/MenuOptionsViewController.swift
+++ b/Source/MenuOptionsViewController.swift
@@ -17,7 +17,7 @@ protocol MenuOptionsViewControllerDelegate : class {
 extension UITableViewCell {
     
     private func indentationOffsetForDepth(itemDepth depth : UInt) -> CGFloat {
-        return CGFloat(depth + 1) * OEXStyles.sharedStyles().standardHorizontalMargin()
+        return CGFloat(depth + 1) * StandardHorizontalMargin
     }
 }
 

--- a/Source/OEXStyles+Swift.swift
+++ b/Source/OEXStyles+Swift.swift
@@ -47,6 +47,10 @@ extension OEXStyles {
         if #available(iOS 9.0, *) {
             UITextField.appearanceWhenContainedInInstancesOfClasses([UISearchBar.classForCoder()]).defaultTextAttributes = searchBarTextStyle.attributes
         }
+        else {
+            //Make sure we remove UIAppearance+Swift.h+m when we drop iOS8 support
+            UITextField.my_appearanceWhenContainedIn(UISearchBar.classForCoder()).defaultTextAttributes = searchBarTextStyle.attributes
+        }
     }
     
     ///**Warning:** Not from style guide. Do not add more uses

--- a/Source/OEXStyles+Swift.swift
+++ b/Source/OEXStyles+Swift.swift
@@ -68,7 +68,7 @@ extension OEXStyles {
         return 50
     }
     
-    var standardVerticalMargin : CGFloat {
+    private var standardVerticalMargin : CGFloat {
         return 8.0
     }
     
@@ -103,4 +103,13 @@ extension OEXStyles {
         return BorderStyle(width: .Hairline, color: OEXStyles.sharedStyles().utilitySuccessBase())
     }
     
+}
+
+//Convenience computed properties for margins
+var StandardHorizontalMargin : CGFloat {
+    return OEXStyles.sharedStyles().standardHorizontalMargin()
+}
+
+var StandardVerticalMargin : CGFloat {
+    return OEXStyles.sharedStyles().standardVerticalMargin
 }

--- a/Source/OEXStyles+Swift.swift
+++ b/Source/OEXStyles+Swift.swift
@@ -19,6 +19,10 @@ extension OEXStyles {
         return OEXTextStyle(weight: .SemiBold, size: .XSmall, color: nil)
     }
     
+    private var searchBarTextStyle : OEXTextStyle {
+        return OEXTextStyle(weight: .Normal, size: .XSmall, color: OEXStyles.sharedStyles().neutralBlack())
+    }
+    
     public func applyGlobalAppearance() {
         
         if (OEXConfig.sharedConfig().shouldEnableNewCourseNavigation()) {
@@ -39,7 +43,10 @@ extension OEXStyles {
         }
         
         UINavigationBar.appearance().translucent = false
-        
+
+        if #available(iOS 9.0, *) {
+            UITextField.appearanceWhenContainedInInstancesOfClasses([UISearchBar.classForCoder()]).defaultTextAttributes = searchBarTextStyle.attributes
+        }
     }
     
     ///**Warning:** Not from style guide. Do not add more uses

--- a/Source/OfflineModeView.swift
+++ b/Source/OfflineModeView.swift
@@ -56,8 +56,8 @@ public class OfflineModeView: UIView {
         messageView.snp_makeConstraints {make in
             make.top.equalTo(self).offset(verticalMargin)
             make.bottom.equalTo(self).offset(-verticalMargin)
-            make.leading.equalTo(self).offset(styles.standardHorizontalMargin())
-            make.trailing.lessThanOrEqualTo(self).offset(styles.standardHorizontalMargin())
+            make.leading.equalTo(self).offset(StandardHorizontalMargin)
+            make.trailing.lessThanOrEqualTo(self).offset(StandardHorizontalMargin)
         }
     }
 }

--- a/Source/PostTableViewCell.swift
+++ b/Source/PostTableViewCell.swift
@@ -18,8 +18,8 @@ class PostTableViewCell: UITableViewCell {
     private let titleLabel = UILabel()
     private let countButton = UIButton(type: .Custom)
     
-    private var cellTextStyle : OEXTextStyle {
-        return OEXTextStyle(weight : .Normal, size: .Base, color: OEXStyles.sharedStyles().neutralLight())
+    private var postTypeStyle : OEXTextStyle {
+        return OEXTextStyle(weight: .Normal, size: .Small, color: OEXStyles.sharedStyles().neutralLight())
     }
     
     private var cellDetailTextStyle : OEXTextStyle {
@@ -54,14 +54,14 @@ class PostTableViewCell: UITableViewCell {
             make.size.equalTo(CGSizeMake(20, 20))
         }
         titleLabel.snp_makeConstraints { (make) -> Void in
-            make.leading.equalTo(typeButton.snp_trailing).offset(15)
-            make.top.greaterThanOrEqualTo(self.contentView).offset(5)
+            make.leading.equalTo(typeButton.snp_trailing).offset(StandardHorizontalMargin)
+            make.top.greaterThanOrEqualTo(self.contentView).offset(StandardVerticalMargin)
         }
         
         byLabel.snp_makeConstraints { (make) -> Void in
             make.leading.equalTo(titleLabel)
             make.top.greaterThanOrEqualTo(titleLabel.snp_bottom)
-            make.bottom.equalTo(contentView).offset(-5)
+            make.bottom.equalTo(contentView).offset(-StandardVerticalMargin)
         }
     }
     
@@ -72,11 +72,11 @@ class PostTableViewCell: UITableViewCell {
     }
     
     private var activeCountStyle : OEXTextStyle {
-        return OEXTextStyle(weight: .Normal, size: .Small, color : OEXStyles.sharedStyles().primaryBaseColor())
+        return OEXTextStyle(weight: .Normal, size: .XSmall, color : OEXStyles.sharedStyles().primaryBaseColor())
     }
     
     private var inactiveCountStyle : OEXTextStyle {
-        return OEXTextStyle(weight: .Normal, size: .Small, color : OEXStyles.sharedStyles().neutralBase())
+        return OEXTextStyle(weight: .Normal, size: .XSmall, color : OEXStyles.sharedStyles().neutralBase())
     }
     
     private var titleText : String? {
@@ -126,7 +126,7 @@ class PostTableViewCell: UITableViewCell {
     }
         
     func usePost(post : DiscussionPostItem, selectedOrderBy : DiscussionPostsSort) {
-        self.typeText = iconForPost(post).attributedTextWithStyle(cellTextStyle)
+        self.typeText = iconForPost(post).attributedTextWithStyle(postTypeStyle)
         self.titleText = post.title
         var options = [NSAttributedString]()
         

--- a/Source/PostsViewController.swift
+++ b/Source/PostsViewController.swift
@@ -294,7 +294,7 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
         }
         
         refineLabel.snp_makeConstraints { (make) -> Void in
-            make.leadingMargin.equalTo(headerView).offset(OEXStyles.sharedStyles().standardHorizontalMargin())
+            make.leadingMargin.equalTo(headerView).offset(StandardHorizontalMargin)
             make.centerY.equalTo(headerView)
         }
         refineLabel.setContentHuggingPriority(UILayoutPriorityRequired, forAxis: .Horizontal)

--- a/Source/SeparatorInsetable.swift
+++ b/Source/SeparatorInsetable.swift
@@ -18,6 +18,17 @@ extension SeparatorInsetable where Self : UIView {
         self.preservesSuperviewLayoutMargins = false
         self.layoutMargins = UIEdgeInsetsZero
     }
+    
+    private var defaultEdgeInsets : UIEdgeInsets {
+        return UIEdgeInsets(top: 0, left: OEXStyles.sharedStyles().standardHorizontalMargin(), bottom: 0, right: 0)
+    }
+    
+    func removeStandardSeparatorInsets() {
+        self.separatorInset = defaultEdgeInsets
+        self.preservesSuperviewLayoutMargins = true
+        self.layoutMargins = defaultEdgeInsets
+        
+    }
 
 }
 

--- a/Source/SeparatorInsetable.swift
+++ b/Source/SeparatorInsetable.swift
@@ -20,7 +20,7 @@ extension SeparatorInsetable where Self : UIView {
     }
     
     private var defaultEdgeInsets : UIEdgeInsets {
-        return UIEdgeInsets(top: 0, left: OEXStyles.sharedStyles().standardHorizontalMargin(), bottom: 0, right: 0)
+        return UIEdgeInsets(top: 0, left: StandardHorizontalMargin, bottom: 0, right: 0)
     }
     
     func removeStandardSeparatorInsets() {

--- a/Source/UIAppearance+Swift.h
+++ b/Source/UIAppearance+Swift.h
@@ -1,0 +1,16 @@
+//
+//  UIAppearance+Swift.h
+//  edX
+//
+//  Created by Ehmad Zubair Chughtai on 08/10/2015.
+//  Copyright © 2015 edX. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//Make sure we remove this when we drop iOS8 support
+
+@interface UIView (UIViewAppearance_Swift)
+// appearanceWhenContainedIn: is not available in Swift. This fixes that.
++ (instancetype)my_appearanceWhenContainedIn:(Class<UIAppearanceContainer>)containerClass;
+@end

--- a/Source/UIAppearance+Swift.m
+++ b/Source/UIAppearance+Swift.m
@@ -1,0 +1,16 @@
+//
+//  UIAppearance+Swift.m
+//  edX
+//
+//  Created by Ehmad Zubair Chughtai on 08/10/2015.
+//  Copyright © 2015 edX. All rights reserved.
+//
+
+#import "UIAppearance+Swift.h"
+
+// UIAppearance+Swift.m
+@implementation UIView (UIViewAppearance_Swift)
++ (instancetype)my_appearanceWhenContainedIn:(Class<UIAppearanceContainer>)containerClass {
+    return [self appearanceWhenContainedIn:containerClass, nil];
+}
+@end

--- a/Source/edX-Bridging-Header.h
+++ b/Source/edX-Bridging-Header.h
@@ -54,6 +54,7 @@
 #import "OEXVideoEncoding.h"
 #import "OEXVideoSummary.h"
 #import "OEXVideoPlayerInterface.h"
+#import "UIAppearance+Swift.h"
 
 #import "Reachability.h"
 

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -390,7 +390,7 @@
 		9E71B73F1B1D9DBD009C81E2 /* OEXStyles+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E71B73E1B1D9DBC009C81E2 /* OEXStyles+Swift.swift */; };
 		9E74AFE71B4A821500B2D843 /* CourseLastAccessedControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E74AFE61B4A821500B2D843 /* CourseLastAccessedControllerTests.swift */; };
 		9E7D1BCC1AEA5BF5000AF768 /* OEXDownloadViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E7D1BCB1AEA5BF5000AF768 /* OEXDownloadViewController.storyboard */; };
-		9E882B6A1BBA9825007347A2 /* DiscussionTopicsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CECC3D1B041FAF0073C63A /* DiscussionTopicsCell.swift */; settings = {ASSET_TAGS = (); }; };
+		9E882B6A1BBA9825007347A2 /* DiscussionTopicCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CECC3D1B041FAF0073C63A /* DiscussionTopicCell.swift */; settings = {ASSET_TAGS = (); }; };
 		9E9AA36C1B3174E300CD7D44 /* CourseLastAccessedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9AA36B1B3174E300CD7D44 /* CourseLastAccessedTests.swift */; };
 		9E9AA36E1B31757800CD7D44 /* CourseStatusInfo.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E9AA36D1B31757800CD7D44 /* CourseStatusInfo.json */; };
 		9EAB5BE91B564C2F00CA9F3C /* ProgressController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EAB5BE81B564C2F00CA9F3C /* ProgressController.swift */; };
@@ -681,7 +681,7 @@
 		1ACD163B1BB1BE63006ACC82 /* UserProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserProfileViewController.swift; sourceTree = "<group>"; };
 		46CECC391B041CDC0073C63A /* CourseDashboardCourseInfoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseDashboardCourseInfoView.swift; sourceTree = "<group>"; };
 		46CECC3B1B041D270073C63A /* CourseDashboardCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseDashboardCell.swift; sourceTree = "<group>"; };
-		46CECC3D1B041FAF0073C63A /* DiscussionTopicsCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscussionTopicsCell.swift; sourceTree = "<group>"; };
+		46CECC3D1B041FAF0073C63A /* DiscussionTopicCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscussionTopicCell.swift; sourceTree = "<group>"; };
 		46CECC3F1B041FCA0073C63A /* DiscussionTopicsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscussionTopicsViewController.swift; sourceTree = "<group>"; };
 		46CECC431B055B0F0073C63A /* CourseDashboardViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseDashboardViewControllerTests.swift; sourceTree = "<group>"; };
 		5D43B1801B0C1F9200448B52 /* PostTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostTableViewCell.swift; sourceTree = "<group>"; };
@@ -1602,7 +1602,7 @@
 				5D43B1841B0C1F9200448B52 /* MenuOptionsViewController.swift */,
 				80056C991B0CDE1A0004D85C /* DiscussionResponsesViewController.swift */,
 				46CECC3F1B041FCA0073C63A /* DiscussionTopicsViewController.swift */,
-				46CECC3D1B041FAF0073C63A /* DiscussionTopicsCell.swift */,
+				46CECC3D1B041FAF0073C63A /* DiscussionTopicCell.swift */,
 				8053290F1B0E80E50093B177 /* DiscussionResponses.storyboard */,
 				5DD0FFC21B17ED2100837121 /* DiscussionCommentsViewController.swift */,
 				5DD0FFCD1B1D225C00837121 /* DiscussionNewPostViewController.swift */,
@@ -3017,7 +3017,7 @@
 				77092C751B42E4C1004AA1A1 /* UIStatusBarStyle+Styles.swift in Sources */,
 				191A002E19405E97004F7902 /* OEXLatestUpdates.m in Sources */,
 				198826F1195D6979005D4D8A /* OEXMyVideosViewController.m in Sources */,
-				9E882B6A1BBA9825007347A2 /* DiscussionTopicsCell.swift in Sources */,
+				9E882B6A1BBA9825007347A2 /* DiscussionTopicCell.swift in Sources */,
 				77AB8C811B33BCBB00AB3FC0 /* PersistentResponseCache.swift in Sources */,
 				B4B285ED1A9B429200DD603A /* OEXNetworkUtility.m in Sources */,
 				BE0D454A192DD4F800D720D6 /* OEXNetworkInterface.m in Sources */,

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 		9E0CC1031BA9574E00A1CFDB /* SpinnerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E0CC1021BA9574E00A1CFDB /* SpinnerButton.swift */; };
 		9E0D4BD31B0C84F800B2417D /* CourseUnknownBlockViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E0D4BD21B0C84F800B2417D /* CourseUnknownBlockViewController.swift */; };
 		9E1081081B8B7EEC00888746 /* PaginatedFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1081071B8B7EEC00888746 /* PaginatedFeed.swift */; };
+		9E17EFD31BC65B7600C903CC /* UIAppearance+Swift.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E17EFD21BC65B7600C903CC /* UIAppearance+Swift.m */; settings = {ASSET_TAGS = (); }; };
 		9E1D952E1B678E4700ABE764 /* AccessibilityCLButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1D952D1B678E4700ABE764 /* AccessibilityCLButton.swift */; };
 		9E1D95321B68CEA000ABE764 /* UIButton+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1D95311B68CEA000ABE764 /* UIButton+Accessibility.swift */; };
 		9E265C9E1B87419B00794461 /* NetworkPaginator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E265C9D1B87419B00794461 /* NetworkPaginator.swift */; };
@@ -1026,6 +1027,8 @@
 		9E0CC1021BA9574E00A1CFDB /* SpinnerButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpinnerButton.swift; sourceTree = "<group>"; };
 		9E0D4BD21B0C84F800B2417D /* CourseUnknownBlockViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseUnknownBlockViewController.swift; sourceTree = "<group>"; };
 		9E1081071B8B7EEC00888746 /* PaginatedFeed.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaginatedFeed.swift; sourceTree = "<group>"; };
+		9E17EFD11BC65B7600C903CC /* UIAppearance+Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIAppearance+Swift.h"; sourceTree = "<group>"; };
+		9E17EFD21BC65B7600C903CC /* UIAppearance+Swift.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIAppearance+Swift.m"; sourceTree = "<group>"; };
 		9E1D952D1B678E4700ABE764 /* AccessibilityCLButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AccessibilityCLButton.swift; path = ../AccessibilityCLButton.swift; sourceTree = "<group>"; };
 		9E1D95311B68CEA000ABE764 /* UIButton+Accessibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIButton+Accessibility.swift"; sourceTree = "<group>"; };
 		9E265C9D1B87419B00794461 /* NetworkPaginator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkPaginator.swift; sourceTree = "<group>"; };
@@ -1773,6 +1776,8 @@
 				1A22CD8F1B90B31A005B07D0 /* UIImage+OEXIcon.swift */,
 				774B39381B5DD85A00595D33 /* UIView+LayoutDirection.swift */,
 				9E0CC1021BA9574E00A1CFDB /* SpinnerButton.swift */,
+				9E17EFD11BC65B7600C903CC /* UIAppearance+Swift.h */,
+				9E17EFD21BC65B7600C903CC /* UIAppearance+Swift.m */,
 			);
 			name = "Library Additions";
 			sourceTree = "<group>";
@@ -3177,6 +3182,7 @@
 				B4B6D6021A949EFC000F44E8 /* OEXRegistrationFormField.m in Sources */,
 				77FDF4191B02910D00E8C639 /* IconMessageView.swift in Sources */,
 				19321F6219615E3300B7D75C /* OEXMyVideosSubSectionViewController.m in Sources */,
+				9E17EFD31BC65B7600C903CC /* UIAppearance+Swift.m in Sources */,
 				77FFA2BE1AC3031900B4D69B /* OEXUsingExternalAuthHeadingView.m in Sources */,
 				775DF41A1AFAB04300F96B2F /* CourseDataManager.swift in Sources */,
 				B4B6D62E1A949F1B000F44E8 /* OEXRegistrationFieldTextAreaController.m in Sources */,


### PR DESCRIPTION
- Discussion Topics screen now matches spec + Auto Resizing for Topics with longer titles
- `UISearchBar` matches spec when on iOS9
- Match Add Comment and Add Response as navigation titles
- Pin the Search Bar to the top and add a separator
- Replace a "" String with a user-friendly string

###### "If user is not following any posts, the "Posts I'm following" should not be visible"
This wasn't done because there's no graceful way to know if the user is following any posts for the endpoint : `/api/discussion/v1/course-v1:TestX+TestCourse+TestRun`

### Topics Screen
![simulator screen shot 07-oct-2015 4 56 35 pm](https://cloud.githubusercontent.com/assets/10597112/10336741/77fb4d90-6d14-11e5-9d16-2cf3df5ce916.png)

### Resizing Cells

![simulator screen shot 07-oct-2015 3 12 25 pm](https://cloud.githubusercontent.com/assets/10597112/10336331/7fe1f732-6d11-11e5-9709-0cf9b1d9be14.png)