### PR TITLE
iOS - Discussions - Refine posts filter and create new post button is missing in some topics

### DIFF
--- a/Source/PostsViewController.swift
+++ b/Source/PostsViewController.swift
@@ -286,13 +286,16 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
         headerView.addSubview(headerButtonHolderView)
         headerButtonHolderView.addSubview(filterButton)
         headerButtonHolderView.addSubview(sortButton)
-        contentView.addSubview(newPostButton)
+        view.addSubview(newPostButton)
         contentView.addSubview(viewSeparator)
     }
     
     private func setConstraints() {
         contentView.snp_makeConstraints { (make) -> Void in
-            make.edges.equalTo(view)
+            make.top.equalTo(view)
+            make.leading.equalTo(view)
+            make.trailing.equalTo(view)
+            //The bottom is equal to newPostButton.snp_top
         }
         
         headerView.snp_makeConstraints { (make) -> Void in
@@ -332,7 +335,8 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
             make.leading.equalTo(view)
             make.trailing.equalTo(view)
             make.height.equalTo(context.allowsPosting ? OEXStyles.sharedStyles().standardFooterHeight : 0)
-            make.bottom.equalTo(contentView.snp_bottom)
+            make.top.equalTo(contentView.snp_bottom)
+            make.bottom.equalTo(view)
         }
         
         tableView.snp_makeConstraints { (make) -> Void in


### PR DESCRIPTION
We don't want the `newPostButton` to be part of the loadController contentView. This is because even if we have `0` results, the user can still create new posts.

On the contrary, the sort and filter buttons don't have the same desired behaviour. If there is an error/no posts, the buttons don't have any function... So we can keep them beneath the loadController contentView.