### PR TITLE
Fix issue with table updates happening in background when request fails.

### DIFF
--- a/Source/OEXInterface.m
+++ b/Source/OEXInterface.m
@@ -604,7 +604,7 @@ static OEXInterface* _sharedInterface = nil;
     [self processData:data forType:URLString usingOfflineCache:NO];
 }
 
-- (void)returnedFaliureForType:(NSString*)URLString {
+- (void)returnedFailureForType:(NSString*)URLString {
     //VIDEO URL
     if([OEXInterface isURLForVideo:URLString]) {
     }

--- a/Source/OEXNetworkInterface.h
+++ b/Source/OEXNetworkInterface.h
@@ -13,7 +13,7 @@
 
 //Foreground Calls
 - (void)returnedData:(NSData*)data forType:(NSString*)URLString;
-- (void)returnedFaliureForType:(NSString*)URLString;
+- (void)returnedFailureForType:(NSString*)URLString;
 
 //Background Calls
 - (void)didAddDownloadForURLString:(NSString*)URLString;

--- a/Source/OEXNetworkInterface.m
+++ b/Source/OEXNetworkInterface.m
@@ -111,19 +111,27 @@
 #pragma mark NetworkDelegate
 
 - (void)receivedData:(NSData*)data forTask:(NSURLSessionTask*)task {
-    [_delegate returnedData:data forType:[self descriptionForURLString:task.originalRequest.URL.absoluteString]];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_delegate returnedData:data forType:[self descriptionForURLString:task.originalRequest.URL.absoluteString]];
+    });
 }
 
-- (void)receivedFaliureforTask:(NSURLSessionTask*)task {
-    [_delegate returnedFaliureForType:[self descriptionForURLString:task.originalRequest.URL.absoluteString]];
+- (void)receivedFailureforTask:(NSURLSessionTask*)task {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_delegate returnedFailureForType:[self descriptionForURLString:task.originalRequest.URL.absoluteString]];
+    });
 }
 
 - (void)downloadAddedForURL:(NSURL*)url {
-    [_delegate didAddDownloadForURLString:url.absoluteString];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_delegate didAddDownloadForURLString:url.absoluteString];
+    });
 }
 
 - (void)downloadAlreadyExistsForURL:(NSURL*)url {
-    [_delegate didRejectDownloadForURLString:url.absoluteString];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [_delegate didRejectDownloadForURLString:url.absoluteString];
+    });
 }
 
 @end

--- a/Source/OEXNetworkManager.h
+++ b/Source/OEXNetworkManager.h
@@ -12,7 +12,7 @@
 
 //Foreground Calls
 - (void)receivedData:(NSData*)data forTask:(NSURLSessionTask*)task;
-- (void)receivedFaliureforTask:(NSURLSessionTask*)task;
+- (void)receivedFailureforTask:(NSURLSessionTask*)task;
 
 //Background Calls
 - (void)downloadAlreadyExistsForURL:(NSURL*)url;

--- a/Source/OEXNetworkManager.m
+++ b/Source/OEXNetworkManager.m
@@ -254,7 +254,7 @@ static OEXNetworkManager* _sharedManager = nil;
         return;
     }
     if(error) {
-        [_delegate receivedFaliureforTask:task];
+        [_delegate receivedFailureforTask:task];
     }
 }
 
@@ -272,7 +272,7 @@ static OEXNetworkManager* _sharedManager = nil;
     int responseStatusCode = (int)[httpResponse statusCode];
     if(responseStatusCode != 200) {
         //ELog(@"Data Task failed for request [%@], Error [%d]", dataTask.taskDescription, responseStatusCode);
-        [_delegate receivedFaliureforTask:dataTask];
+        [_delegate receivedFailureforTask:dataTask];
         return;
     }
 


### PR DESCRIPTION
I was seeing us call reloadData from inside a network callback on
OEXFrontCourseViewController, which of course made UIKit super unhappy.
Looking deeper, I found that the old network manager never dispatched
off the URL session's callback thread, so we were doing things like
updating UI on background threads.

This just shoves all the callbacks onto the main thread.

I'm sure there are still threading issues in that thing, but this
seeemed like the easiest way to resolve most of them.

Also gets rid of some faliures I discovered along the way.