### PR TITLE
Fix crash pushing back after watching video.

### DIFF
--- a/Source/OEXStyles+Swift.swift
+++ b/Source/OEXStyles+Swift.swift
@@ -38,10 +38,7 @@ extension OEXStyles {
             UISegmentedControl.appearance().tintColor = self.neutralLight()
         }
         
-        if UIDevice.currentDevice().isOSVersionAtLeast8() {
-            UINavigationBar.appearance().translucent = false
-        }
-        
+        UINavigationBar.appearance().translucent = false
         
     }
     

--- a/Source/OEXVideoPlayerInterface.m
+++ b/Source/OEXVideoPlayerInterface.m
@@ -234,7 +234,17 @@
     [super viewWillDisappear:animated];
     [NSObject cancelPreviousPerformRequestsWithTarget:self];
     [_moviePlayerController setShouldAutoplay:NO];
-    [_moviePlayerController pause];
+    
+    // There appears to be an OS bug on iOS 8
+    // where if you don't call "stop" before a movie player view disappears
+    // it can cause a crash
+    // See http://stackoverflow.com/questions/31188035/overreleased-mpmovieplayercontroller-under-arc-in-ios-sdk-8-4-on-ipad
+    if([UIDevice isOSVersionAtLeast9]) {
+        [_moviePlayerController pause];
+    }
+    else {
+        [_moviePlayerController stop];
+    }
     _shouldRotate = NO;
 }
 

--- a/Source/UIDevice+OSVersion.swift
+++ b/Source/UIDevice+OSVersion.swift
@@ -9,15 +9,15 @@
 import Foundation
 
 extension UIDevice {
+    /// This is only for use from Objective-C code. Swift code should use
+    /// if #available.
     private func isOSVersionAtLeast(version : Int) -> Bool {
         return UIDevice.currentDevice().systemVersion.compare(String(version), options: NSStringCompareOptions.NumericSearch) != .OrderedAscending
     }
     
-    func isOSVersionAtLeast8() -> Bool {
-        return isOSVersionAtLeast(8)
-    }
-    
-    class func isOSVersionAtLeast8() -> Bool {
-        return currentDevice().isOSVersionAtLeast8()
+    /// This is only for use from Objective-C code. Swift code should use
+    /// if #available.
+    class func isOSVersionAtLeast9() -> Bool {
+        return currentDevice().isOSVersionAtLeast(9)
     }
 }


### PR DESCRIPTION
There was a crash if you started watching a video and then hit the back
button. It appears to be caused by an iOS 8 only OS bug.

Also cleans up usage of isOSVersionAtLeast8 so we only check for the
one version back.