### PR TITLE
Aggressively stop videos.

### DIFF
--- a/Source/CourseOutlineTableSource.swift
+++ b/Source/CourseOutlineTableSource.swift
@@ -74,6 +74,10 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
     
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
+        
+        if let path = self.tableView.indexPathForSelectedRow {
+            self.tableView.deselectRowAtIndexPath(path, animated: false)
+        }
         if let highlightID = highlightedBlockID, indexPath = indexPathForBlockWithID(highlightID)
         {
             tableView.scrollToRowAtIndexPath(indexPath, atScrollPosition: UITableViewScrollPosition.Middle, animated: false)

--- a/Source/CutomePlayer/CLVideoPlayer.m
+++ b/Source/CutomePlayer/CLVideoPlayer.m
@@ -83,6 +83,10 @@ static const NSTimeInterval fullscreenAnimationDuration = 0.3;
 }
 
 - (void)dealloc {
+    // You would think that deallocating the movie controller would be enough,
+    // but apparently it's a buggy piece of junk and you need to do this too
+    // or it will continue downloading and playing the audio stream in the background
+    self.contentURL = nil;
     _delegate = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }

--- a/Source/OEXVideoPlayerInterface.m
+++ b/Source/OEXVideoPlayerInterface.m
@@ -190,24 +190,22 @@
     switch([_moviePlayerController playbackState])
     {
         case MPMoviePlaybackStateStopped:
-            //NSLog(@"Stopped");
+            OEXLogInfo(@"VIDEO", @"Stopped");
             break;
         case MPMoviePlaybackStatePlaying:
-
+            OEXLogInfo(@"VIDEO", @"Playing");
             break;
         case MPMoviePlaybackStatePaused:
-            //NSLog(@"Paused");
+            OEXLogInfo(@"VIDEO", @"Playing");
             break;
         case MPMoviePlaybackStateInterrupted:
-            //NSLog(@"Interrupted");
+            OEXLogInfo(@"VIDEO", @"Interrupted");
             break;
         case MPMoviePlaybackStateSeekingForward:
-            //NSLog(@"Seeking Forward");
+            OEXLogInfo(@"VIDEO", @"Seeking Forward");
             break;
         case MPMoviePlaybackStateSeekingBackward:
-            //NSLog(@"Seeking Backward");
-            break;
-        default:
+            OEXLogInfo(@"VIDEO", @"Seeking Backward");
             break;
     }
 }


### PR DESCRIPTION
As best I can tell, MPMoviePlayer is a piece of junk. Even if you
deallocate it and call -stop. It can still finish loading your video and
play audio. Setting the contentURL to ``nil`` in dealloc seems to fix
that.

Additionally, disable caching for videos since having multiple videos
running concurrently and offline seems to cause bad interactions that
prevent videos from playing properly.

I'm hoping that things should improve if we switch to
AVPlayerViewController.