### PR TITLE
Fix crash on My Videos

### DIFF
--- a/Source/OEXMyVideosViewController.m
+++ b/Source/OEXMyVideosViewController.m
@@ -297,7 +297,6 @@ typedef  enum OEXAlertType
 
     // Used for autorotation
     [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(orientationChanged:) name:UIDeviceOrientationDidChangeNotification object:nil];
 
     // Show Custom editing View
     [self.customEditing.btn_Edit addTarget:self action:@selector(editTableClicked:) forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
This was only on device, since the simulator wasn't sending any
orientation changed messages without prompting.

One more reason to avoid selectors - the method had been removed but it
was still triggered by a notification.

JIRA: https://openedx.atlassian.net/browse/MA-1417