### PR TITLE
Navigation title now matches spec

### DIFF
--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -354,7 +354,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         
         super.viewDidLoad()
         
-        self.navigationItem.title = Strings.discussionPost
+        self.navigationItem.title = postItem?.navigationItemTitle
         self.view.backgroundColor = OEXStyles.sharedStyles().discussionsBackgroundColor
         self.contentView.backgroundColor = OEXStyles.sharedStyles().neutralXLight()
         tableView.backgroundColor = UIColor.clearColor()
@@ -779,6 +779,18 @@ extension DiscussionPostItem : AuthorLabelProtocol {
 
 extension DiscussionResponseItem : AuthorLabelProtocol {
     
+}
+
+private extension DiscussionPostItem {
+    
+    var navigationItemTitle : String {
+        switch self.type {
+        case .Discussion:
+            return Strings.discussion
+        case .Question:
+            return self.hasEndorsed ? Strings.answeredQuestion : Strings.unansweredQuestion
+        }
+    }
 }
 
 

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -88,6 +88,8 @@
 "ANNOUNCEMENT_UNAVAILABLE"="There are currently no announcements for this course.";
 /* Label indicating the response answer in Discussion Add comment screen */
 "ANSWER"="Answer";
+/* Navigation title for a Question Post which has endorsed answers */
+"ANSWERED_QUESTION"="Answered Question";
 /* Prefix used with Staff of Community TA on the posts screen */
 "BY_AUTHOR" = "By {author_name}";
 /* Prefix used with Staff of Community TA on the posts screen */
@@ -476,6 +478,8 @@
 "UNABLE_TO_LOAD_COURSE_CONTENT"="Unable to load course content.\nTry again later.";
 /* Filtering option to show unanswered discussion posts */
 "UNANSWERED"="Unanswered";
+/* Navigation title for a Question Post which has no endorsed answers */
+"UNANSWERED_QUESTION" = "Unanswered Question";
 /* Filtering option to show unread discussion posts*/
 "UNREAD"="Unread";
 /* Placeholder title for course content with no title */


### PR DESCRIPTION
#### According to @explorerleslie 

The options should be: 
Discussion
Unanswered Question
Answered Question
We shouldn't differentiate between closed and not closed here.