### PR TITLE
Introduce pagination primitives

### DIFF
--- a/Source/DiscussionAPI.swift
+++ b/Source/DiscussionAPI.swift
@@ -43,8 +43,6 @@ extension Bool {
     }
 }
 
-public let defaultPageSize : Int = 20
-
 public class DiscussionAPI {
     
     
@@ -228,8 +226,8 @@ public class DiscussionAPI {
         if let order = orderBy.apiRepresentation {
             query["order_by"] = JSON(order)
         }
-        query["page_size"] = JSON(defaultPageSize)
-        query[PaginationInfo.standardPageParam] = JSON(pageNumber)
+        query[PaginationDefaults.pageParam] = JSON(pageNumber)
+        query[PaginationDefaults.pageSizeParam] = JSON(PaginationDefaults.pageSizeParam)
         return NetworkRequest(
             method : HTTPMethod.GET,
             path : "/api/discussion/v1/threads/",
@@ -256,8 +254,8 @@ public class DiscussionAPI {
         if let order = orderBy.apiRepresentation {
             query["order_by"] = JSON(order)
         }
-        query["page_size"] = JSON(defaultPageSize)
-        query[PaginationInfo.standardPageParam] = JSON(pageNumber)
+        query[PaginationDefaults.pageParam] = JSON(pageNumber)
+        query[PaginationDefaults.pageSizeParam] = JSON(PaginationDefaults.pageSizeParam)
         return NetworkRequest(
             method : HTTPMethod.GET,
             path : "/api/discussion/v1/threads/",
@@ -272,10 +270,11 @@ public class DiscussionAPI {
         return NetworkRequest(
             method : HTTPMethod.GET,
             path : "/api/discussion/v1/threads/",
-            query: ["course_id" : JSON(courseID),
+            query: [
+                "course_id" : JSON(courseID),
                 "text_search": JSON(searchText),
-                PaginationInfo.standardPageParam : JSON(pageNumber),
-                "page_size" : JSON(defaultPageSize)
+                PaginationDefaults.pageParam : JSON(pageNumber),
+                PaginationDefaults.pageSizeParam : JSON(PaginationDefaults.pageSizeParam)
             ],
             requiresAuth : true,
             deserializer : .JSONResponse(threadListDeserializer)
@@ -286,8 +285,8 @@ public class DiscussionAPI {
     //Questions can not be fetched if the endorsed field isn't populated
     static func getResponses(threadID: String,  threadType : PostThreadType, endorsedOnly endorsed : Bool =  false, pageNumber : Int = 1) -> NetworkRequest<[DiscussionComment]> {
         var query = [
-            "page_size" : JSON(defaultPageSize),
-            "page" : JSON(pageNumber),
+            PaginationDefaults.pageParam : JSON(pageNumber),
+            PaginationDefaults.pageSizeParam : JSON(PaginationDefaults.pageSizeParam),
             "thread_id": JSON(threadID),
         ]
         

--- a/Source/DiscussionAPI.swift
+++ b/Source/DiscussionAPI.swift
@@ -229,7 +229,7 @@ public class DiscussionAPI {
             query["order_by"] = JSON(order)
         }
         query["page_size"] = JSON(defaultPageSize)
-        query["page"] = JSON(pageNumber)
+        query[PaginationInfo.standardPageParam] = JSON(pageNumber)
         return NetworkRequest(
             method : HTTPMethod.GET,
             path : "/api/discussion/v1/threads/",
@@ -257,7 +257,7 @@ public class DiscussionAPI {
             query["order_by"] = JSON(order)
         }
         query["page_size"] = JSON(defaultPageSize)
-        query["page"] = JSON(pageNumber)
+        query[PaginationInfo.standardPageParam] = JSON(pageNumber)
         return NetworkRequest(
             method : HTTPMethod.GET,
             path : "/api/discussion/v1/threads/",
@@ -272,7 +272,11 @@ public class DiscussionAPI {
         return NetworkRequest(
             method : HTTPMethod.GET,
             path : "/api/discussion/v1/threads/",
-            query: ["course_id" : JSON(courseID), "text_search": JSON(searchText), "page" : JSON(pageNumber), "page_size" : JSON(defaultPageSize)],
+            query: ["course_id" : JSON(courseID),
+                "text_search": JSON(searchText),
+                PaginationInfo.standardPageParam : JSON(pageNumber),
+                "page_size" : JSON(defaultPageSize)
+            ],
             requiresAuth : true,
             deserializer : .JSONResponse(threadListDeserializer)
         )

--- a/Source/DiscussionAPI.swift
+++ b/Source/DiscussionAPI.swift
@@ -45,8 +45,6 @@ extension Bool {
 
 public class DiscussionAPI {
     
-    
-    
     private static func threadDeserializer(response : NSHTTPURLResponse, json : JSON) -> Result<DiscussionThread> {
         return DiscussionThread(json : json).toResult(NSError.oex_courseContentLoadError())
     }
@@ -227,7 +225,7 @@ public class DiscussionAPI {
             query["order_by"] = JSON(order)
         }
         query[PaginationDefaults.pageParam] = JSON(pageNumber)
-        query[PaginationDefaults.pageSizeParam] = JSON(PaginationDefaults.pageSizeParam)
+        query[PaginationDefaults.pageSizeParam] = JSON(PaginationDefaults.pageSize)
         return NetworkRequest(
             method : HTTPMethod.GET,
             path : "/api/discussion/v1/threads/",
@@ -255,7 +253,7 @@ public class DiscussionAPI {
             query["order_by"] = JSON(order)
         }
         query[PaginationDefaults.pageParam] = JSON(pageNumber)
-        query[PaginationDefaults.pageSizeParam] = JSON(PaginationDefaults.pageSizeParam)
+        query[PaginationDefaults.pageSizeParam] = JSON(PaginationDefaults.pageSize)
         return NetworkRequest(
             method : HTTPMethod.GET,
             path : "/api/discussion/v1/threads/",
@@ -274,7 +272,7 @@ public class DiscussionAPI {
                 "course_id" : JSON(courseID),
                 "text_search": JSON(searchText),
                 PaginationDefaults.pageParam : JSON(pageNumber),
-                PaginationDefaults.pageSizeParam : JSON(PaginationDefaults.pageSizeParam)
+                PaginationDefaults.pageSizeParam : JSON(PaginationDefaults.pageSize)
             ],
             requiresAuth : true,
             deserializer : .JSONResponse(threadListDeserializer)
@@ -286,7 +284,7 @@ public class DiscussionAPI {
     static func getResponses(threadID: String,  threadType : PostThreadType, endorsedOnly endorsed : Bool =  false, pageNumber : Int = 1) -> NetworkRequest<[DiscussionComment]> {
         var query = [
             PaginationDefaults.pageParam : JSON(pageNumber),
-            PaginationDefaults.pageSizeParam : JSON(PaginationDefaults.pageSizeParam),
+            PaginationDefaults.pageSizeParam : JSON(PaginationDefaults.pageSize),
             "thread_id": JSON(threadID),
         ]
         

--- a/Source/NetworkManager.swift
+++ b/Source/NetworkManager.swift
@@ -53,15 +53,6 @@ public struct NetworkRequest<Out> {
             self.deserializer = deserializer
             self.additionalHeaders = headers
     }
-    
-    var pageSize : Int? {
-        if let pageSize = query[PaginationDefaults.pageSizeParam] {
-            return pageSize.intValue
-        }
-        else {
-            return nil
-        }
-    }
 }
 
 extension NetworkRequest: CustomDebugStringConvertible {

--- a/Source/NetworkManager.swift
+++ b/Source/NetworkManager.swift
@@ -54,8 +54,7 @@ public struct NetworkRequest<Out> {
             self.additionalHeaders = headers
     }
     
-    //Apparently swift doesn't allow a computed property in a struct
-    func pageSize() -> Int? {
+    var pageSize : Int? {
         if let pageSize = query["page_size"] {
             return pageSize.intValue
         }

--- a/Source/NetworkManager.swift
+++ b/Source/NetworkManager.swift
@@ -55,7 +55,7 @@ public struct NetworkRequest<Out> {
     }
     
     var pageSize : Int? {
-        if let pageSize = query["page_size"] {
+        if let pageSize = query[PaginationDefaults.pageSizeParam] {
             return pageSize.intValue
         }
         else {

--- a/Source/NetworkPaginator.swift
+++ b/Source/NetworkPaginator.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+// This is deprecated. Use PaginationController + UnwrappedNetworkPaginator instead.
 public class NetworkPaginator<A> {
     
     private let paginatedFeed : PaginatedFeed<NetworkRequest<[A]>>
@@ -43,15 +44,16 @@ public class NetworkPaginator<A> {
     }
     
     func loadDataIfAvailable(callback : NetworkResult<[A]>? -> Void) {
-        if (!hasMoreResults) {
+        guard let nextRequest = paginatedFeed.next() where hasMoreResults else {
             loading = false
             callback(nil)
             return
         }
         loading = true
-        networkManager?.taskForRequest(paginatedFeed.next()) { [weak self] results in
+        
+        networkManager?.taskForRequest(nextRequest) { [weak self] results in
             self?.loading = false
-            if let items = results.data, resultsPerPage = self?.paginatedFeed.current().pageSize() {
+            if let items = results.data, resultsPerPage = self?.paginatedFeed.current().pageSize {
                 self?.hasMoreResults = items.count == resultsPerPage
             }
             else {

--- a/Source/PaginatedFeed.swift
+++ b/Source/PaginatedFeed.swift
@@ -18,7 +18,7 @@ class PaginatedFeed<A> {
         self.generator = f
     }
     
-     func next() -> A {
+    func next() -> A? {
         page++
         let result = generator(page)
         return result

--- a/Source/PaginationInfo.swift
+++ b/Source/PaginationInfo.swift
@@ -6,10 +6,14 @@
 //  Copyright © 2015 edX. All rights reserved.
 //
 
-public struct PaginationInfo {
-    
+public struct PaginationDefaults {
+    // Defaults for our APIs
     static let startPage = 1
-    static let standardPageParam = "page"
+    static let pageParam = "page"
+    static let pageSizeParam = "page_size"
+}
+
+public struct PaginationInfo {
     
     let totalCount : Int
     let pageCount : Int

--- a/Source/PaginationInfo.swift
+++ b/Source/PaginationInfo.swift
@@ -1,0 +1,53 @@
+//
+//  PaginationInfo.swift
+//  edX
+//
+//  Created by Akiva Leffert on 12/14/15.
+//  Copyright © 2015 edX. All rights reserved.
+//
+
+public struct PaginationInfo {
+    
+    static let startPage = 1
+    static let standardPageParam = "page"
+    
+    let totalCount : Int
+    let pageCount : Int
+    let previous : NSURL?
+    let next : NSURL?
+    
+    init?(json : JSON) {
+        guard let totalCount = json["count"].int else { return nil }
+        guard let pageCount = json["num_pages"].int else { return nil }
+        self.totalCount = totalCount
+        self.pageCount = pageCount
+        
+        self.previous = json["previous"].string.flatMap { NSURL(string: $0) }
+        self.next = json["next"].string.flatMap { NSURL(string: $0) }
+    }
+    
+    init(totalCount : Int, pageCount : Int, previous : NSURL? = nil, next: NSURL? = nil) {
+        self.totalCount = totalCount
+        self.pageCount = pageCount
+        self.previous = previous
+        self.next = next
+    }
+}
+
+public struct Paginated<A> {
+    
+    let pagination : PaginationInfo
+    let value : A
+    
+    init?(json : JSON, valueParser : JSON -> A?) {
+        guard let pagination = PaginationInfo(json: json["pagination"]) else { return nil }
+        guard let value = valueParser(json["results"]) else { return nil }
+        self.value = value
+        self.pagination = pagination
+    }
+    
+    init(pagination : PaginationInfo, value : A) {
+        self.pagination = pagination
+        self.value = value
+    }
+}

--- a/Source/PaginationInfo.swift
+++ b/Source/PaginationInfo.swift
@@ -56,3 +56,11 @@ public struct Paginated<A> {
         self.value = value
     }
 }
+
+extension NetworkRequest {
+
+    var pageSize : Int? {
+        return query[PaginationDefaults.pageSizeParam]?.intValue
+    }
+
+}

--- a/Source/PaginationInfo.swift
+++ b/Source/PaginationInfo.swift
@@ -9,6 +9,7 @@
 public struct PaginationDefaults {
     // Defaults for our APIs
     static let startPage = 1
+    static let pageSize = 20
     static let pageParam = "page"
     static let pageSizeParam = "page_size"
 }

--- a/Source/Paginator.swift
+++ b/Source/Paginator.swift
@@ -1,0 +1,126 @@
+//
+//  Paginator.swift
+//  edX
+//
+//  Created by Akiva Leffert on 12/16/15.
+//  Copyright © 2015 edX. All rights reserved.
+//
+
+protocol Paginator {
+    typealias Element
+    // Accumulation of all the objects loaded so far
+    var stream : Stream<[Element]> { get }
+    var hasNext : Bool { get }
+    func loadMore()
+}
+
+// Since Swift doesn't support generic protocols, we need a way to wrap
+// the associated type from Paginator into a generic parameter.
+// This bridges the two. This is slightly awkward so 
+// TODO: Revisit when Swift supports generic protocols
+class AnyPaginator<A> : Paginator {
+    typealias Element = A
+    let stream : Stream<[Element]>
+    private var _hasNext: () -> Bool
+    let _loadMore: () -> Void
+    
+    init<P: Paginator where P.Element == A>(_ paginator : P) {
+        self.stream = paginator.stream
+        self._loadMore = paginator.loadMore
+        self._hasNext = { paginator.hasNext }
+    }
+    
+    var hasNext : Bool {
+        return _hasNext()
+    }
+    
+    func loadMore() {
+        self._loadMore()
+    }
+}
+
+class WrappedPaginator<A> : NSObject, Paginator {
+    typealias Element = A
+    
+    private var itemStream = BackedStream<Paginated<[A]>>()
+    private var generator : Int -> Stream<Paginated<[A]>>
+    private var currentPage : Int = PaginationInfo.startPage
+    
+    init(generator : Int -> Stream<Paginated<[A]>>) {
+        self.generator = generator
+    }
+    
+    convenience init(networkManager : NetworkManager, requestGenerator : Int -> NetworkRequest<Paginated<[A]>>) {
+        self.init {page in
+            let request = requestGenerator(page)
+            return networkManager.streamForRequest(request)
+        }
+    }
+    
+    private(set) lazy var stream : Stream<[A]> = {
+        accumulate(self.itemStream.map { $0.value } )
+    }()
+    
+    var hasNext: Bool {
+        return currentPage == PaginationInfo.startPage || (stream.value?.count ?? 0) != itemStream.value?.pagination.totalCount
+    }
+    
+    func loadMore() {
+        if !itemStream.active {
+            let stream = generator(currentPage)
+            itemStream.backWithStream(stream)
+            stream.listenOnce(self) {[weak self] in
+                if $0.isSuccess {
+                    self?.currentPage += 1
+                }
+            }
+        }
+    }
+}
+
+// We previously did not return an explicit pagination body in our endpoints.
+// As such, this is a paginator that guesses whether it's at the end of the stream.
+// DO NOT ADD MORE USES OF THIS
+// Instead, update the server endpoint to use a standard pagination container
+// and use WrappedPaginator.
+class UnwrappedNetworkPaginator<A> : NSObject, Paginator {
+    typealias Element = A
+    private var itemStream = BackedStream<[A]>()
+    private var generator : Int -> NetworkRequest<[A]>
+    private var lastRequest: NetworkRequest<[A]>?
+    private let networkManager : NetworkManager
+    private var currentPage : Int = PaginationInfo.startPage
+    
+    init(networkManager : NetworkManager, generator : Int -> NetworkRequest<[A]>) {
+        self.networkManager = networkManager
+        self.generator = generator
+    }
+    
+    private(set) lazy var stream : Stream<[A]> = {
+        accumulate(self.itemStream)
+    }()
+    
+    var hasNext : Bool {
+        guard let lastRequest = lastRequest else { return true }
+        guard let pageSize = lastRequest.pageSize else { return true }
+        guard let lastItems = itemStream.value else { return true }
+        // This is just an approximation since we don't have count information
+        // If we returned a number other than the page size, we must be out of pages
+        return lastItems.count == pageSize
+    }
+    
+    func loadMore() {
+        if !itemStream.active {
+            let request = generator(currentPage)
+            lastRequest = request
+            
+            let stream = networkManager.streamForRequest(request)
+            itemStream.backWithStream(stream)
+            stream.listenOnce(self) {[weak self] in
+                if $0.isSuccess {
+                    self?.currentPage += 1
+                }
+            }
+        }
+    }
+}

--- a/Source/Paginator.swift
+++ b/Source/Paginator.swift
@@ -44,7 +44,7 @@ class WrappedPaginator<A> : NSObject, Paginator {
     
     private var itemStream = BackedStream<Paginated<[A]>>()
     private var generator : Int -> Stream<Paginated<[A]>>
-    private var currentPage : Int = PaginationInfo.startPage
+    private var currentPage : Int = PaginationDefaults.startPage
     
     init(generator : Int -> Stream<Paginated<[A]>>) {
         self.generator = generator
@@ -62,7 +62,7 @@ class WrappedPaginator<A> : NSObject, Paginator {
     }()
     
     var hasNext: Bool {
-        return currentPage == PaginationInfo.startPage || (stream.value?.count ?? 0) != itemStream.value?.pagination.totalCount
+        return currentPage == PaginationDefaults.startPage || (stream.value?.count ?? 0) != itemStream.value?.pagination.totalCount
     }
     
     func loadMore() {
@@ -89,7 +89,7 @@ class UnwrappedNetworkPaginator<A> : NSObject, Paginator {
     private var generator : Int -> NetworkRequest<[A]>
     private var lastRequest: NetworkRequest<[A]>?
     private let networkManager : NetworkManager
-    private var currentPage : Int = PaginationInfo.startPage
+    private var currentPage : Int = PaginationDefaults.startPage
     
     init(networkManager : NetworkManager, generator : Int -> NetworkRequest<[A]>) {
         self.networkManager = networkManager

--- a/Test/PaginationInfoTests.swift
+++ b/Test/PaginationInfoTests.swift
@@ -1,0 +1,38 @@
+//
+//  PaginationInfoTests.swift
+//  edX
+//
+//  Created by Akiva Leffert on 12/14/15.
+//  Copyright © 2015 edX. All rights reserved.
+//
+
+import XCTest
+@testable import edX
+
+class PaginationInfoTests: XCTestCase {
+    
+    func testParseSuccess() {
+        let json = JSON([
+            "count" : 25,
+            "num_pages" : 3,
+            "previous" : "http://example.com/previous",
+            "next" : "http://example.com/next",
+            ])
+        let info = PaginationInfo(json: json)
+        XCTAssertEqual(info!.pageCount, 3)
+        XCTAssertEqual(info!.totalCount, 25)
+        XCTAssertEqual(info!.next, NSURL(string: "http://example.com/next")!)
+        XCTAssertEqual(info!.previous, NSURL(string: "http://example.com/previous")!)
+    }
+    
+    func testParseFailure() {
+        let json = JSON([
+            "count" : 25,
+            "previous" : "http://example.com/previous",
+            "next" : "http://example.com/next",
+            ])
+        let info = PaginationInfo(json: json)
+        XCTAssertNil(info)
+    }
+
+}

--- a/Test/PaginatorTests.swift
+++ b/Test/PaginatorTests.swift
@@ -1,0 +1,151 @@
+//
+//  PaginatorTests.swift
+//  edX
+//
+//  Created by Akiva Leffert on 12/16/15.
+//  Copyright © 2015 edX. All rights reserved.
+//
+
+import XCTest
+
+@testable import edX
+
+let sampleResult = [1, 2, 3, 4]
+class PaginatorTests: XCTestCase {
+    
+    func testWrappedPaginatorStartsLoadable() {
+        let paginator = WrappedPaginator { i in
+            return Stream<Paginated<[Int]>>()
+        }
+        XCTAssertTrue(paginator.hasNext)
+    }
+    
+    func testWrappedPaginatorContinuesLoadable() {
+        let paginator = WrappedPaginator<Int> { _ in
+            let info = PaginationInfo(totalCount: 100, pageCount: 4)
+            return Stream(value: Paginated(pagination: info, value: sampleResult))
+        }
+        XCTAssertTrue(paginator.hasNext)
+        paginator.loadMore()
+        
+        XCTAssertEqual(paginator.stream.value!, sampleResult)
+        XCTAssertTrue(paginator.hasNext)
+    }
+    
+    func testWrappedPaginatorEnds() {
+        let paginator = WrappedPaginator<Int> { _ in
+            let info = PaginationInfo(totalCount: 100, pageCount: 4)
+            return Stream(value: Paginated(pagination: info, value: sampleResult))
+        }
+        while paginator.hasNext {
+            paginator.loadMore()
+        }
+        XCTAssertEqual(paginator.stream.value!.count, 100)
+    }
+    
+    func testWrappedPaginatorOnlyLoadsWhenInactive() {
+        var loadAttempts = 0
+        let networkManager = MockNetworkManager()
+        let paginator = WrappedPaginator<Int>(networkManager: networkManager) {i in
+            let request = NetworkRequest<Paginated<[Int]>>(
+                method: .GET,
+                path: "fakepath",
+                deserializer: ResponseDeserializer.JSONResponse { _ in
+                    let info = PaginationInfo(totalCount: 100, pageCount: 20)
+                    return Success(Paginated(pagination: info, value: sampleResult))
+                }
+            )
+            return request
+        }
+        networkManager.interceptWhenMatching({(_ : NetworkRequest<Paginated<[Int]>>) in true}) {
+            let info = PaginationInfo(totalCount: 100, pageCount: 20)
+            loadAttempts = loadAttempts + 1
+            return (nil, Paginated(pagination: info, value: sampleResult))
+        }
+        
+        // Try loading a bunch of times
+        paginator.loadMore()
+        paginator.loadMore()
+        paginator.loadMore()
+        
+        self.waitForStream(paginator.stream)
+        
+        XCTAssertFalse(paginator.stream.active)
+        
+        // But we should only actually try to load once since we drop requests while we're loading
+        XCTAssertEqual(loadAttempts, 1)
+    }
+    
+    func unwrappedPaginatorEnvironment(pageSize : Int = sampleResult.count) -> (MockNetworkManager, UnwrappedNetworkPaginator<Int>) {
+        let networkManager = MockNetworkManager()
+        let paginator = UnwrappedNetworkPaginator<Int>(networkManager: networkManager) {_ in
+            let request = NetworkRequest<[Int]>(
+                method: .GET,
+                path: "fakepath",
+                query: ["page_size" : JSON(pageSize)],
+                deserializer: ResponseDeserializer.JSONResponse { _ in
+                    return Success(sampleResult)
+                }
+            )
+            return request
+        }
+        return (networkManager, paginator)
+    }
+    
+    func testUnwrappedPaginatorStartsLoadable() {
+        let (_, paginator) = unwrappedPaginatorEnvironment()
+        XCTAssertTrue(paginator.hasNext)
+    }
+    
+    func testUnwrappedPaginatorContinuesLoadable() {
+        let (networkManager, paginator) = unwrappedPaginatorEnvironment()
+        
+        networkManager.interceptWhenMatching({(_ : NetworkRequest<[Int]>) in true}) {
+            return (nil, sampleResult)
+        }
+        
+        XCTAssertTrue(paginator.hasNext)
+        paginator.loadMore()
+        
+        waitForStream(paginator.stream)
+        XCTAssertEqual(paginator.stream.value!, sampleResult)
+        XCTAssertTrue(paginator.hasNext)
+    }
+    
+    func testUnwrappedPaginatorEnds() {
+        let (networkManager, paginator) = unwrappedPaginatorEnvironment(sampleResult.count + 1)
+
+        networkManager.interceptWhenMatching({(_ : NetworkRequest<[Int]>) in true}) {
+            return (nil, sampleResult)
+        }
+        
+        XCTAssertTrue(paginator.hasNext)
+        paginator.loadMore()
+        
+        waitForStream(paginator.stream)
+        XCTAssertFalse(paginator.hasNext)
+    }
+    
+    
+    func testUnwrappedPaginatorOnlyLoadsWhenInactive() {
+        let (networkManager, paginator) = unwrappedPaginatorEnvironment()
+        var loadAttempts = 0
+        
+        networkManager.interceptWhenMatching({(_ : NetworkRequest<[Int]>) in true}) {
+            loadAttempts = loadAttempts + 1
+            return (nil, sampleResult)
+        }
+        
+        // Try loading a bunch of times
+        paginator.loadMore()
+        paginator.loadMore()
+        paginator.loadMore()
+        
+        self.waitForStream(paginator.stream)
+        
+        XCTAssertFalse(paginator.stream.active)
+        
+        // But we should only actually try to load once since we drop requests while we're loading
+        XCTAssertEqual(loadAttempts, 1)
+    }
+}

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -192,6 +192,8 @@
 		7714A2601AB37CF7004C2254 /* OEXRegistrationFieldError.m in Sources */ = {isa = PBXBuildFile; fileRef = 7714A25F1AB37CF7004C2254 /* OEXRegistrationFieldError.m */; };
 		771FA0161B4588D80067F22D /* CourseDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 771FA0151B4588D80067F22D /* CourseDataManagerTests.swift */; };
 		771FA0181B458C7C0067F22D /* OEXRemovable.m in Sources */ = {isa = PBXBuildFile; fileRef = 771FA0171B458C7C0067F22D /* OEXRemovable.m */; };
+		77236EED1C21C376006AC1A4 /* Paginator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77236EEC1C21C376006AC1A4 /* Paginator.swift */; };
+		77236EEF1C21C3D5006AC1A4 /* PaginatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77236EEE1C21C3D5006AC1A4 /* PaginatorTests.swift */; };
 		772619B71ADDA8ED005BD7E4 /* OEXPushSettingsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 772619B61ADDA8ED005BD7E4 /* OEXPushSettingsManager.m */; };
 		772619BA1ADDC68E005BD7E4 /* OEXMockUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 772619B91ADDC68E005BD7E4 /* OEXMockUserDefaults.m */; };
 		7726BD1D1A36572F003B3354 /* NSMutableDictionary+OEXSafeAccess.m in Sources */ = {isa = PBXBuildFile; fileRef = 7726BD1C1A36572F003B3354 /* NSMutableDictionary+OEXSafeAccess.m */; };
@@ -365,6 +367,8 @@
 		77CBF55A1BFBE89300B4F121 /* CourseAnnouncementsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77CBF5591BFBE89300B4F121 /* CourseAnnouncementsViewControllerTests.swift */; };
 		77D470571C11EB4D00C6F0C9 /* ChoiceLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D470561C11EB4D00C6F0C9 /* ChoiceLabel.swift */; };
 		77D5F43F1C1F1C8F0079E228 /* OEXCourse+TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D5F43E1C1F1C8F0079E228 /* OEXCourse+TestData.swift */; };
+		77D5F4411C1F81F30079E228 /* PaginationInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D5F4401C1F81F30079E228 /* PaginationInfo.swift */; };
+		77D5F4431C1F83910079E228 /* PaginationInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D5F4421C1F83910079E228 /* PaginationInfoTests.swift */; };
 		77D705FA1B79573800ABCB70 /* OEXHTTPStatusCode+Groups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D705F91B79573800ABCB70 /* OEXHTTPStatusCode+Groups.swift */; };
 		77D705FC1B7C0DEC00ABCB70 /* OEXCourseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D705FB1B7C0DEC00ABCB70 /* OEXCourseTests.swift */; };
 		77D76BFD1AA5076D00C51C2C /* OEXLocalizedString.m in Sources */ = {isa = PBXBuildFile; fileRef = 77D76BFC1AA5076D00C51C2C /* OEXLocalizedString.m */; };
@@ -823,6 +827,8 @@
 		771772CC1ADC4032001A5AC6 /* Pods-edXTests.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "Pods-edXTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-edXTests/Pods-edXTests.release.xcconfig"; sourceTree = "<group>"; };
 		771FA0151B4588D80067F22D /* CourseDataManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseDataManagerTests.swift; sourceTree = "<group>"; };
 		771FA0171B458C7C0067F22D /* OEXRemovable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXRemovable.m; sourceTree = "<group>"; };
+		77236EEC1C21C376006AC1A4 /* Paginator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Paginator.swift; sourceTree = "<group>"; };
+		77236EEE1C21C3D5006AC1A4 /* PaginatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaginatorTests.swift; sourceTree = "<group>"; };
 		772619B51ADDA8ED005BD7E4 /* OEXPushSettingsManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXPushSettingsManager.h; sourceTree = "<group>"; };
 		772619B61ADDA8ED005BD7E4 /* OEXPushSettingsManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXPushSettingsManager.m; sourceTree = "<group>"; };
 		772619B81ADDC68E005BD7E4 /* OEXMockUserDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXMockUserDefaults.h; sourceTree = "<group>"; };
@@ -1038,6 +1044,8 @@
 		77CBF5591BFBE89300B4F121 /* CourseAnnouncementsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseAnnouncementsViewControllerTests.swift; sourceTree = "<group>"; };
 		77D470561C11EB4D00C6F0C9 /* ChoiceLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChoiceLabel.swift; sourceTree = "<group>"; };
 		77D5F43E1C1F1C8F0079E228 /* OEXCourse+TestData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OEXCourse+TestData.swift"; sourceTree = "<group>"; };
+		77D5F4401C1F81F30079E228 /* PaginationInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaginationInfo.swift; sourceTree = "<group>"; };
+		77D5F4421C1F83910079E228 /* PaginationInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaginationInfoTests.swift; sourceTree = "<group>"; };
 		77D705F91B79573800ABCB70 /* OEXHTTPStatusCode+Groups.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OEXHTTPStatusCode+Groups.swift"; sourceTree = "<group>"; };
 		77D705FB1B7C0DEC00ABCB70 /* OEXCourseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OEXCourseTests.swift; sourceTree = "<group>"; };
 		77D76BFB1AA5076D00C51C2C /* OEXLocalizedString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXLocalizedString.h; sourceTree = "<group>"; };
@@ -2585,6 +2593,8 @@
 		BECB7B331924C0C3009C77F1 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				77236EEE1C21C3D5006AC1A4 /* PaginatorTests.swift */,
+				77D5F4421C1F83910079E228 /* PaginationInfoTests.swift */,
 				77AFD10C1C1A63C3001985FD /* UserAgentGenerationOperation.swift */,
 				77AFD10F1C1B4F79001985FD /* NSString+TestExamples.h */,
 				77AFD1101C1B4F79001985FD /* NSString+TestExamples.m */,
@@ -2705,6 +2715,8 @@
 		BECB7B531924CA0C009C77F1 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				77236EEC1C21C376006AC1A4 /* Paginator.swift */,
+				77D5F4401C1F81F30079E228 /* PaginationInfo.swift */,
 				7793764C1BED27D000900A8C /* BasicAuthCredential.swift */,
 				7793764E1BED404C00900A8C /* OEXConfig+URLCredentialProvider.swift */,
 				77AB8C801B33BCBB00AB3FC0 /* PersistentResponseCache.swift */,
@@ -3200,6 +3212,7 @@
 				1918AFC51949B66400F40345 /* OEXGenericTableViewCell.m in Sources */,
 				77ADF4AF1AC1F80E00AC8955 /* OEXGoogleAuthProvider.m in Sources */,
 				1A7CEA331BABA8C70043A58C /* ProfileImageView.swift in Sources */,
+				77236EED1C21C376006AC1A4 /* Paginator.swift in Sources */,
 				7727EC351BBC73F300C9987F /* RevealViewController.swift in Sources */,
 				1AA7E8091BD5B92D00130CAE /* NSHTTPURLResponse+OEXHelpers.swift in Sources */,
 				77FFA2C11AC3087A00B4D69B /* NSAttributedString+OEXFormatting.m in Sources */,
@@ -3430,6 +3443,7 @@
 				777EFEFD1A7AFF0E00F8BF06 /* OEXRouter.m in Sources */,
 				9EC6E0FE1BDE106500729704 /* IrregularBorderView.swift in Sources */,
 				8F562F881A1F2D2C00320DB3 /* OEXGoogleSocial.m in Sources */,
+				77D5F4411C1F81F30079E228 /* PaginationInfo.swift in Sources */,
 				77D705FA1B79573800ABCB70 /* OEXHTTPStatusCode+Groups.swift in Sources */,
 				B4B6D6291A949F1B000F44E8 /* OEXRegistrationFieldEmailController.m in Sources */,
 				773B1D421B1F48F100B861DF /* CourseOutlineHeaderView.swift in Sources */,
@@ -3469,6 +3483,7 @@
 				7772BE821AF822500081CA7A /* UIBarButtonItem+OEXBlockActionsTests.m in Sources */,
 				9CA725F41A8E1B56009244A6 /* OEXFindCoursesTests.m in Sources */,
 				77EC88A01AB878880050F9CF /* NSString+OEXFormattingTests.m in Sources */,
+				77236EEF1C21C3D5006AC1A4 /* PaginatorTests.swift in Sources */,
 				77AFD11D1C1B7721001985FD /* NSObject+SafeKVOTests.swift in Sources */,
 				B4B285EA1A9B182900DD603A /* OEXConfigTests.m in Sources */,
 				77864DD71B1002A800182FC2 /* MockNetworkManager.swift in Sources */,
@@ -3545,6 +3560,7 @@
 				7772BE941AF94CA60081CA7A /* Array+Functional.swift in Sources */,
 				77567B791ACA00F900877A7B /* NSNotificationCenter+OEXSafeAccessTests.m in Sources */,
 				9E9AA36C1B3174E300CD7D44 /* CourseLastAccessedTests.swift in Sources */,
+				77D5F4431C1F83910079E228 /* PaginationInfoTests.swift in Sources */,
 				778F17831C0E06640099BF93 /* TestRouterEnvironment.swift in Sources */,
 				77000A4C1A775904007D306C /* NSDate+OEXComparisonsTests.m in Sources */,
 				778F17761C0D00340099BF93 /* OEXInterface+Mock.m in Sources */,


### PR DESCRIPTION
The goal here is to get rid of NetworkPaginator and replace it with the new
PaginationController which is more general, testable, and has a simpler
interface

Next steps are:
1. Adopt PaginationController in CourseCatalogViewController.
2. Replace NetworkPaginator where it is currently used in the
discussions code.

At that point we'll have one system where the differences in payload
content (whether there's a "pagination" package or not) are abstracted
into the specific Paginator implementation used.