### PR TITLE
Parameterize platform name

### DIFF
--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -186,11 +186,11 @@ public class CourseOutlineViewController :
         case .Full:
             return LoadState.failed(NSError.oex_courseContentLoadError())
         case .Video:
-            let parameter = "mode_switcher"
-            let message = Strings.noVideosTryModeSwitcher(modeSwitcher: "{\(parameter)}")
-            let attributedMessage = loadController.messageStyle.attributedStringWithText(message)
-            let formattedMessage = attributedMessage.oex_formatWithParameters([parameter : Icon.CourseModeVideo.attributedTextWithStyle(loadController.messageStyle , inline : true)])
-            let accessibilityMessage = message.oex_formatWithParameters([parameter : Strings.courseModePickerDescription])
+            let style = loadController.messageStyle
+            let message = style.apply(Strings.noVideosTryModeSwitcher)
+            let iconText = Icon.CourseModeVideo.attributedTextWithStyle(style, inline: true)
+            let formattedMessage = message(iconText)
+            let accessibilityMessage = Strings.noVideosTryModeSwitcher(modeSwitcher: Strings.courseModePickerDescription)
             return LoadState.empty(icon: Icon.CourseModeFull, attributedMessage : formattedMessage, accessibilityMessage : accessibilityMessage)
         }
     }

--- a/Source/DiscussionCommentsViewController.swift
+++ b/Source/DiscussionCommentsViewController.swift
@@ -122,7 +122,7 @@ class DiscussionCommentCell: UITableViewCell {
         
         self.containerView.backgroundColor = OEXStyles.sharedStyles().neutralWhiteT()
         
-        let message = Strings.comment(count: Float(response.commentCount))
+        let message = Strings.comment(count: response.commentCount)
         let buttonTitle = NSAttributedString.joinInNaturalLayout([
             Icon.Comment.attributedTextWithStyle(smallIconStyle),
             smallTextStyle.attributedStringWithText(message)])

--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -519,7 +519,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
 
             if let responseCount = item.responseCount {
                 let icon = Icon.Comment.attributedTextWithStyle(infoTextStyle)
-                let countLabelText = infoTextStyle.attributedStringWithText(Strings.response(count: Float(responseCount)))
+                let countLabelText = infoTextStyle.attributedStringWithText(Strings.response(count: responseCount))
                 
                 let labelText = NSAttributedString.joinInNaturalLayout([icon,countLabelText])
                 cell.responseCountLabel.attributedText = labelText
@@ -613,7 +613,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
             icon = postClosed ? Icon.Closed : Icon.Comment
         }
         else {
-            prompt = Strings.commentsToResponse(count: Float(commentCount))
+            prompt = Strings.commentsToResponse(count: commentCount)
             icon = Icon.Comment
         }
         
@@ -690,7 +690,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         let iconStyle = voted ? cellIconSelectedStyle : cellButtonStyle
         let buttonText = NSAttributedString.joinInNaturalLayout([
             Icon.UpVote.attributedTextWithStyle(iconStyle, inline : true),
-            cellButtonStyle.attributedStringWithText(Strings.vote(count: Float(voteCount)))])
+            cellButtonStyle.attributedStringWithText(Strings.vote(count: voteCount))])
         
         button.setAttributedTitle(buttonText, forState:.Normal)
     }

