### PR TITLE
Add non persistence support to remote image.

### DIFF
--- a/Source/CourseCardView.swift
+++ b/Source/CourseCardView.swift
@@ -15,7 +15,7 @@ class CourseCardView: UIView, UIGestureRecognizerDelegate {
     
     var course: OEXCourse?
     
-    private let coverImage = UIImageView()
+    private let coverImageView = UIImageView()
     private let container = UIView()
     private let titleLabel = UILabel()
     private let detailLabel = UILabel()
@@ -49,14 +49,12 @@ class CourseCardView: UIView, UIGestureRecognizerDelegate {
         setup()
     }
     
-    var networkManager : NetworkManager?
-    
     @available(iOS 8.0, *)
     override func prepareForInterfaceBuilder() {
         super.prepareForInterfaceBuilder()
         
         let bundle = NSBundle(forClass: self.dynamicType)
-        coverImage.image = UIImage(named:"Splash_map", inBundle: bundle, compatibleWithTraitCollection: self.traitCollection)
+        coverImageView.image = UIImage(named:"Splash_map", inBundle: bundle, compatibleWithTraitCollection: self.traitCollection)
         titleLabel.attributedText = titleTextStyle.attributedStringWithText("Demo Course")
         detailLabel.attributedText = detailTextStyle.attributedStringWithText("edx | DemoX")
         bottomTrailingLabel.attributedText = detailTextStyle.attributedStringWithText("X Videos, 1.23 MB")
@@ -68,23 +66,23 @@ class CourseCardView: UIView, UIGestureRecognizerDelegate {
         self.bottomLine.backgroundColor = OEXStyles.sharedStyles().neutralXLight()
         
         self.container.backgroundColor = OEXStyles.sharedStyles().neutralWhite().colorWithAlphaComponent(0.85)
-        self.coverImage.backgroundColor = OEXStyles.sharedStyles().neutralWhiteT()
-        self.coverImage.contentMode = UIViewContentMode.ScaleAspectFill
-        self.coverImage.clipsToBounds = true
-        self.coverImage.hidesLoadingSpinner = true
+        self.coverImageView.backgroundColor = OEXStyles.sharedStyles().neutralWhiteT()
+        self.coverImageView.contentMode = UIViewContentMode.ScaleAspectFill
+        self.coverImageView.clipsToBounds = true
+        self.coverImageView.hidesLoadingSpinner = true
         
         self.container.accessibilityIdentifier = "Title Bar"
         self.container.addSubview(titleLabel)
         self.container.addSubview(detailLabel)
         self.container.addSubview(bottomTrailingLabel)
         
-        self.addSubview(coverImage)
+        self.addSubview(coverImageView)
         self.addSubview(container)
-        self.insertSubview(bottomLine, aboveSubview: coverImage)
+        self.insertSubview(bottomLine, aboveSubview: coverImageView)
         self.addSubview(overlayContainer)
         
-        coverImage.setContentCompressionResistancePriority(UILayoutPriorityDefaultLow, forAxis: .Horizontal)
-        coverImage.setContentCompressionResistancePriority(UILayoutPriorityDefaultLow, forAxis: .Vertical)
+        coverImageView.setContentCompressionResistancePriority(UILayoutPriorityDefaultLow, forAxis: .Horizontal)
+        coverImageView.setContentCompressionResistancePriority(UILayoutPriorityDefaultLow, forAxis: .Vertical)
         detailLabel.setContentHuggingPriority(UILayoutPriorityDefaultLow, forAxis: UILayoutConstraintAxis.Horizontal)
         detailLabel.setContentCompressionResistancePriority(UILayoutPriorityDefaultHigh, forAxis: UILayoutConstraintAxis.Horizontal)
         
@@ -93,11 +91,11 @@ class CourseCardView: UIView, UIGestureRecognizerDelegate {
             make.trailing.equalTo(self).priorityRequired()
             make.bottom.equalTo(self).offset(-OEXStyles.dividerSize())
         }
-        self.coverImage.snp_makeConstraints { (make) -> Void in
+        self.coverImageView.snp_makeConstraints { (make) -> Void in
             make.top.equalTo(self)
             make.leading.equalTo(self)
             make.trailing.equalTo(self)
-            make.height.equalTo(self.coverImage.snp_width).multipliedBy(0.533).priorityLow()
+            make.height.equalTo(self.coverImageView.snp_width).multipliedBy(0.533).priorityLow()
             make.bottom.equalTo(self)
         }
         self.titleLabel.snp_makeConstraints { (make) -> Void in
@@ -170,28 +168,21 @@ class CourseCardView: UIView, UIGestureRecognizerDelegate {
         }
     }
     
+    var coverImage : RemoteImage? {
+        get {
+            return self.coverImageView.remoteImage
+        }
+        set {
+            self.coverImageView.remoteImage = newValue
+        }
+    }
+    
     private func cardTapped() {
         self.tapAction?(self)
     }
     
     private func updateAcessibilityLabel() {
         accessibilityLabel = "\(titleText),\(detailText),\(bottomTrailingText)"
-    }
-    
-    private func imageURL() -> String? {
-        if let courseInCell = self.course, relativeURLString = courseInCell.courseImageURL {
-            let baseURL = OEXConfig.sharedConfig().apiHostURL()
-            return NSURL(string: relativeURLString, relativeToURL: baseURL)?.absoluteString
-        }
-        return nil
-    }
-    
-    func setCoverImage() {
-        let placeholder = UIImage(named: "Splash_map")
-        coverImage.image = placeholder
-        if let networkManager = networkManager, imageURL = imageURL() where !imageURL.isEmpty {
-            coverImage.remoteImage = RemoteImageImpl(url: imageURL, networkManager: networkManager, placeholder: placeholder)
-        }
     }
     
     func addCenteredOverlay(view : UIView) {

--- a/Source/CourseCatalogDetailView.swift
+++ b/Source/CourseCatalogDetailView.swift
@@ -43,8 +43,6 @@ class CourseCatalogDetailView : UIView, UIWebViewDelegate {
         self.container = TZStackView(arrangedSubviews: [courseCard, insetContainer])
         self.environment = environment
         
-        courseCard.networkManager = environment.networkManager
-        
         super.init(frame: frame)
         
         setup()
@@ -191,7 +189,7 @@ extension CourseCatalogDetailView {
     }
     
     func applyCourse(course : OEXCourse) {
-        CourseCardViewModel.applyCourse(course, toCardView: courseCard)
+        CourseCardViewModel.onCourseCatalog(course).apply(courseCard, networkManager: self.environment.networkManager)
         self.blurbText = course.short_description
         self.descriptionHTML = course.overview_html
         let fields = fieldsForCourse(course)

--- a/Source/CourseCatalogViewController.swift
+++ b/Source/CourseCatalogViewController.swift
@@ -37,7 +37,7 @@ class CourseCatalogViewController: UIViewController, CoursesTableViewControllerD
     }()
     
     private lazy var tableController : CoursesTableViewController = {
-        return CoursesTableViewController(courseStream: self.stream)
+        return CoursesTableViewController(environment : self.environment, courseStream: self.stream)
     }()
 
     

--- a/Source/CourseDashboardViewController.swift
+++ b/Source/CourseDashboardViewController.swift
@@ -113,9 +113,8 @@ public class CourseDashboardViewController: UIViewController, UITableViewDataSou
         }
         
         let courseView = CourseCardView(frame: CGRectZero)
-        courseView.networkManager = self.environment.networkManager
         if let course = self.course {
-            CourseCardViewModel.applyCourse(course, toCardView: courseView, forType : .Dashboard)
+            CourseCardViewModel.onDashboard(course).apply(courseView, networkManager: self.environment.networkManager)
         }
         addShareButton(courseView)
 

--- a/Source/CoursesTableViewController.swift
+++ b/Source/CoursesTableViewController.swift
@@ -42,15 +42,18 @@ protocol CoursesTableViewControllerDelegate : class {
 }
 
 class CoursesTableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+    typealias Environment = NetworkManagerProvider
     
+    private var environment : Environment
     weak var delegate : CoursesTableViewControllerDelegate?
     
     private lazy var tableView = UITableView()
     private lazy var loadController = LoadStateViewController()
     private let courseStream : Stream<[OEXCourse]>
     
-    init(courseStream : Stream<[OEXCourse]>) {
+    init(environment: Environment, courseStream : Stream<[OEXCourse]>) {
         self.courseStream = courseStream
+        self.environment = environment
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -99,7 +102,7 @@ class CoursesTableViewController: UIViewController, UITableViewDelegate, UITable
             self?.delegate?.coursesTableChoseCourse(course)
         }
         
-        CourseCardViewModel.applyCourse(course, toCardView: cell.courseView)
+        CourseCardViewModel.onCourseCatalog(course).apply(cell.courseView, networkManager: self.environment.networkManager)
         cell.course = course
 
         return cell

--- a/Source/OEXFrontCourseViewController.m
+++ b/Source/OEXFrontCourseViewController.m
@@ -326,8 +326,7 @@
         OEXCourse* obj_course = [self.arr_CourseData objectAtIndex:indexPath.section];
 
         CourseCardView* infoView = cell.infoView;
-        infoView.networkManager = self.environment.networkManager;
-        [CourseCardViewModel applyCourse:obj_course toCardView:infoView forType:CardTypeHome videoDetails: nil];
+        [[CourseCardViewModel onHome:obj_course] apply:infoView networkManager:self.environment.networkManager];
         __weak __typeof(self) owner = self;
         infoView.tapAction = ^(CourseCardView* card) {
             [owner showCourse:obj_course];

--- a/Source/OEXMyVideosViewController.m
+++ b/Source/OEXMyVideosViewController.m
@@ -508,7 +508,6 @@ typedef  enum OEXAlertType
         cell.infoView.tapAction = ^(CourseCardView* card){
             [owner choseCourse:card.course];
         };
-        infoView.networkManager = self.environment.networkManager;
         
         NSDictionary* dictVideo = [self.arr_CourseData objectAtIndex:indexPath.section];
         OEXCourse* obj_course = [dictVideo objectForKey:CAV_KEY_COURSE];
@@ -525,7 +524,7 @@ typedef  enum OEXAlertType
         }
         NSString* videoDetails = [NSString stringWithFormat:@"%@, %@", Vcount, [dictVideo objectForKey:CAV_KEY_VIDEOS_SIZE]];
         
-        [CourseCardViewModel applyCourse:obj_course toCardView:infoView forType:CardTypeVideo videoDetails:videoDetails];
+        [[CourseCardViewModel onMyVideos:obj_course collectionInfo:videoDetails] apply:infoView networkManager:self.environment.networkManager];
         
         return cell;
     }

--- a/Source/RemoteImage.swift
+++ b/Source/RemoteImage.swift
@@ -25,11 +25,13 @@ struct RemoteImageImpl: RemoteImage {
     let url: String
     var localImage: UIImage?
     let networkManager: NetworkManager
+    let persist: Bool
     
-    init(url: String, networkManager: NetworkManager, placeholder: UIImage?) {
+    init(url: String, networkManager: NetworkManager, placeholder: UIImage?, persist: Bool) {
         self.url = url
         self.placeholder = placeholder
         self.networkManager = networkManager
+        self.persist = persist
     }
     
     private var filename: String {
@@ -69,7 +71,9 @@ struct RemoteImageImpl: RemoteImage {
             let cost = data.length
             imageCache.setObject(newImage, forKey: filename, cost: cost)
             
-            data.writeToFile(localFile, atomically: false)
+            if persist {
+                data.writeToFile(localFile, atomically: false)
+            }
             return Success(result)
         }
         
@@ -86,7 +90,7 @@ struct RemoteImageImpl: RemoteImage {
     }
 }
 
-private struct RemoteImageJustImage : RemoteImage {
+struct RemoteImageJustImage : RemoteImage {
     let placeholder: UIImage?
     var image: UIImage?
     

--- a/Source/UserProfile.swift
+++ b/Source/UserProfile.swift
@@ -90,7 +90,7 @@ extension UserProfile { //ViewModel
     func image(networkManager: NetworkManager) -> RemoteImage {
         
         let url = hasProfileImage && imageURL != nil ? imageURL! : ""
-        return RemoteImageImpl(url: url, networkManager: networkManager, placeholder: UIImage(named: "avatarPlaceholder"))
+        return RemoteImageImpl(url: url, networkManager: networkManager, placeholder: UIImage(named: "avatarPlaceholder"), persist: true)
     }
     
     var country: String? {


### PR DESCRIPTION
We don't want the course catalog to persist all the course images.

Factor CourseCardViewModel to better break apart the different cases.
This also makes the environment part of the model setup instead of the view,
which seems like a more natural separation of concerns and should make
it harder to forget, which we've had a couple bugs about.