### PR TITLE
Fix issue with long titles in course outline

### DIFF
--- a/Source/CourseOutlineItemView.swift
+++ b/Source/CourseOutlineItemView.swift
@@ -161,7 +161,8 @@ public class CourseOutlineItemView: UIView {
             if let view = trailingView {
                 trailingContainer.addSubview(view)
                 view.snp_makeConstraints {make in
-                    make.edges.equalTo(trailingContainer)
+                    // required to prevent long titles from compressing this
+                    make.edges.equalTo(trailingContainer).priorityRequired()
                 }
             }
             setNeedsLayout()

--- a/Source/DownloadsAccessoryView.swift
+++ b/Source/DownloadsAccessoryView.swift
@@ -30,6 +30,9 @@ class DownloadsAccessoryView : UIView {
         
         downloadButton.tintColor = OEXStyles.sharedStyles().neutralBase()
         downloadButton.contentEdgeInsets = UIEdgeInsetsMake(15, 10, 15, 10)
+        downloadButton.setContentCompressionResistancePriority(UILayoutPriorityRequired, forAxis: .Horizontal)
+        countLabel.setContentCompressionResistancePriority(UILayoutPriorityRequired, forAxis: .Horizontal)
+        downloadSpinner.setContentCompressionResistancePriority(UILayoutPriorityRequired, forAxis: .Horizontal)
         
         self.addSubview(downloadButton)
         self.addSubview(downloadSpinner)


### PR DESCRIPTION
The download view was getting squashed.

Before:
![img_5182](https://cloud.githubusercontent.com/assets/114396/11078300/0a53d896-87d3-11e5-964b-5a8be29b3f94.png)

After:
![screen shot 2015-11-10 at 5 46 23 pm](https://cloud.githubusercontent.com/assets/114396/11078308/0e8a3fa4-87d3-11e5-9335-4acfbcaf6983.png)
