### PR TITLE
Fix missing properties for trackEvent with screen

### DIFF
--- a/Source/SegmentAnalyticsTracker.swift
+++ b/Source/SegmentAnalyticsTracker.swift
@@ -86,6 +86,6 @@ class SegmentAnalyticsTracker : NSObject, OEXAnalyticsTracker {
         event.category = OEXAnalyticsCategoryScreen
         event.name = OEXAnalyticsEventScreen;
         event.courseID = courseID
-        trackEvent(event, forComponent: nil, withProperties: [:])
+        trackEvent(event, forComponent: nil, withProperties: properties)
     }
 }


### PR DESCRIPTION
The whole point of this was that ``screen`` events don't track any of
their properties so we need to actually do that. This fixes a bug where
we weren't actually passing them through.