### PR TITLE
Fix issue with bunched text.

### DIFF
--- a/Source/IconMessageView.swift
+++ b/Source/IconMessageView.swift
@@ -26,7 +26,6 @@ class IconMessageView : UIView {
     private var buttonFontStyle : OEXTextStyle {
         return OEXTextStyle(weight :.Normal, size : .Base, color : styles?.neutralDark())
     }
-    private let shouldRotateIcon : Bool
     
     private let iconView : UIImageView
     private let messageView : UILabel
@@ -34,10 +33,8 @@ class IconMessageView : UIView {
     
     private let container : UIView
     
-    init(icon : Icon? = nil, message : String? = nil, buttonTitle : String? = nil, styles : OEXStyles?, shouldRotateIcon : Bool = false) {
+    init(icon : Icon? = nil, message : String? = nil, buttonTitle : String? = nil, styles : OEXStyles?) {
         self.styles = styles
-        
-        self.shouldRotateIcon = shouldRotateIcon
         
         container = UIView(frame: CGRectZero)
         iconView = UIImageView(frame: CGRectZero)
@@ -83,14 +80,7 @@ class IconMessageView : UIView {
     
     var icon : Icon? {
         didSet {
-            if self.shouldRotateIcon {
-                rotateImageViewClockwise(iconView)
-                iconView.image = icon?.imageWithFontSize(IconMessageRotatedSize)
-            }
-            else {
-                iconView.image = icon?.imageWithFontSize(IconMessageSize)
-            }
-            
+            iconView.image = icon?.imageWithFontSize(IconMessageSize)
         }
     }
     
@@ -140,8 +130,8 @@ class IconMessageView : UIView {
         container.snp_makeConstraints { (make) -> Void in
             make.center.equalTo(self)
             make.leading.greaterThanOrEqualTo(self)
-            make.top.greaterThanOrEqualTo(self)
             make.trailing.lessThanOrEqualTo(self)
+            make.top.greaterThanOrEqualTo(self)
             make.bottom.lessThanOrEqualTo(self)
         }
         
@@ -149,10 +139,6 @@ class IconMessageView : UIView {
             make.leading.equalTo(container)
             make.trailing.equalTo(container)
             make.top.equalTo(container)
-        }
-        
-        if shouldRotateIcon {
-            iconView.center = CGPointMake(iconView.frame.size.width/2, iconView.frame.size.height/2);
         }
         
         messageView.snp_updateConstraints { (make) -> Void in

--- a/Source/VideoBlockViewController.swift
+++ b/Source/VideoBlockViewController.swift
@@ -90,7 +90,7 @@ class VideoBlockViewController : UIViewController, CourseBlockViewController, OE
         videoController.view.translatesAutoresizingMaskIntoConstraints = false
         videoController.fadeInOnLoad = false
         
-        rotateDeviceMessageView = IconMessageView(icon: .Mobile, message: OEXLocalizedString("ROTATE_DEVICE", nil), styles: self.environment.styles, shouldRotateIcon : true)
+        rotateDeviceMessageView = IconMessageView(icon: .RotateDevice, message: Strings.rotateDevice, styles: self.environment.styles)
         contentView!.addSubview(rotateDeviceMessageView!)
         
         view.backgroundColor = self.environment.styles?.standardBackgroundColor()


### PR DESCRIPTION
We were rotating a view 90 degrees to get its icon to be rotated 90
degress which screwed up autolayout. This switches to actually rendering
the icon rotated. Since this was a thing we were already doing in a one
off way, this generalizes the concept and creates a rotated icon
renderer. It also factors the icon renderer list to better catch
exhaustivity when not using FontAwesome.

JIRA: https://openedx.atlassian.net/browse/MA-1440