### PR TITLE
Fix broken tap on course card in my videos.

### DIFF
--- a/Source/CourseCardView.swift
+++ b/Source/CourseCardView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @IBDesignable
-class CourseCardView: UIView {
+class CourseCardView: UIView, UIGestureRecognizerDelegate {
     private let arrowHeight = 15.0
     private let verticalMargin = 10
     
@@ -121,7 +121,13 @@ class CourseCardView: UIView {
             make.trailing.equalTo(self.container).offset(-StandardHorizontalMargin)
         }
         
-        self.addGestureRecognizer(UITapGestureRecognizer {[weak self] _ in self?.cardTapped() })
+        let tapGesture = UITapGestureRecognizer {[weak self] _ in self?.cardTapped() }
+        tapGesture.delegate = self
+        self.addGestureRecognizer(tapGesture)
+    }
+    
+    override func gestureRecognizerShouldBegin(gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return tapAction != nil
     }
     
     var titleText : String? {

--- a/Source/OEXMyVideosViewController.m
+++ b/Source/OEXMyVideosViewController.m
@@ -490,12 +490,24 @@ typedef  enum OEXAlertType
     return [self.arr_CourseData count];
 }
 
+- (void)choseCourse:(OEXCourse*)course {
+    [self cancelTableClicked:nil];
+    // Navigate to nextview and pass array of HelperVideoDownload obj...
+    [_videoPlayerInterface resetPlayer];
+    _videoPlayerInterface = nil;
+    [[OEXRouter sharedRouter] showVideoSubSectionFromViewController:self forCourse:course withCourseData:nil];
+}
+
 - (UITableViewCell*)tableView:(UITableView*)tableView cellForRowAtIndexPath:(NSIndexPath*)indexPath {
     if(tableView == self.table_MyVideos) {
         static NSString* cellIndentifier = @"PlayerCell";
 
         OEXFrontTableViewCell* cell = [tableView dequeueReusableCellWithIdentifier:cellIndentifier];
         CourseCardView* infoView = cell.infoView;
+        __typeof(self) owner = self;
+        cell.infoView.tapAction = ^(CourseCardView* card){
+            [owner choseCourse:card.course];
+        };
         infoView.networkManager = self.environment.networkManager;
         
         NSDictionary* dictVideo = [self.arr_CourseData objectAtIndex:indexPath.section];
@@ -625,18 +637,7 @@ typedef  enum OEXAlertType
 
     clickedIndexpath = indexPath;
 
-    if(tableView == self.table_MyVideos) {
-        // To revert back to original
-        [self cancelTableClicked:nil];
-
-        NSDictionary* dictVideo = [self.arr_CourseData objectAtIndex:indexPath.section];
-        OEXCourse* obj_course = [dictVideo objectForKey:CAV_KEY_COURSE];
-        // Navigate to nextview and pass array of HelperVideoDownload obj...
-        [_videoPlayerInterface resetPlayer];
-        _videoPlayerInterface = nil;
-        [[OEXRouter sharedRouter] showVideoSubSectionFromViewController:self forCourse:obj_course withCourseData:nil];
-    }
-    else if(tableView == self.table_RecentVideos) {
+    if(tableView == self.table_RecentVideos) {
         if(!_isTableEditing) {
             // Check for disabling the prev/next videos
             [self CheckIfFirstVideoPlayed:indexPath];


### PR DESCRIPTION
When we added the optional tap action on the course card, it overrode the table
view's tap gesture, causing the my videos tap on a course to break.

This fixes it in two ways:
1. The card gesture will only activate if the card view has a tapAction
2. Switch the my videos table to use the card's tapAction property.
This makes the code more direct and simpler.

JIRA: https://openedx.atlassian.net/browse/MA-1792