### PR TITLE
Change interface for ``Operation`` to make it easier to end one

### DIFF
--- a/Source/DetachedStreamOperation.swift
+++ b/Source/DetachedStreamOperation.swift
@@ -19,7 +19,7 @@ class StreamWaitOperation<A> : Operation {
         self.completion = completion
     }
 
-    override func performStart() {
+    override func performWithDoneAction(doneAction: () -> Void) {
         dispatch_async(dispatch_get_main_queue()) {[weak self] _ in
             if let owner = self {
                 // We should just be able to do this with weak self, but the compiler crashes as of Swift 1.2
@@ -27,8 +27,7 @@ class StreamWaitOperation<A> : Operation {
                     if !(owner?.cancelled ?? false) {
                         owner?.completion?(result)
                     }
-                    owner?.executing = false
-                    owner?.finished = true
+                    doneAction()
                 }
             }
         }

--- a/Source/Operation.swift
+++ b/Source/Operation.swift
@@ -38,7 +38,10 @@ class Operation : NSOperation {
     @objc override func start() {
         self.executing = true
         self.finished = false
-        performStart()
+        performWithDoneAction {[weak self] in
+            self?.executing = false
+            self?.finished = true
+        }
     }
     
     override func cancel() {
@@ -47,8 +50,8 @@ class Operation : NSOperation {
     }
     
     /// Subclasses should implement this since they might not be able to implement -start directly if they
-    /// have generic arguments
-    func performStart() {
+    /// have generic arguments. Call doneAction when your task is done
+    func performWithDoneAction(doneAction : () -> Void) {
         
     }
 }


### PR DESCRIPTION
I'm hoping that having an explicit done block makes it harder to forget
to finalize the operation.