### PR TITLE
Add stream combinators 'accumulate' & 'delay'

### DIFF
--- a/Source/DetachedStreamOperation.swift
+++ b/Source/DetachedStreamOperation.swift
@@ -13,8 +13,10 @@ import UIKit
 class StreamWaitOperation<A> : Operation {
     private let completion : (Result<A> -> Void)?
     private let stream : Stream<A>
+    private let fireIfAlreadyLoaded : Bool
 
-    init(stream : Stream<A>, completion : (Result<A> -> Void)? = nil) {
+    init(stream : Stream<A>, fireIfAlreadyLoaded : Bool, completion : (Result<A> -> Void)? = nil) {
+        self.fireIfAlreadyLoaded = fireIfAlreadyLoaded
         self.stream = stream
         self.completion = completion
     }
@@ -23,7 +25,7 @@ class StreamWaitOperation<A> : Operation {
         dispatch_async(dispatch_get_main_queue()) {[weak self] _ in
             if let owner = self {
                 // We should just be able to do this with weak self, but the compiler crashes as of Swift 1.2
-                owner.stream.listen(owner, fireIfAlreadyLoaded: true) {[weak owner] result in
+                owner.stream.listenOnce(owner, fireIfAlreadyLoaded: owner.fireIfAlreadyLoaded) {[weak owner] result in
                     if !(owner?.cancelled ?? false) {
                         owner?.completion?(result)
                     }

--- a/Test/XCTestCase+Async.swift
+++ b/Test/XCTestCase+Async.swift
@@ -18,9 +18,9 @@ extension XCTestCase {
         waitForExpectationsWithTimeout(5, handler: handler)
     }
     
-    func waitForStream<A>(stream : Stream<A>, verifier : (Result<A> -> Void)? = nil) {
+    func waitForStream<A>(stream : Stream<A>, fireIfAlreadyLoaded: Bool = true, verifier : (Result<A> -> Void)? = nil) {
         let expectation = expectationWithDescription("stream fires")
-        stream.extendLifetimeUntilFirstResult {
+        stream.extendLifetimeUntilFirstResult(fireIfAlreadyLoaded: fireIfAlreadyLoaded) {
             verifier?($0)
             expectation.fulfill()
         }


### PR DESCRIPTION
These are needed for pagination + testing pagination, respectively.

Accumulate combines a stream of arrays into one big array.
Delay delays the output of a stream over time. Easy way to make
something async.