### PR TITLE
Show video speed/caption controls in landscape.

### DIFF
--- a/Source/CutomePlayer/CLVideoPlayer.m
+++ b/Source/CutomePlayer/CLVideoPlayer.m
@@ -147,11 +147,12 @@ static const NSTimeInterval fullscreenAnimationDuration = 0.3;
             keyWindow = [[[UIApplication sharedApplication] windows] objectAtIndex:0];
         }
 
+        UIView* container = keyWindow.rootViewController.view;
         if(CGRectEqualToRect(self.movieBackgroundView.frame, CGRectZero)) {
-            [self.movieBackgroundView setFrame:keyWindow.bounds];
+            [self.movieBackgroundView setFrame:container.bounds];
         }
 
-        [keyWindow addSubview:self.movieBackgroundView];
+        [container addSubview:self.movieBackgroundView];
         [UIView animateWithDuration:animated ? fullscreenAnimationDuration: 0.0 delay:0.0 options:UIViewAnimationOptionCurveLinear animations:^{
             self.movieBackgroundView.alpha = 1.f;
         } completion:^(BOOL finished) {

--- a/Source/OEXCourseVideoDownloadTableViewController.m
+++ b/Source/OEXCourseVideoDownloadTableViewController.m
@@ -1608,7 +1608,7 @@ typedef  enum OEXAlertType
 #pragma mark add observer
 
 - (void)addObserver {
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged:) name:@"UIDeviceOrientationDidChangeNotification" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged:) name:UIDeviceOrientationDidChangeNotification object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(playNextVideo) name:NOTIFICATION_NEXT_VIDEO object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(playPreviousVideo) name:NOTIFICATION_PREVIOUS_VIDEO object:nil];

--- a/Source/OEXMyVideosSubSectionViewController.m
+++ b/Source/OEXMyVideosSubSectionViewController.m
@@ -224,7 +224,7 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
 
     // Used for autorotation
     [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged:) name:@"UIDeviceOrientationDidChangeNotification" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged:) name:UIDeviceOrientationDidChangeNotification object:nil];
 
     // Show Custom editing View
     [self.customEditing.btn_Edit addTarget:self action:@selector(editTableClicked:) forControlEvents:UIControlEventTouchUpInside];

--- a/Source/OEXMyVideosViewController.m
+++ b/Source/OEXMyVideosViewController.m
@@ -297,7 +297,7 @@ typedef  enum OEXAlertType
 
     // Used for autorotation
     [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged:) name:@"UIDeviceOrientationDidChangeNotification" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged:) name:UIDeviceOrientationDidChangeNotification object:nil];
 
     // Show Custom editing View
     [self.customEditing.btn_Edit addTarget:self action:@selector(editTableClicked:) forControlEvents:UIControlEventTouchUpInside];

--- a/Source/OEXVideoPlayerInterface.h
+++ b/Source/OEXVideoPlayerInterface.h
@@ -31,7 +31,6 @@
 @property (assign, nonatomic) BOOL fadeInOnLoad;
 
 - (void)orientationChanged:(NSNotification*)notification;
-- (void)updatePlaybackRate:(float)newPlaybackRate;
 - (void)playVideoFor:(OEXHelperVideoDownload*)video;
 - (void)resetPlayer;
 - (void)videoPlayerShouldRotate;

--- a/Source/OEXVideoPlayerInterface.m
+++ b/Source/OEXVideoPlayerInterface.m
@@ -53,7 +53,7 @@
     
     [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
     //Add observer
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged:) name:@"UIDeviceOrientationDidChangeNotification" object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged:) name:UIDeviceOrientationDidChangeNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(exitFullScreenMode:) name:MPMoviePlayerDidExitFullscreenNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(enterFullScreenMode:) name:MPMoviePlayerDidEnterFullscreenNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -397,14 +397,6 @@
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
     return [OEXStyles sharedStyles].standardStatusBarStyle;
-}
-
-///Video interface
-- (void)updatePlaybackRate:(float)newPlaybackRate {
-    [_moviePlayerController pause];
-    [_moviePlayerController setCurrentPlaybackRate:newPlaybackRate];
-    [_moviePlayerController prepareToPlay];
-    [_moviePlayerController play];
 }
 
 - (void)dealloc {


### PR DESCRIPTION
These were getting covered up because we were adding the controller
directly to the front window. This change has us move to the front of
the root view controller. This is still not a great fix since the alerts
come in sideways, but it's an improvement over not showing them at all.
Unfortunately, the correct fix for this is either to:
1. Restore our more custom controls and add them as a subview of the
video player.
2. Significantly refactor the video player and its assorted containers
to handle landscape in a more disciplined way (migrate to
AVPlayerViewController and have the container be responsible for
fullscreen support + showing/hiding status bar, toolbar, and navigation
bar.

Also includes minor cleanup:
- Use system notification symbol instead of quoted string
- Remove unused method

JIRA: https://openedx.atlassian.net/browse/MA-1446