### PR TITLE
Fix issue with scrollbar covered by graded content header

### DIFF
--- a/Source/AuthenticatedWebViewController.swift
+++ b/Source/AuthenticatedWebViewController.swift
@@ -19,7 +19,7 @@ class HeaderViewInsets : ContentInsetsSource {
     }
     
     var affectsScrollIndicators : Bool {
-        return false
+        return true
     }
 }
 


### PR DESCRIPTION
Missed this when we were changed it from scrolling to a permaheader.