--- a/Source/DownloadsAccessoryView.swift
+++ b/Source/DownloadsAccessoryView.swift
@@ -97,7 +97,7 @@ class DownloadsAccessoryView : UIView {
                 countLabel.hidden = false
                 
                 if let count = itemCount {
-                    let message = Strings.downloadManyVideos(videoCount: Float(count))
+                    let message = Strings.downloadManyVideos(videoCount: count)
                     self.accessibilityLabel = message
                 }
                 else {
@@ -122,7 +122,7 @@ class DownloadsAccessoryView : UIView {
                 countLabel.hidden = false
                 
                 if let count = itemCount {
-                    let message = Strings.downloadManyVideos(videoCount: Float(count))
+                    let message = Strings.downloadManyVideos(videoCount: count)
                     self.accessibilityLabel = message
                 }
                 else {

--- a/Source/NSAttributedString+Formatting.swift
+++ b/Source/NSAttributedString+Formatting.swift
@@ -1,0 +1,35 @@
+//
+//  NSAttributedString+Formatting.swift
+//  edX
+//
+//  Created by Akiva Leffert on 10/15/15.
+//  Copyright © 2015 edX. All rights reserved.
+//
+
+import Foundation
+
+extension OEXTextStyle {
+
+    func apply(f : String -> String) -> (NSAttributedString -> NSAttributedString) {
+        return {(s : NSAttributedString) in
+            let string = f("{__param__}")
+            let template = self.attributedStringWithText(string)
+            return template.oex_formatWithParameters(["__param__" : s])
+        }
+    }
+    
+    @nonobjc
+    func apply(f : (String, String) -> String) -> ((NSAttributedString, NSAttributedString) -> NSAttributedString) {
+        return {(s1: NSAttributedString, s2: NSAttributedString) in
+            let string = f("{__param1__}", "{__param2__}")
+            let template = self.attributedStringWithText(string)
+            return template.oex_formatWithParameters(["__param1__": s1, "__param2__": s2])
+        }
+    }
+    
+}
+extension String {
+    func applyStyle(style : OEXTextStyle) -> NSAttributedString {
+        return style.attributedStringWithText(self)
+    }
+}

--- a/Source/NSAttributedString+OEXFormatting.h
+++ b/Source/NSAttributedString+OEXFormatting.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// @param parameters A map between keys and NSAttributedStrings to replace those strings with.
 /// See -[NSString oex_formatWithParameters:] for a more detailed description.
-- (NSAttributedString*)oex_formatWithParameters:(NSDictionary*)parameters;
+- (NSAttributedString*)oex_formatWithParameters:(NSDictionary<NSString*, NSAttributedString*>*)parameters;
 
 @end
 

--- a/Source/NSAttributedString+OEXFormatting.m
+++ b/Source/NSAttributedString+OEXFormatting.m
@@ -10,7 +10,7 @@
 
 @implementation NSAttributedString (OEXFormatting)
 
-- (NSAttributedString*)oex_formatWithParameters:(NSDictionary*)parameters {
+- (NSAttributedString*)oex_formatWithParameters:(NSDictionary<NSString*, NSAttributedString*>*)parameters {
     NSMutableAttributedString* result = self.mutableCopy;
     [parameters enumerateKeysAndObjectsUsingBlock:^(NSString* key, NSAttributedString* value, BOOL* stop) {
         NSString* token = [NSString stringWithFormat:@"{%@}", key];

--- a/Source/NSError+OEXKnownErrors.m
+++ b/Source/NSError+OEXKnownErrors.m
@@ -79,28 +79,24 @@ NSString* const OEXErrorDomain = @"org.edx.error";
 - (NSAttributedString*)attributedDescriptionWithBaseStyle:(OEXTextStyle*)style {
 
     switch (self.access.error_code) {
-        case OEXStartDateError:
+        case OEXStartDateError: {
+            
+            NSAttributedString*(^template)(NSAttributedString*) = [style apply:^(NSString* s){ return [Strings courseWillStartAtDate:s]; }];
             if(self.displayInfo.type == OEXStartTypeString && self.displayInfo.displayDate.length > 0) {
-                NSString* parameter = @"{parameter}";
-                NSString* base = [Strings courseWillStartAtDate:parameter];
-                NSAttributedString* template = [style attributedStringWithText:
-                                                base];
                 NSAttributedString* styledDate = [style.withWeight(OEXTextWeightBold) attributedStringWithText:self.displayInfo.displayDate];
-                NSAttributedString* message = [template oex_formatWithParameters:@{@"parameter" : styledDate}];
+                NSAttributedString* message = template(styledDate);
                 return message;
             }
             else if(self.displayInfo.type == OEXStartTypeTimestamp && self.displayInfo.date != nil) {
-                NSString* parameter = @"{parameter}";
-                NSString* base = [Strings courseWillStartAtDate:parameter];
-                NSAttributedString* template = [style attributedStringWithText:base];
                 NSString* displayDate = [OEXDateFormatting formatAsMonthDayYearString: self.displayInfo.date];
                 NSAttributedString* styledDate = [style.withWeight(OEXTextWeightBold) attributedStringWithText:displayDate]; 
-                NSAttributedString* message = [template oex_formatWithParameters:@{@"parameter" : styledDate}];
+                NSAttributedString* message = template(styledDate);
                 return message;
             }
             else {
                 return [style attributedStringWithText: [Strings courseNotStarted]];
             }
+        }
         case OEXMilestoneError:
         case OEXVisibilityError:
         case OEXUnknownError:

--- a/Source/OEXConfig.h
+++ b/Source/OEXConfig.h
@@ -40,7 +40,12 @@ NS_ASSUME_NONNULL_BEGIN
 // in case we need to do something clever in individual cases
 @interface OEXConfig (OEXKnownConfigs)
 
+// Debugging string for configuration name
 - (nullable NSString*)environmentName;
+/// User facing platform name, like "edX"
+- (nonnull NSString*)platformName;
+/// User facing platform web destination, like "edx.org"
+- (nonnull NSString*)platformDestinationName;
 
 // Network
 // TODO: Transition this to an actual NSURL

--- a/Source/OEXConfig.m
+++ b/Source/OEXConfig.m
@@ -21,6 +21,8 @@
 static NSString* const OEXAPIHostURL = @"API_HOST_URL";
 static NSString* const OEXDiscussionsEnabledKey = @"DISCUSSIONS_ENABLED";
 static NSString* const OEXEnvironmentDisplayName = @"ENVIRONMENT_DISPLAY_NAME";
+static NSString* const OEXPlatformName = @"PLATFORM_NAME";
+static NSString* const OEXPlatformDestinationName = @"PLATFORM_DESTINATION_NAME";
 static NSString* const OEXFacebookAppID = @"FACEBOOK_APP_ID";
 static NSString* const OEXFeedbackEmailAddress = @"FEEDBACK_EMAIL_ADDRESS";
 
@@ -99,7 +101,15 @@ static OEXConfig* sSharedConfig;
 
 - (NSString*)environmentName {
     // This is for debug display, so if we don't have it, it makes sense to return the empty string
-    return [self stringForKey:OEXEnvironmentDisplayName] ? : @"";
+    return [self stringForKey:OEXEnvironmentDisplayName] ?: @"";
+}
+
+- (NSString*)platformName {
+    return [self stringForKey:OEXPlatformName] ?: @"My open edX instance";
+}
+
+- (NSString*)platformDestinationName {
+    return [self stringForKey:OEXPlatformDestinationName] ?: @"example.com";
 }
 
 - (NSString*)facebookURLScheme {

--- a/Source/OEXCourse.m
+++ b/Source/OEXCourse.m
@@ -92,6 +92,8 @@
     return self;
 }
 
+
+
 - (BOOL)isStartDateOld {
     return [self.start_display_info.date oex_isInThePast];
 }

--- a/Source/OEXCourseVideoDownloadTableViewController.m
+++ b/Source/OEXCourseVideoDownloadTableViewController.m
@@ -1305,7 +1305,7 @@ typedef  enum OEXAlertType
 
     [self.table_Videos reloadData];
 
-    NSString* message = [Strings videosDeletedWithCount:deleteCount];
+    NSString* message = [Strings videosDeletedWithCount:deleteCount formatted:nil];
     [[OEXStatusMessageViewController sharedInstance] showMessage:message onViewController:self];
 
 //    [self disableDeleteButton];

--- a/Source/OEXCustomTabBarViewViewController.m
+++ b/Source/OEXCustomTabBarViewViewController.m
@@ -811,7 +811,7 @@
     NSInteger downloadingCount = [_dataInterface downloadVideos:validArray];
 
     if(downloadingCount > 0) {
-        NSString* message = [Strings videosDownloadingWithCount:downloadingCount];
+        NSString* message = [Strings videosDownloadingWithCount:downloadingCount formatted:nil];
         [[OEXStatusMessageViewController sharedInstance] showMessage:message onViewController:self];
     }
     else {

--- a/Source/OEXDownloadViewController.m
+++ b/Source/OEXDownloadViewController.m
@@ -178,7 +178,7 @@
 
         [cell.btn_cancel addTarget:self action:@selector(btnCancelPressed:) forControlEvents:UIControlEventTouchUpInside];
         
-        cell.accessibilityLabel = [Strings acessibilityDownloadViewCellWithVideoName:videoName percentComplete:@(progress).description];
+        cell.accessibilityLabel = [self downloadStatusAccessibilityLabelForVideoName:videoName percentComplete:(progress / OEXMaxDownloadProgress)];
     }
 }
 
@@ -212,6 +212,13 @@
 
 /// Update progress for visible rows
 
+- (NSString*)downloadStatusAccessibilityLabelForVideoName:(NSString*)video percentComplete:(double)percentage {
+    NSNumberFormatter* formatter = [[NSNumberFormatter alloc] init];
+    formatter.numberStyle = NSNumberFormatterPercentStyle;
+    NSString* formatted = [formatter stringFromNumber:@(percentage)];
+    return [Strings accessibilityDownloadViewCell:video percentComplete:formatted](percentage);
+}
+
 - (void)updateProgressForVisibleRows {
     NSArray* array = [self.table_Downloads visibleCells];
 
@@ -226,7 +233,8 @@
             if(progress == OEXMaxDownloadProgress) {
                 needReload = YES;
             }
-            cell.accessibilityLabel = [Strings acessibilityDownloadViewCellWithVideoName:cell.lbl_title.text percentComplete:@(progress / OEXMaxDownloadProgress).description];
+            
+            cell.accessibilityLabel = [self downloadStatusAccessibilityLabelForVideoName:video.summary.name percentComplete:(progress / OEXMaxDownloadProgress)];
         }
     }
 

--- a/Source/OEXFrontCourseViewController.m
+++ b/Source/OEXFrontCourseViewController.m
@@ -231,7 +231,8 @@
 }
     
 - (void)showExternalRegistrationWithExistingLoginMessage:(NSNotification*)notification {
-    NSString* message = [Strings externalRegistrationBecameLoginWithService:notification.object];
+    NSString* platform = [[OEXConfig sharedConfig] platformName];
+    NSString* message = [Strings externalRegistrationBecameLoginWithPlatformName:platform service:notification.object];
     [[OEXStatusMessageViewController sharedInstance] showMessage:message onViewController:self];
 }
 

--- a/Source/OEXGenericCourseTableViewController.m
+++ b/Source/OEXGenericCourseTableViewController.m
@@ -310,7 +310,7 @@
     NSInteger downloadingCount = [_dataInterface downloadVideos:validArray];
 
     if(downloadingCount > 0) {
-        NSString* message = [Strings videosDownloadingWithCount:downloadingCount];
+        NSString* message = [Strings videosDownloadingWithCount:downloadingCount formatted:nil];
         [[OEXStatusMessageViewController sharedInstance] showMessage:message onViewController:self];
         [self.table_Generic reloadData];
     }

--- a/Source/OEXLocalizedString.h
+++ b/Source/OEXLocalizedString.h
@@ -22,7 +22,7 @@ NSString* OEXLocalizedString(NSString* string,  NSString* __nullable  comment);
 /// Along with a comment there.
 /// For full documentation on the format to deal with the different plural cases see
 /// https://github.com/Smartling/ios-i18n
-NSString* OEXLocalizedStringPlural(NSString* key, float value,  NSString* __nullable  comment);
+NSString* OEXLocalizedStringPlural(NSString* key, NSInteger value,  NSString* __nullable  comment);
 
 
 NS_ASSUME_NONNULL_END

--- a/Source/OEXLocalizedString.m
+++ b/Source/OEXLocalizedString.m
@@ -15,7 +15,7 @@ NSString* OEXLocalizedString(NSString* key, NSString* comment) {
     return result;
 }
 
-NSString* OEXLocalizedStringPlural(NSString* key, float value, NSString* comment) {
+NSString* OEXLocalizedStringPlural(NSString* key, NSInteger value, NSString* comment) {
     NSString* result = SLPluralizedString(key, value, comment);
     return result;
 }

--- a/Source/OEXMyVideosSubSectionViewController.m
+++ b/Source/OEXMyVideosSubSectionViewController.m
@@ -1007,7 +1007,7 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
                 [self performSelector:@selector(pop) withObject:nil afterDelay:1.0];
             }
             else {
-                NSString* message = [Strings videosDeletedWithCount:deleteCount];
+                NSString* message = [Strings videosDownloadingWithCount:deleteCount formatted:nil];
                 [[OEXStatusMessageViewController sharedInstance] showMessage:message onViewController:self];
 
                 // clear all objects form array after deletion.

--- a/Source/OEXMyVideosViewController.m
+++ b/Source/OEXMyVideosViewController.m
@@ -1297,7 +1297,7 @@ typedef  enum OEXAlertType
             [self.table_RecentVideos reloadData];
             [self.table_MyVideos reloadData];
 
-            NSString* message = [Strings videosDeletedWithCount:deleteCount];
+            NSString* message = [Strings videosDownloadingWithCount:deleteCount formatted:nil];
             [[OEXStatusMessageViewController sharedInstance] showMessage:message onViewController:self];
 
             // clear all objects form array after deletion.

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -149,7 +149,8 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
     self.automaticallyAdjustsScrollViewInsets = NO;
     // set the custom navigation view properties
 
-    self.titleLabel.text = [Strings registrationSignUpForEdx];
+    NSString* platform = [[OEXConfig sharedConfig] platformName];
+    self.titleLabel.text = [Strings registrationSignUpForPlatformWithPlatformName:platform];
     [self.titleLabel setFont:[UIFont fontWithName:semiboldFont size:20.f]];
 
     ////Create and initalize 'btnCreateAccount' button
@@ -171,9 +172,9 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
     self.agreementLabel.textAlignment = NSTextAlignmentCenter;
     self.agreementLabel.numberOfLines = 0;
     self.agreementLabel.lineBreakMode = NSLineBreakByWordWrapping;
-    self.agreementLabel.text = [Strings registrationAgreementMessage];
+    self.agreementLabel.text = [Strings registrationAgreementMessageWithPlatformName:platform];
     self.agreementLink = [[UIButton alloc] init];
-    [self.agreementLink setTitle:[Strings registrationAgreementButtonTitle] forState:UIControlStateNormal];
+    [self.agreementLink setTitle:[Strings registrationAgreementButtonTitleWithPlatformName:platform] forState:UIControlStateNormal];
     [self.agreementLink.titleLabel setFont:[UIFont fontWithName:semiboldFont size:10]];
     [self.agreementLink setTitleColor:[UIColor colorWithRed:0.16 green:0.44 blue:0.84 alpha:1] forState:UIControlStateNormal];
     [self.agreementLink addTarget:self action:@selector(agreementButtonTapped:) forControlEvents:UIControlEventTouchUpInside];

--- a/Source/OEXUsingExternalAuthHeadingView.m
+++ b/Source/OEXUsingExternalAuthHeadingView.m
@@ -101,12 +101,10 @@ static const UIEdgeInsets OEXUsingExternalAuthMessageInsets = {.top = 10, .left 
 }
 
 - (NSAttributedString*)messageTextWithProvider:(NSString*)provider {
-    NSString* service = @"service";
-    NSString* parameter = @"{service}";
-    
-    NSAttributedString* message = [self.styles.headingMessageTextStyle attributedStringWithText: [Strings completeRegistrationInfoWithService:parameter]];
+    NSAttributedString* message = [self.styles.headingMessageTextStyle attributedStringWithText: [Strings completeRegistrationInfoWithService:@"{service}" platformName:@"{platform}"]];
     NSAttributedString* serviceString = [self.styles.headingMessageProviderStyle attributedStringWithText:provider];
-    return [message oex_formatWithParameters:@{service : serviceString}];
+    NSString* platform = [[OEXConfig sharedConfig] platformName];
+    return [message oex_formatWithParameters:@{@"service" : serviceString, @"platform" : platform}];
 }
 
 @end

--- a/Source/OEXUsingExternalAuthHeadingView.m
+++ b/Source/OEXUsingExternalAuthHeadingView.m
@@ -101,10 +101,13 @@ static const UIEdgeInsets OEXUsingExternalAuthMessageInsets = {.top = 10, .left 
 }
 
 - (NSAttributedString*)messageTextWithProvider:(NSString*)provider {
-    NSAttributedString* message = [self.styles.headingMessageTextStyle attributedStringWithText: [Strings completeRegistrationInfoWithService:@"{service}" platformName:@"{platform}"]];
-    NSAttributedString* serviceString = [self.styles.headingMessageProviderStyle attributedStringWithText:provider];
+    OEXTextStyle* style = self.styles.headingMessageProviderStyle;
     NSString* platform = [[OEXConfig sharedConfig] platformName];
-    return [message oex_formatWithParameters:@{@"service" : serviceString, @"platform" : platform}];
+    NSAttributedString*(^template)(NSAttributedString*) = [style apply:^(NSString* service) {
+        return [Strings completeRegistrationInfoWithService:service platformName:platform];
+    }];
+    NSAttributedString* serviceString = [self.styles.headingMessageProviderStyle attributedStringWithText:provider];
+    return template(serviceString);
 }
 
 @end

--- a/Source/ProgressController.swift
+++ b/Source/ProgressController.swift
@@ -28,18 +28,7 @@ public class ProgressController: NSObject {
     }()
     
     private var downloadProgress : CGFloat {
-        get {
-            return CGFloat(self.dataInterface?.totalProgress ?? 0)
-        }
-        
-        set {
-            //Assuming there wouldn't be a situation where we'd want to force-hide the views. Also, this will automatically show the View when reachability is back on or any other situation where we hid it unwillingly.
-            showProgessView()
-            circularProgressView.setProgress(newValue, animated: true)
-            let percentStr = percentFormatter.stringFromNumber(newValue)!
-            downloadButton.accessibilityLabel = NSString(format: Strings.accessibilityDownloadProgressButton, percentStr) as String
-        }
-        
+        return CGFloat(self.dataInterface?.totalProgress ?? 0)
     }
     
     init(owner : UIViewController, router : OEXRouter, dataInterface : OEXInterface) {
@@ -49,7 +38,7 @@ public class ProgressController: NSObject {
         
         downloadButton = UIButton(type: .System)
         downloadButton.setImage(UIImage(named: "ic_download_arrow"), forState: .Normal)
-        downloadButton.accessibilityLabel = NSString(format: Strings.accessibilityDownloadProgressButton, "") as String
+        downloadButton.accessibilityLabel = Strings.accessibilityDownloadProgressButton(percentComplete: 0, formatted: nil)
         downloadButton.accessibilityHint = Strings.accessibilityDownloadProgressButtonHint
         downloadButton.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitUpdatesFrequently
         downloadButton.frame = ProgressViewFrame
@@ -70,14 +59,17 @@ public class ProgressController: NSObject {
             }, forEvents: .TouchUpInside)
         
         NSNotificationCenter.defaultCenter().oex_addObserver(self, name: OEXDownloadProgressChangedNotification) { (_, observer, _) -> Void in
-            observer.updateDownloadProgress()
+            observer.updateProgressDisplay()
         }
     }
     
-    private func updateDownloadProgress() {
-        // Working around the compiler error of Assigning the property to itself. Should fix this when Swift improves
-        weak var weakSelf = self
-        weakSelf?.downloadProgress = weakSelf?.downloadProgress ?? 0
+    private func updateProgressDisplay() {
+        //Assuming there wouldn't be a situation where we'd want to force-hide the views. Also, this will automatically show the View when reachability is back on or any other situation where we hid it unwillingly.
+        showProgessView()
+        circularProgressView.setProgress(downloadProgress, animated: true)
+        let percentStr = percentFormatter.stringFromNumber(downloadProgress)!
+        let numeric = Int(downloadProgress * 100)
+        downloadButton.accessibilityLabel = Strings.accessibilityDownloadProgressButton(percentComplete: numeric, formatted: percentStr)
     }
     
     func navigationItem() -> UIBarButtonItem {

--- a/Source/UserProfileViewController.swift
+++ b/Source/UserProfileViewController.swift
@@ -228,7 +228,7 @@ public class UserProfileViewController: UIViewController {
         usernameLabel.attributedText = usernameStyle.attributedStringWithText(profile.username)
 
         if profile.sharingLimitedProfile {
-            setMessage(editable ? Strings.Profile.showingLimited : Strings.Profile.learnerHasLimitedProfile)
+            setMessage(editable ? Strings.Profile.showingLimited : Strings.Profile.learnerHasLimitedProfile(platformName: OEXConfig.sharedConfig().platformName()))
 
             if (profile.parentalConsent ?? false) && editable {
                 let newStyle = OEXMutableTextStyle(textStyle: bioStyle)

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -24,12 +24,16 @@
 "ACCESSIBILITY_NAVIGATION" = "Navigation";
 /* Call to action for Course content on Home Screen */
 "ACCESSIBILITY_SHOWS_COURSE_CONTENT" = "Shows course content.";
-/* Acessibility label for the download progress button. Input is an already localized percentage eg. 44% */
-"ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON" = "Downloads in progress: %@.";
+/* Acessibility label for the download progress button. {percent_complete} is an already localized numeric percentage like "44%" */
+"ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON##{one}" = "Downloads in progress: {percent_complete}";
+/* Acessibility label for the download progress button. {percent_complete} is an already localized numeric percentage like "44%" */
+"ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON##{many}" = "Downloads in progress: {percent_complete}";
 /* Acessibility hint for the download progress button. */
 "ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON_HINT" = "View current downloads";
-/* Accessibility hint for video download list row cells. Input #2 is an already localized percentage eg. 44%. Input #1 is the video name. */
-"ACESSIBILITY_DOWNLOAD_VIEW_CELL" = "Downloading {video_name}. {percent_complete} complete.";
+/* Accessibility hint for video download list row cells. {video_name} is the name of video being downloaded. {percent_complete} is an already localized numeric percentage like "44%". */
+"ACCESSIBILITY_DOWNLOAD_VIEW_CELL##{one}" = "Downloading {video_name}. {percent_complete} percent complete.";
+/* Accessibility hint for video download list row cells. {video_name} is the name of video being downloaded. {percent_complete} is an already localized numeric percentage like "44%". */
+"ACCESSIBILITY_DOWNLOAD_VIEW_CELL##{many}" = "Downloading {video_name}. {percent_complete} percent complete.";
 /* Accessibility hint for number of downloadable videos */
 "ACCESSIBILITY_DOWNLOADABLE_VIDEOS##{one}" = "Downloads {video_count} video.";
 /* Accessibility hint for number of downloadable videos */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -107,7 +107,7 @@
 /* Title of dropdown from which the user can select topics on New Post Screen */
 "CHOOSE_A_TOPIC" = "Choose a topic...";
 /* Prompt text shown after user chooses to begin registering with an external service like Facebook or Google. {service} will be replaced with a service name like Google or Facebook. */
-"COMPLETE_REGISTRATION_INFO" = "You've successfully signed in with {service}. We just need a little more information before you start learning with edX.";
+"COMPLETE_REGISTRATION_INFO" = "You've successfully signed in with {service}. We just need a little more information before you start learning with {platform_name}.";
 /* Prompt text shown after user chooses to begin registering with an external service like Facebook or Google */
 "COMPLETE_REGISTRATION_PROMPT" = "Complete your registration";
 /* Title of alert when confirming deletion of a video */
@@ -231,14 +231,10 @@
 /* Text used when the post is visible to everyone */
 "EVERYONE"="everyone";
 /* Message when user attempts to register an account using an external service like Facebook or Google, but they already have an account linked to that service */
-"EXTERNAL_REGISTRATION_BECAME_LOGIN" = "You already set up an edX account with your {service} account. You have been logged in with that account.";
+"EXTERNAL_REGISTRATION_BECAME_LOGIN" = "You already set up an {platform_name} account with your {service} account. You have been logged in with that account.";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */
-"FACEBOOK_ACCOUNT_NOT_ASSOCIATED_MESSAGE"="Make sure your Facebook account is associated with your edX account on edx.org";
-/* Title for overlay message shown when facebook login fails */
-"FACEBOOK_ACCOUNT_NOT_ASSOCIATED_TITLE"="Facebook account not associated with edX account";
-/* Error message shown when topics aren't loaded on the Create a New Post screen */
 "FAILED_TO_LOAD_TOPICS"="Failed to load topics.";
 /* Title of find courses screen */
 "FIND_COURSES"="Find Courses";
@@ -260,10 +256,10 @@
 "FORM_LABEL"="{label}:";
 /* Google login method */
 "GOOGLE"="Google";
-/* Overlay message shown when facebook login fails because the user's account isn't linked */
-"GOOGLE_ACCOUNT_NOT_ASSOCIATED_MESSAGE"="Make sure your Google account is associated with your edX account on edx.org";
-/* Title of overlay message shown when facebook login fails because the user's account isn't linked */
-"GOOGLE_ACCOUNT_NOT_ASSOCIATED_TITLE"="Google account not associated with edX account";
+/* Overlay message shown when third party login fails because the user's account isn't linked. {service} is a third party login service like "Facebook". {platform_name} is the name of the service like "edX". {destination_name} is the name of service's web destination like "edx.org" */
+"SERVICE_ACCOUNT_NOT_ASSOCIATED_MESSAGE"="Make sure your {service} account is associated with your {platform_name} account on {destination_name}";
+/* Title of overlay message shown when login through an external service fails because the user's account isn't linked. For example, "Google account not associated with edX account" */
+"SERVICE_ACCOUNT_NOT_ASSOCIATED_TITLE"="{service} account not associated with {platform_name} account";
 /* Indicator for course content that is marked as having a graded component */
 "GRADED" = "Graded";
 /* Warning shown to indicate that the user is in a section of graded content. */
@@ -281,7 +277,7 @@
 /* Title for Course Item that was last accessed */
 "LAST_ACCESSED" = "Last Accessed";
 /* Button title to begin login */
-"LOGIN_SIGN_IN_TO_EDX"="Sign in to edX";
+"LOGIN_SIGN_IN_TO_PLATFORM"="Sign in to {platform_name}";
 /* Prompt leading user to create account screen */
 "LOGIN_SPLASH_SIGN_UP"="Sign up and start learning";
 /* Prompt leading user to sign in screen */
@@ -377,7 +373,7 @@
 /* Accessibility hint for language field in user profile */
 "PROFILE.LANGUAGE_ACCESSIBILITY_HINT" = "Your preferred language";
 /* Shown when viewing someone else's limied profile. */
-"PROFILE.LEARNER_HAS_LIMITED_PROFILE" = "This edX learner is currently sharing a limited profile.";
+"PROFILE.LEARNER_HAS_LIMITED_PROFILE" = "This {platform_name} learner is currently sharing a limited profile.";
 /* User has not filled in an "about me" on their profile */
 "PROFILE.NO_BIO" = "No about me info provided.";
 /* Profile screen text indicating that the user is currently only displaying a limited profile */
@@ -401,9 +397,9 @@
 /* Button title when responses are closed for a thread */
 "RESPONSES_CLOSED"="Responses are closed for this post";
 /* Title of registration agreement */
-"REGISTRATION_AGREEMENT_BUTTON_TITLE"="edX Terms of Service and Honor Code";
+"REGISTRATION_AGREEMENT_BUTTON_TITLE"="{platform_name} Terms of Service and Honor Code";
 /* Create account agreement. Followed by list of agreement names like "End User License Agreement" */
-"REGISTRATION_AGREEMENT_MESSAGE"="By creating an edX account, you agree to the ";
+"REGISTRATION_AGREEMENT_MESSAGE"="By creating an {platform_name} account, you agree to the ";
 /* Button text allowing user create an account */
 "REGISTRATION_CREATE_MY_ACCOUNT"="Create my account";
 /* Text shown while waiting for registration request */
@@ -429,7 +425,7 @@
 /* Heading on registration screen allowing users to sign up using external services like Facebook and Google. Will be preceded by text "Sign up with" */
 "REGISTRATION_SIGN_UP_ALTERNATE_PROMPT"="or sign up with email";
 /* Registration screen title */
-"REGISTRATION_SIGN_UP_FOR_EDX"="Sign up for edX";
+"REGISTRATION_SIGN_UP_FOR_PLATFORM"="Sign up for {platform_name}";
 /* Alert dialog title prompting user to enter an email address to reset their password */
 "RESET_PASSWORD_TITLE"="Reset Password";
 /* Alert dialog content prompting user to enter an email address to reset their password */

--- a/Test/NSAttributedString+FormattingTests.swift
+++ b/Test/NSAttributedString+FormattingTests.swift
@@ -1,0 +1,23 @@
+//
+//  NSAttributedString+FormattingTests.swift
+//  edX
+//
+//  Created by Akiva Leffert on 10/15/15.
+//  Copyright © 2015 edX. All rights reserved.
+//
+
+import XCTest
+@testable import edX
+
+class NSAttributedString_FormattingTests: XCTestCase {
+
+    func testParameterization() {
+        let f = { "Hello " + $0 }
+        let style = OEXTextStyle(weight: .Normal, size: .Base, color: nil)
+        let styled = style.apply(f)
+        let name = "someone".applyStyle(style)
+        let result = styled(name)
+        XCTAssertEqual(result.string, "Hello someone")
+    }
+    
+}

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -145,6 +145,8 @@
 		77000A4A1A7757E0007D306C /* NSDate+OEXComparisons.m in Sources */ = {isa = PBXBuildFile; fileRef = 77000A491A7757E0007D306C /* NSDate+OEXComparisons.m */; };
 		77000A4C1A775904007D306C /* NSDate+OEXComparisonsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77000A4B1A775904007D306C /* NSDate+OEXComparisonsTests.m */; };
 		77056C3E1B3F320800D9DB4A /* DetailToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77056C3D1B3F320800D9DB4A /* DetailToolbarButton.swift */; };
+		7706AAC11BCFEEBF00728432 /* NSAttributedString+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7706AAC01BCFEEBF00728432 /* NSAttributedString+Formatting.swift */; settings = {ASSET_TAGS = (); }; };
+		7706AAC31BCFF28B00728432 /* NSAttributedString+FormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7706AAC21BCFF28B00728432 /* NSAttributedString+FormattingTests.swift */; settings = {ASSET_TAGS = (); }; };
 		770848BA1B200C76002FEEEE /* ViewTopMessageController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770848B91B200C76002FEEEE /* ViewTopMessageController.swift */; };
 		770848BC1B209EF4002FEEEE /* BorderStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770848BB1B209EF4002FEEEE /* BorderStyle.swift */; };
 		770848BF1B20D5F9002FEEEE /* TestEnvironmentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770848BE1B20D5F9002FEEEE /* TestEnvironmentBuilder.swift */; };
@@ -724,6 +726,8 @@
 		77000A491A7757E0007D306C /* NSDate+OEXComparisons.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+OEXComparisons.m"; sourceTree = "<group>"; };
 		77000A4B1A775904007D306C /* NSDate+OEXComparisonsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+OEXComparisonsTests.m"; sourceTree = "<group>"; };
 		77056C3D1B3F320800D9DB4A /* DetailToolbarButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailToolbarButton.swift; sourceTree = "<group>"; };
+		7706AAC01BCFEEBF00728432 /* NSAttributedString+Formatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Formatting.swift"; sourceTree = "<group>"; };
+		7706AAC21BCFF28B00728432 /* NSAttributedString+FormattingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+FormattingTests.swift"; sourceTree = "<group>"; };
 		770848B91B200C76002FEEEE /* ViewTopMessageController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewTopMessageController.swift; sourceTree = "<group>"; };
 		770848BB1B209EF4002FEEEE /* BorderStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BorderStyle.swift; sourceTree = "<group>"; };
 		770848BE1B20D5F9002FEEEE /* TestEnvironmentBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestEnvironmentBuilder.swift; sourceTree = "<group>"; };
@@ -1746,6 +1750,7 @@
 		776459831A0968F0008404CC /* Library Additions */ = {
 			isa = PBXGroup;
 			children = (
+				7706AAC01BCFEEBF00728432 /* NSAttributedString+Formatting.swift */,
 				778CC8231BBECD9100DCCAE4 /* JSON+RawValueExtractable.swift */,
 				7727EC341BBC73F300C9987F /* RevealViewController.swift */,
 				5DEA47D51B62F64300831EC9 /* QLearnSDK */,
@@ -2484,6 +2489,7 @@
 		BECB7B331924C0C3009C77F1 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				7706AAC21BCFF28B00728432 /* NSAttributedString+FormattingTests.swift */,
 				771273311BA9DF8F008BA397 /* OEXTextStyleTests.swift */,
 				77E00B721B83997E00573622 /* DiscussionNewCommentViewControllerTests.swift */,
 				773181431B7066E5000CC050 /* DiscussionNewPostViewControllerTests.swift */,
@@ -2994,6 +3000,7 @@
 				7772BE931AF94AA40081CA7A /* Array+Functional.swift in Sources */,
 				770A3D451AF0167A008F09D9 /* UIControl+OEXBlockActions.m in Sources */,
 				770848C41B21334F002FEEEE /* OEXMathUtilities.m in Sources */,
+				7706AAC11BCFEEBF00728432 /* NSAttributedString+Formatting.swift in Sources */,
 				778D53351B3D96E900441A98 /* ListCursor.swift in Sources */,
 				B498405919753C6C00019D1F /* CLVideoPlayer.m in Sources */,
 				B4B6D62A1A949F1B000F44E8 /* OEXRegistrationFieldSelectController.m in Sources */,
@@ -3337,6 +3344,7 @@
 				9E35A2841B32D7090040B9A9 /* DateFormattingTests.swift in Sources */,
 				77864DDC1B14BC4700182FC2 /* Result+Assertions.swift in Sources */,
 				1A6E86261BB9CEC90039A216 /* UserProfileViewTests.swift in Sources */,
+				7706AAC31BCFF28B00728432 /* NSAttributedString+FormattingTests.swift in Sources */,
 				772619BA1ADDC68E005BD7E4 /* OEXMockUserDefaults.m in Sources */,
 				771273321BA9DF8F008BA397 /* OEXTextStyleTests.swift in Sources */,
 				77AE2F621ABB71840027E799 /* OEXFileUtilityTests.m in Sources */,

--- a/script/Localizations.swift
+++ b/script/Localizations.swift
@@ -145,10 +145,11 @@ extension Item {
                 if arguments.count == 1 {
                     let arg = arguments[0]
                     let name = variableName(arg)
-                    return "static func \(variableName(key.name))(\(name) \(name) : Float) -> String { return OEXLocalizedStringPlural(\"\(key.name)\", \(name), nil).oex_formatWithParameters([\"\(arg)\": \(name)]) }"
+                    return "static func \(variableName(key.name))(\(name) \(name) : Int, formatted : String? = nil) -> String { return OEXLocalizedStringPlural(\"\(key.name)\", \(name), nil).oex_formatWithParameters([\"\(arg)\": formatted ?? \(name).description]) }"
+                    
                 }
                 else {
-                    return "static func \(variableName(key.name))(\(args)) -> (Float -> String) { return {pluralizingCount in OEXLocalizedStringPlural(\"\(key.name)\", pluralizingCount, nil).oex_formatWithParameters([\(formatParams)]) }}"
+                    return "static func \(variableName(key.name))(\(args)) -> (Int -> String) { return {pluralizingCount in OEXLocalizedStringPlural(\"\(key.name)\", pluralizingCount, nil).oex_formatWithParameters([\(formatParams)]) }}"
                 }
             }
         }
@@ -157,7 +158,7 @@ extension Item {
             case .Single:
                 return "static var \(variableName(key.name)) = OEXLocalizedString(\"\(key.original)\", nil)"
             case .Multi:
-                return "static func \(variableName(key.name))(count : Float) -> String { return OEXLocalizedStringPlural(\"\(key.name)\", count, nil) } "
+                return "static func \(variableName(key.name))(count : Int) -> String { return OEXLocalizedStringPlural(\"\(key.name)\", count, nil) } "
             }
         }
     }


### PR DESCRIPTION
Improve handling of parameterized strings to use ints instead of floats as the way it decides what case it's in (singular vs plural) and then pass an optional formatted string for more interesting cases like percent.

@mikekatz This should really have been in response to your comment on the other PR, but I got all crossed up on branches)