### PR TITLE
Fix issue hiding discussions tab

### DIFF
--- a/Source/OEXCourse+Swift.swift
+++ b/Source/OEXCourse+Swift.swift
@@ -11,6 +11,9 @@ import Foundation
 extension OEXCourse {
     
     var hasDiscussionsEnabled : Bool {
-        return self.discussionUrl != nil
+        guard let url = self.discussionUrl where !url.isEmpty else {
+            return false
+        }
+        return true
     }
 }

--- a/Test/CourseDashboardViewControllerTests.swift
+++ b/Test/CourseDashboardViewControllerTests.swift
@@ -42,13 +42,13 @@ class CourseDashboardViewControllerTests: SnapshotTestCase {
     }
     
     func testDiscussionsEnabled() {
-        XCTAssertTrue(discussionsVisibleWhenEnabled(true, courseHasDiscussions: true), "Discussion should be enabled for this test")
-    }
-
-    func testDiscussionsDisabled() {
-        XCTAssertFalse(discussionsVisibleWhenEnabled(false, courseHasDiscussions: false), "Discussion should be disabled for this test")
-        XCTAssertFalse(discussionsVisibleWhenEnabled(false, courseHasDiscussions: true), "Discussion should be disabled, discussion Config is disabled")
-        XCTAssertFalse(discussionsVisibleWhenEnabled(true, courseHasDiscussions: false), "Discussion should be disabled, Course doesn't have discussions")
+        for enabledInConfig in [true, false] {
+            for enabledInCourse in [true, false] {
+                let expected = enabledInConfig && enabledInCourse
+                let result = discussionsVisibleWhenEnabled(enabledInConfig, courseHasDiscussions: enabledInCourse)
+                XCTAssertEqual(result, expected, "Expected discussion visiblity \(expected) when enabledInConfig: \(enabledInConfig), enabledInCourse:\(enabledInCourse)")
+            }
+        }
     }
     
     func testSnapshot() {


### PR DESCRIPTION
We have this horrible code that converts ``null`` responses to the
empty string, so this check was seeing "" because the endpoint was
returning "null". This fixes that check.

JIRA: https://openedx.atlassian.net/browse/MA-1352