### PR TITLE
Fix unit tests

### DIFF
--- a/Test/CourseContentPageViewControllerTests.swift
+++ b/Test/CourseContentPageViewControllerTests.swift
@@ -152,7 +152,7 @@ class CourseContentPageViewControllerTests: SnapshotTestCase {
         loadAndVerifyControllerWithInitialChild(childID, parentID: outline.root) {_ in
             return { expectation -> Void in
                 dispatch_async(dispatch_get_main_queue()) {
-                    self.tracker.eventStream.listen(self) {_ in
+                    self.tracker.eventStream.listenOnce(self) {_ in
                         let events = self.tracker.events.flatMap { return $0.asScreen }
                         
                         if events.count < 2 {


### PR DESCRIPTION
We had a listener which was never getting removed. It should really just
be automatically getting removed once it gets dealloced. So this probably
indicates a memory cycle in the tests somewhere. I took a pass at the
actual app and that leak doesn't seem to be there, so I don't think it's
a serious problem - though we should fix it.

But in the mean time this fixes the tests.