### PR TITLE
Factor forums models to remove redundancy

### DIFF
--- a/QLearnSDK/DiscussionObjectModel.swift
+++ b/QLearnSDK/DiscussionObjectModel.swift
@@ -10,13 +10,15 @@ NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS 
 
 import UIKit
 
+// See https://openedx.atlassian.net/wiki/display/MA/Discussion+API
+
 public struct DiscussionComment {
     var commentID: String
-    var parentId: String?
-    var threadId: String?
+    var parentID: String?
+    var threadID: String
     var rawBody: String?
     var renderedBody: String?
-    var author: String?
+    var author: String
     var authorLabel: String?
     var voted = false
     var voteCount = 0
@@ -29,67 +31,76 @@ public struct DiscussionComment {
     var flagged = false
     var abuseFlagged = false
     var editableFields: String?
-    var children: [DiscussionComment]?
+    var children: [DiscussionComment]
     
+}
+
+extension DiscussionComment {
     init?(json: JSON) {
-        
-        if let identifier = json["id"].string {
-            commentID = identifier
-            parentId = json["parent_id"].string
-            threadId = json["thread_id"].string
-            rawBody = json["raw_body"].string
-            renderedBody = json["rendered_body"].string
-            author = json["author"].string
-            authorLabel = json["author_label"].string
-            voted = json["voted"].boolValue
-            voteCount = json["vote_count"].intValue
-            if let dateStr = json["created_at"].string {
-                createdAt = OEXDateFormatting.dateWithServerString(dateStr)
-            }
-            if let dateStr = json["updated_at"].string {
-                updatedAt = OEXDateFormatting.dateWithServerString(dateStr)
-            }
-            endorsed = json["endorsed"].boolValue
-            endorsedBy = json["endorsed_by"].string
-            endorsedByLabel = json["endorsed_by_label"].string
-            if let dateStr = json["endorsed_at"].string {
-                endorsedAt = OEXDateFormatting.dateWithServerString(dateStr)
-            }
-            flagged = json["flagged"].boolValue
-            abuseFlagged = json["abuse_flagged"].boolValue
-            editableFields = json["editable_fields"].string
-            if let childrenJson = json["children"].array {
-                var children = [DiscussionComment]()
-                for childJson in childrenJson {
-                    if let child = DiscussionComment(json: childJson) {
-                        children.append(child)
-                    }
+        guard let
+            threadID = json["thread_id"].string,
+            commentID = json["id"].string,
+            author = json["author"].string else
+        {
+                return nil
+        }
+
+        self.parentID = json["parent_id"].string
+        self.threadID = threadID
+        self.commentID = commentID
+        self.rawBody = json["raw_body"].string
+        self.renderedBody = json["rendered_body"].string
+        self.author = author
+        self.authorLabel = json["author_label"].string
+        self.voted = json["voted"].boolValue
+        self.voteCount = json["vote_count"].intValue
+        if let dateStr = json["created_at"].string {
+            self.createdAt = OEXDateFormatting.dateWithServerString(dateStr)
+        }
+        if let dateStr = json["updated_at"].string {
+            self.updatedAt = OEXDateFormatting.dateWithServerString(dateStr)
+        }
+        self.endorsed = json["endorsed"].boolValue
+        self.endorsedBy = json["endorsed_by"].string
+        self.endorsedByLabel = json["endorsed_by_label"].string
+        if let dateStr = json["endorsed_at"].string {
+            self.endorsedAt = OEXDateFormatting.dateWithServerString(dateStr)
+        }
+        self.flagged = json["flagged"].boolValue
+        self.abuseFlagged = json["abuse_flagged"].boolValue
+        self.editableFields = json["editable_fields"].string
+        if let childrenJson = json["children"].array {
+            var children = [DiscussionComment]()
+            for childJson in childrenJson {
+                if let child = DiscussionComment(json: childJson) {
+                    children.append(child)
                 }
-                self.children = children
             }
-        } else {
-            return nil
+            self.children = children
+        }
+        else {
+            self.children = []
         }
     }
 }
 
 
-public enum PostThreadType : String {
+public enum DiscussionThreadType : String {
     case Question = "question"
     case Discussion = "discussion"
 }
 
 public struct DiscussionThread {
-    var identifier: String?
-    var type: PostThreadType?
+    var threadID: String
+    var type: DiscussionThreadType
     var courseId: String?
-    var topicId: String?
+    var topicId: String
     var groupId: Int?
     var groupName: String?
     var title: String?
     var rawBody: String?
     var renderedBody: String?
-    var author: String?
+    var author: String
     var authorLabel: String?
     var commentCount = 0
     var commentListUrl: String?
@@ -107,45 +118,51 @@ public struct DiscussionThread {
     var read = false
     var unreadCommentCount = 0
     var responseCount : Int?
-    
-    init?(json: JSON) {
-        if let identifier = json["id"].string {
-            self.identifier = identifier
-            type = PostThreadType(rawValue: json["type"].string ?? "")
-            courseId = json["course_id"].string
-            topicId = json["topic_id"].string
-            groupId = json["group_id"].intValue
-            groupName = json["group_name"].string
-            title = json["title"].string
-            rawBody = json["raw_body"].string
-            renderedBody = json["rendered_body"].string
-            author = json["author"].string
-            authorLabel = json["author_label"].string
-            commentCount = json["comment_count"].intValue
-            commentListUrl = json["comment_list_url"].string
-            hasEndorsed = json["has_endorsed"].boolValue
-            pinned = json["pinned"].boolValue
-            closed = json["closed"].boolValue
-            following = json["following"].boolValue
-            flagged = json["flagged"].boolValue
-            abuseFlagged = json["abuse_flagged"].boolValue
-            voted = json["voted"].boolValue
-            voteCount = json["vote_count"].intValue
-            read = json["read"].boolValue
-            unreadCommentCount = json["unread_comment_count"].intValue
-            
-            if let dateStr = json["created_at"].string {
-                createdAt = OEXDateFormatting.dateWithServerString(dateStr)
-            }
-            if let dateStr = json["updated_at"].string {
-                updatedAt = OEXDateFormatting.dateWithServerString(dateStr)
-            }
-            editableFields = json["editable_fields"].string
-            if let numberOfResponses = json["response_count"].int {
-                responseCount = numberOfResponses
-            }
-        } else {
+}
+
+extension DiscussionThread {
+    public init?(json: JSON) {
+        guard let
+            topicId = json["topic_id"].string,
+            identifier = json["id"].string,
+            author = json["author"].string else
+        {
             return nil
+        }
+        self.threadID = identifier
+        self.topicId = topicId
+        
+        self.type = DiscussionThreadType(rawValue: json["type"].string ?? "") ?? .Discussion
+        self.courseId = json["course_id"].string
+        self.groupId = json["group_id"].intValue
+        self.groupName = json["group_name"].string
+        self.title = json["title"].string
+        self.rawBody = json["raw_body"].string
+        self.renderedBody = json["rendered_body"].string
+        self.author = author
+        self.authorLabel = json["author_label"].string
+        self.commentCount = json["comment_count"].intValue
+        self.commentListUrl = json["comment_list_url"].string
+        self.hasEndorsed = json["has_endorsed"].boolValue
+        self.pinned = json["pinned"].boolValue
+        self.closed = json["closed"].boolValue
+        self.following = json["following"].boolValue
+        self.flagged = json["flagged"].boolValue
+        self.abuseFlagged = json["abuse_flagged"].boolValue
+        self.voted = json["voted"].boolValue
+        self.voteCount = json["vote_count"].intValue
+        self.read = json["read"].boolValue
+        self.unreadCommentCount = json["unread_comment_count"].intValue
+        
+        if let dateStr = json["created_at"].string {
+            self.createdAt = OEXDateFormatting.dateWithServerString(dateStr)
+        }
+        if let dateStr = json["updated_at"].string {
+            self.updatedAt = OEXDateFormatting.dateWithServerString(dateStr)
+        }
+        self.editableFields = json["editable_fields"].string
+        if let numberOfResponses = json["response_count"].int {
+            self.responseCount = numberOfResponses
         }
     }
 }

--- a/Source/DiscussionAPI.swift
+++ b/Source/DiscussionAPI.swift
@@ -275,7 +275,7 @@ public class DiscussionAPI {
     
     //TODO: Yet to decide the semantics for the *endorsed* field. Setting false by default to fetch all questions.
     //Questions can not be fetched if the endorsed field isn't populated
-    static func getResponses(threadID: String,  threadType : PostThreadType, endorsedOnly endorsed : Bool =  false, pageNumber : Int = 1) -> NetworkRequest<[DiscussionComment]> {
+    static func getResponses(threadID: String,  threadType : DiscussionThreadType, endorsedOnly endorsed : Bool =  false, pageNumber : Int = 1) -> NetworkRequest<[DiscussionComment]> {
         var query = [
             PaginationDefaults.pageParam : JSON(pageNumber),
             PaginationDefaults.pageSizeParam : JSON(PaginationDefaults.pageSize),

--- a/Source/DiscussionCommentsViewController.swift
+++ b/Source/DiscussionCommentsViewController.swift
@@ -117,13 +117,14 @@ class DiscussionCommentCell: UITableViewCell {
         self.contentView.backgroundColor = OEXStyles.sharedStyles().discussionsBackgroundColor
     }
     
-    func useResponse(response : DiscussionResponseItem, position : CellPosition) {
-        self.bodyTextLabel.attributedText = commentTextStyle.attributedStringWithText(response.body)
+    func useResponse(response : DiscussionComment, position : CellPosition) {
+        self.bodyTextLabel.attributedText = commentTextStyle.attributedStringWithText(response.renderedBody)
         self.authorLabel.attributedText = response.authorLabelForTextStyle(smallTextStyle)
         
         self.containerView.backgroundColor = OEXStyles.sharedStyles().neutralWhiteT()
         
-        let message = Strings.comment(count: response.commentCount)
+        // TODO: Get a better count in here 
+        let message = Strings.comment(count: response.children.count)
         let buttonTitle = NSAttributedString.joinInNaturalLayout([
             Icon.Comment.attributedTextWithStyle(smallIconStyle),
             smallTextStyle.attributedStringWithText(message)])
@@ -136,9 +137,8 @@ class DiscussionCommentCell: UITableViewCell {
     func useComment(comment : DiscussionComment, inViewController viewController : DiscussionCommentsViewController, position : CellPosition) {
         bodyTextLabel.attributedText = commentTextStyle.attributedStringWithText(comment.rawBody)
         
-        if let item = DiscussionResponseItem(comment: comment) {
-            authorLabel.attributedText = item.authorLabelForTextStyle(smallTextStyle)
-        }
+        authorLabel.attributedText = comment.authorLabelForTextStyle(smallTextStyle)
+        
         self.containerView.backgroundColor = OEXStyles.sharedStyles().neutralXXLight()
         
         let buttonTitle = NSAttributedString.joinInNaturalLayout([
@@ -186,7 +186,7 @@ class DiscussionCommentsViewController: UIViewController, UITableViewDataSource,
     private let addCommentButton = UIButton(type: .System)
     private var tableView: UITableView!
     private var comments : [DiscussionComment]  = []
-    private let responseItem: DiscussionResponseItem
+    private let responseItem: DiscussionComment
     
     //Since didSet doesn't get called from within initialization context, we need to set it with another variable.
     private var commentsClosed : Bool = false {
@@ -206,7 +206,7 @@ class DiscussionCommentsViewController: UIViewController, UITableViewDataSource,
             if (!commentsClosed) {
                 addCommentButton.oex_addAction({[weak self] (action : AnyObject!) -> Void in
                     if let owner = self {
-                        owner.environment.router?.showDiscussionNewCommentFromController(owner, courseID: owner.courseID, item: DiscussionItem.Response(owner.responseItem))
+                        owner.environment.router?.showDiscussionNewCommentFromController(owner, courseID: owner.courseID, context: .Comment(owner.responseItem))
                     }
                     }, forEvents: UIControlEvents.TouchUpInside)
             }
@@ -217,7 +217,7 @@ class DiscussionCommentsViewController: UIViewController, UITableViewDataSource,
     //TODO: Get rid of this variable when Swift improves
     private var closed : Bool = false
     
-    init(environment: Environment, courseID : String, responseItem: DiscussionResponseItem, closed : Bool) {
+    init(environment: Environment, courseID : String, responseItem: DiscussionComment, closed : Bool) {
         self.courseID = courseID
         self.environment = environment
         self.responseItem = responseItem

--- a/Source/DiscussionNewCommentViewController.swift
+++ b/Source/DiscussionNewCommentViewController.swift
@@ -9,12 +9,45 @@
 import UIKit
 
 protocol DiscussionNewCommentViewControllerDelegate : class {
-    func newCommentController(controller  : DiscussionNewCommentViewController, addedItem item: DiscussionResponseItem)
+    func newCommentController(controller  : DiscussionNewCommentViewController, addedComment comment: DiscussionComment)
 }
 
 public class DiscussionNewCommentViewController: UIViewController, UITextViewDelegate {
     
     public typealias Environment = protocol<DataManagerProvider, NetworkManagerProvider, OEXRouterProvider>
+    
+    public enum Context {
+        case Thread(DiscussionThread)
+        case Comment(DiscussionComment)
+        
+        var threadID: String {
+            switch self {
+            case let .Thread(thread): return thread.threadID
+            case let .Comment(comment): return comment.threadID
+            }
+        }
+        
+        var renderedBody: String? {
+            switch self {
+            case let .Thread(thread): return thread.renderedBody
+            case let .Comment(comment): return comment.renderedBody
+            }
+        }
+        
+        var newCommentParentID: String? {
+            switch self {
+            case .Thread(_): return nil
+            case let .Comment(comment): return comment.commentID
+            }
+        }
+        
+        func authorLabelForTextStyle(style : OEXTextStyle) -> NSAttributedString {
+            switch self {
+            case let .Thread(thread): return thread.authorLabelForTextStyle(style)
+            case let .Comment(comment): return comment.authorLabelForTextStyle(style)
+            }
+        }
+    }
     
     private let ANSWER_LABEL_VISIBLE_HEIGHT : CGFloat = 15
     
@@ -36,7 +69,7 @@ public class DiscussionNewCommentViewController: UIViewController, UITextViewDel
     private let insetsController = ContentInsetsController()
     private let growingTextController = GrowingTextViewController()
     
-    private let ownerItem: DiscussionItem
+    private let context: Context
     private let courseID : String
     
     private var editingStyle : OEXTextStyle {
@@ -60,9 +93,9 @@ public class DiscussionNewCommentViewController: UIViewController, UITextViewDel
         }
     }
     
-    public init(environment: Environment, courseID : String, item: DiscussionItem) {
+    public init(environment: Environment, courseID : String, context: Context) {
         self.environment = environment
-        self.ownerItem = item
+        self.context = context
         self.courseID = courseID
         super.init(nibName: "DiscussionNewCommentViewController", bundle: nil)
     }
@@ -78,15 +111,14 @@ public class DiscussionNewCommentViewController: UIViewController, UITextViewDel
         addCommentButton.showProgress = true
         // create new response or comment
         
-        let apiRequest = DiscussionAPI.createNewComment(ownerItem.threadID, text: contentTextView.text, parentID: ownerItem.responseID)
+        let apiRequest = DiscussionAPI.createNewComment(context.threadID, text: contentTextView.text, parentID: context.newCommentParentID)
         
         environment.networkManager.taskForRequest(apiRequest) {[weak self] result in
             self?.addCommentButton.showProgress = false
             if let comment = result.data,
-                threadID = comment.threadId,
                 courseID = self?.courseID {
                     let dataManager = self?.environment.dataManager.courseDataManager.discussionManagerForCourseWithID(courseID)
-                    dataManager?.commentAddedStream.send((threadID: threadID, comment: comment))
+                    dataManager?.commentAddedStream.send((threadID: comment.threadID, comment: comment))
                     
                     self?.dismissViewControllerAnimated(true, completion: nil)
             }
@@ -165,24 +197,25 @@ public class DiscussionNewCommentViewController: UIViewController, UITextViewDel
         let placeholderText : String
         let navigationItemTitle : String
         
-        switch ownerItem {
-        case .Post(_):
+        switch context {
+        case let .Thread(thread):
             buttonTitle = Strings.addResponse
             placeholderText = Strings.addAResponse
             navigationItemTitle = Strings.addResponse
-        case .Response(_):
+            responseTitle.attributedText = responseTitleStyle.attributedStringWithText(thread.title)
+            self.isEndorsed = false
+        case let .Comment(comment):
             buttonTitle = Strings.addComment
             placeholderText = Strings.addAComment
             navigationItemTitle = Strings.addComment
             responseTitle.snp_makeConstraints{ (make) -> Void in
                 make.height.equalTo(0)
             }
+            self.isEndorsed = comment.endorsed
         }
         
-        self.isEndorsed = ownerItem.isEndorsed
         
-        responseTitle.attributedText = responseTitleStyle.attributedStringWithText(ownerItem.title)
-        responseBody.attributedText = responseBodyStyle.attributedStringWithText(ownerItem.body)
+        responseBody.attributedText = responseBodyStyle.attributedStringWithText(context.renderedBody)
         
         addCommentButton.applyButtonStyle(OEXStyles.sharedStyles().filledPrimaryButtonStyle, withTitle: buttonTitle)
         contentTextView.placeholder = placeholderText
@@ -192,7 +225,7 @@ public class DiscussionNewCommentViewController: UIViewController, UITextViewDel
             Icon.Answered.attributedTextWithStyle(answerLabelStyle, inline : true),
                             answerLabelStyle.attributedStringWithText(Strings.answer)])
 
-        personTimeLabel.attributedText = ownerItem.authorLabelForTextStyle(personTimeLabelStyle)
+        personTimeLabel.attributedText = context.authorLabelForTextStyle(personTimeLabelStyle)
     }
     
 

--- a/Source/DiscussionNewPostViewController.swift
+++ b/Source/DiscussionNewPostViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 struct DiscussionNewThread {
     let courseID: String
     let topicID: String
-    let type: PostThreadType
+    let type: DiscussionThreadType
     let title: String
     let rawBody: String
 }
@@ -48,7 +48,7 @@ public class DiscussionNewPostViewController: UIViewController, UITextViewDelega
     private var optionsViewController: MenuOptionsViewController?
     
 
-    private var selectedThreadType: PostThreadType = .Discussion {
+    private var selectedThreadType: DiscussionThreadType = .Discussion {
         didSet {
             switch selectedThreadType {
             case .Discussion:
@@ -129,7 +129,7 @@ public class DiscussionNewPostViewController: UIViewController, UITextViewDelega
         
         self.view.backgroundColor = OEXStyles.sharedStyles().neutralXLight()
         
-        let segmentOptions : [(title : String, value : PostThreadType)] = [
+        let segmentOptions : [(title : String, value : DiscussionThreadType)] = [
             (title : Strings.discussion, value : .Discussion),
             (title : Strings.question, value : .Question),
         ]

--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -8,142 +8,6 @@
 
 import Foundation
 
-public enum DiscussionItem {
-    case Post(DiscussionPostItem)
-    case Response(DiscussionResponseItem)
-    
-    var threadID : String {
-        switch self {
-            case let .Post(item): return item.threadID
-            case let .Response(item): return item.threadID
-        }
-    }
-    
-    var responseID : String? {
-        switch self {
-            case .Post(_): return nil
-            case let .Response(item): return item.responseID
-        }
-    }
-    
-    var title: String? {
-        switch self {
-            case let .Post(item): return item.title
-            case .Response(_): return nil
-        }
-    }
-    
-    var body: String {
-        switch self {
-        case let .Post(item): return item.body
-        case let .Response(item): return item.body
-        }
-    }
-    
-    var createdAt: NSDate {
-        switch self {
-        case let .Post(item): return item.createdAt
-        case let .Response(item): return item.createdAt
-        }
-    }
-    
-    var author: String {
-        switch self {
-        case let .Post(item): return item.author
-        case let .Response(item): return item.author
-        }
-    }
-    
-    var isResponse : Bool {
-        return self.responseID != nil
-    }
-    
-    var isEndorsed : Bool {
-        switch self {
-        case .Post(_): return false //A post itself can never be endorsed
-        case let .Response(item): return item.endorsed
-        }
-    }
-    
-    //We can make this enum conform to AuthorLabelProtocol when Swift improves
-    func authorLabelForTextStyle(textStyle : OEXTextStyle) -> NSAttributedString {
-        switch self {
-        case let .Post(item) : return item.authorLabelForTextStyle(textStyle)
-        case let .Response(item) : return item.authorLabelForTextStyle(textStyle)
-        }
-    }
-}
-
-public struct DiscussionResponseItem {
-    public let body: String
-    public let author: String
-    public let createdAt: NSDate
-    public var voteCount: Int
-    public let responseID: String
-    public let threadID: String
-    public let flagged: Bool
-    public var voted: Bool
-    public let children: [DiscussionComment]
-    public let commentCount : Int
-    public let endorsed : Bool
-    public let authorLabel : String?
-    
-    public init(
-        body: String,
-        author: String,
-        createdAt: NSDate,
-        voteCount: Int,
-        responseID: String,
-        threadID: String,
-        flagged: Bool,
-        voted: Bool,
-        children: [DiscussionComment],
-        commentCount : Int,
-        endorsed : Bool,
-        authorLabel : String?
-        )
-    {
-        self.body = body
-        self.author = author
-        self.createdAt = createdAt
-        self.voteCount = voteCount
-        self.responseID = responseID
-        self.threadID = threadID
-        self.flagged = flagged
-        self.voted = voted
-        self.children = children
-        self.commentCount = commentCount
-        self.endorsed = endorsed
-        self.authorLabel = authorLabel
-    }
-    
-    //TODO: Use this initializer where possible
-    public init?(comment : DiscussionComment) {
-        guard let body = comment.rawBody,
-            author = comment.author,
-            createdAt = comment.createdAt,
-            threadID = comment.threadId,
-            children = comment.children else {
-                return nil }
-        
-        let voteCount = comment.voteCount
-        self.init(
-            body: body,
-            author: author,
-            createdAt: createdAt,
-            voteCount: voteCount,
-            responseID: comment.commentID,
-            threadID: threadID,
-            flagged: comment.flagged,
-            voted: comment.voted,
-            children: children,
-            commentCount: children.count,
-            endorsed: comment.endorsed,
-            authorLabel: comment.authorLabel
-        )
-    }
-}
-
 private let GeneralPadding: CGFloat = 8.0
 
 private let cellButtonStyle = OEXTextStyle(weight:.Normal, size:.Small, color: OEXStyles.sharedStyles().neutralDark())
@@ -210,7 +74,6 @@ class DiscussionResponseCell: UITableViewCell {
     @IBOutlet private var endorsedLabel: UILabel!
     @IBOutlet private var separatorLine: UIView!
     @IBOutlet private var separatorLineHeightConstraint: NSLayoutConstraint!
-    
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -281,7 +144,8 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
     }
     
     var environment: Environment!
-    var courseID : String!
+    var courseID: String!
+    var threadID: String!
     
     var loadController : LoadStateViewController?
     
@@ -291,34 +155,41 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
     @IBOutlet var contentView: UIView!
     
     private let addResponseButton = UIButton(type: .System)
-    private var responses : [DiscussionResponseItem]  = []
-    var postItem: DiscussionPostItem?
+    private var responses : [DiscussionComment]  = []
+    var thread: DiscussionThread?
     var postFollowing = false
 
-    var postClosed : Bool = false {
-        didSet {
-            let styles = OEXStyles.sharedStyles()
-            let footerStyle = OEXTextStyle(weight: .Normal, size: .Base, color: OEXStyles.sharedStyles().neutralWhite())
-            
-            let icon = postClosed ? Icon.Closed : Icon.Create
-            let text = postClosed ? Strings.responsesClosed : Strings.addAResponse
-            
-            let buttonTitle = NSAttributedString.joinInNaturalLayout([icon.attributedTextWithStyle(footerStyle.withSize(.XSmall)),
-                footerStyle.attributedStringWithText(text)])
-            
-            addResponseButton.setAttributedTitle(buttonTitle, forState: .Normal)
-            addResponseButton.backgroundColor = postClosed ? styles.neutralBase() : styles.primaryXDarkColor()
-            addResponseButton.enabled = !postClosed
-            
-            if !postClosed {
-                addResponseButton.oex_addAction({ [weak self] (action : AnyObject!) -> Void in
-                    if let owner = self, item = owner.postItem {
-                        owner.environment.router?.showDiscussionNewCommentFromController(owner, courseID: owner.courseID, item: DiscussionItem.Post(item))
-                    }
-                    }, forEvents: UIControlEvents.TouchUpInside)
-            }
-            
+    func loadedThread(thread : DiscussionThread) {
+        let hadThread = self.thread != nil
+        self.thread = thread
+        if !hadThread {
+            self.loadInitialData()
         }
+        let styles = OEXStyles.sharedStyles()
+        let footerStyle = OEXTextStyle(weight: .Normal, size: .Base, color: OEXStyles.sharedStyles().neutralWhite())
+        
+        let icon = postClosed ? Icon.Closed : Icon.Create
+        let text = postClosed ? Strings.responsesClosed : Strings.addAResponse
+        
+        let buttonTitle = NSAttributedString.joinInNaturalLayout([icon.attributedTextWithStyle(footerStyle.withSize(.XSmall)),
+            footerStyle.attributedStringWithText(text)])
+        
+        addResponseButton.setAttributedTitle(buttonTitle, forState: .Normal)
+        addResponseButton.backgroundColor = postClosed ? styles.neutralBase() : styles.primaryXDarkColor()
+        addResponseButton.enabled = !postClosed
+        
+        addResponseButton.oex_removeAllActions()
+        if !thread.closed {
+            addResponseButton.oex_addAction({ [weak self] (action : AnyObject!) -> Void in
+                if let owner = self, thread = owner.thread {
+                    owner.environment.router?.showDiscussionNewCommentFromController(owner, courseID: owner.courseID, context: .Thread(thread))
+                }
+                }, forEvents: UIControlEvents.TouchUpInside)
+        }
+        
+        self.navigationItem.title = navigationItemTitleForThread(thread)
+        
+        tableView.reloadSections(NSIndexSet(index: TableSection.Post.rawValue) , withRowAnimation: .Fade)
     }
     
     var titleTextStyle : OEXTextStyle {
@@ -344,7 +215,6 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         
         super.viewDidLoad()
         
-        self.navigationItem.title = postItem?.navigationItemTitle
         self.view.backgroundColor = OEXStyles.sharedStyles().discussionsBackgroundColor
         self.contentView.backgroundColor = OEXStyles.sharedStyles().neutralXLight()
         tableView.backgroundColor = UIColor.clearColor()
@@ -352,8 +222,6 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         tableView.dataSource = self
         
         loadController = LoadStateViewController()
-
-        postClosed = postItem?.closed ?? false
         
         addResponseButton.contentVerticalAlignment = .Center
         view.addSubview(addResponseButton)
@@ -376,48 +244,58 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         super.viewDidAppear(animated)
         loadInitialData()
         markThreadAsRead()
-        updatePostItem()
+        loadThread()
+    }
+    
+    func navigationItemTitleForThread(thread : DiscussionThread) -> String {
+        switch thread.type {
+        case .Discussion:
+            return Strings.discussion
+        case .Question:
+            return thread.hasEndorsed ? Strings.answeredQuestion : Strings.unansweredQuestion
+        }
+    }
+    
+    private var postClosed : Bool {
+        return thread?.closed ?? false
     }
     
     private func markThreadAsRead() {
-        if let item = postItem {
-            let apiRequest = DiscussionAPI.readThread(true, threadID: item.threadID)
+        if let thread = thread {
+            let apiRequest = DiscussionAPI.readThread(true, threadID: thread.topicId)
             
             self.environment.networkManager.taskForRequest(apiRequest) {[weak self] result in
                 if let thread = result.data {
-                    self?.postItem?.read = thread.read
+                    self?.loadedThread(thread)
                     self?.tableView.reloadSections(NSIndexSet(index: TableSection.Post.rawValue) , withRowAnimation: .Fade)
                 }
             }
         }
     }
     
-    private func updatePostItem() {
-        if let item = postItem {
-            let updatePostRequest = DiscussionAPI.getThreadByID(item.threadID)
-            self.environment.networkManager.taskForRequest(updatePostRequest) {[weak self] thread in
-                if let postThread = thread.data {
-                    self?.postItem = DiscussionPostItem(thread: postThread, defaultThreadType: .Discussion)
-                    self?.tableView.reloadSections(NSIndexSet(index: TableSection.Post.rawValue) , withRowAnimation: .Fade)
-                }
+    private func loadThread() {
+        let updatePostRequest = DiscussionAPI.getThreadByID(threadID)
+        self.environment.networkManager.taskForRequest(updatePostRequest) {[weak self] response in
+            if let postThread = response.data {
+                self?.loadedThread(postThread)
             }
         }
     }
     
     private func loadInitialData() {
-        if let item = postItem {
-            postFollowing = item.following
+        if let thread = thread {
+            postFollowing = thread.following
             
-            self.networkPaginator = NetworkPaginator(networkManager: self.environment.networkManager, paginatedFeed: item.unendorsedCommentsPaginatedFeed, tableView: self.tableView)
+            self.networkPaginator = NetworkPaginator(networkManager: self.environment.networkManager, paginatedFeed: thread.unendorsedCommentsPaginatedFeed, tableView: self.tableView)
             
-            switch item.type {
+            switch thread.type {
             case .Discussion:
                 //Start loading data via the paginator
                 loadPaginatedDataIfAvailable(removePrevious: true)
             case .Question:
                 //Load the endorsed responses only at first
                 //If there are no endorsed responses, load paginated data
-                let endorsedCommentsRequest = DiscussionAPI.getResponses(item.threadID, threadType: item.type, endorsedOnly: true)
+                let endorsedCommentsRequest = DiscussionAPI.getResponses(thread.threadID, threadType: thread.type, endorsedOnly: true)
                 self.environment.networkManager.taskForRequest(endorsedCommentsRequest) {[weak self] result in
                     guard let responses : [DiscussionComment] = result.data where !responses.isEmpty else {
                         self?.loadPaginatedDataIfAvailable(removePrevious: true)
@@ -441,10 +319,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
             }
         
             for response in responses {
-                //Confusion with the name here because the backend treats Comments and Responses alike
-                if let item = DiscussionResponseItem(comment: response) {
-                    self.responses.append(item)
-                }
+                self.responses.append(response)
             }
             self.tableView.reloadData()
             self.loadController?.state = .Loaded
@@ -453,12 +328,12 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
     @IBAction func commentTapped(sender: AnyObject) {
         if let button = sender as? DiscussionCellButton, row = button.row {
             let response = responses[row]
-            if response.children.count == 0 {
+            if response.children.count == 0{
                 if !postClosed {
-                    environment.router?.showDiscussionNewCommentFromController(self, courseID: courseID, item: DiscussionItem.Response(response))
+                    environment.router?.showDiscussionNewCommentFromController(self, courseID: courseID, context: .Comment(response))
                 }
             } else {
-                environment.router?.showDiscussionCommentsFromViewController(self, courseID : courseID, item: response, closed : postClosed)
+                environment.router?.showDiscussionCommentsFromViewController(self, courseID : courseID, response: response, closed : postClosed)
             }
         }
     }
@@ -479,19 +354,15 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         }
     }
     
-    func cellForPostAtIndexPath(indexPath : NSIndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCellWithIdentifier(DiscussionPostCell.identifier, forIndexPath: indexPath) as! DiscussionPostCell
-        
-        if let item = postItem {
-
+    func applyThreadToCell(cell: DiscussionPostCell) -> UITableViewCell {
+        if let thread = self.thread {
             var authorLabelAttributedStrings = [NSAttributedString]()
             
-            
-            cell.titleLabel.attributedText = titleTextStyle.attributedStringWithText(item.title)
-            cell.bodyTextLabel.attributedText = postBodyTextStyle.attributedStringWithText(item.body)
+            cell.titleLabel.attributedText = titleTextStyle.attributedStringWithText(thread.title)
+            cell.bodyTextLabel.attributedText = postBodyTextStyle.attributedStringWithText(thread.renderedBody)
             
             let visibilityString : String
-            if let cohortName = item.groupName {
+            if let cohortName = thread.groupName {
                 visibilityString = Strings.postVisibility(cohort: cohortName)
             }
             else {
@@ -505,11 +376,11 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
                 authorLabelAttributedStrings.append(Icon.Closed.attributedTextWithStyle(infoTextStyle, inline: true))
             }
             
-            if (item.pinned) {
+            if (thread.pinned) {
                 authorLabelAttributedStrings.append(Icon.Pinned.attributedTextWithStyle(infoTextStyle, inline: true))
             }
             
-            authorLabelAttributedStrings.append(item.authorLabelForTextStyle(infoTextStyle))
+            authorLabelAttributedStrings.append(thread.authorLabelForTextStyle(infoTextStyle))
             
             cell.authorButton.setAttributedTitle(NSAttributedString.joinInNaturalLayout(authorLabelAttributedStrings), forState: .Normal)
             let profilesEnabled = OEXConfig.sharedConfig().shouldEnableProfiles()
@@ -517,11 +388,11 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
             if profilesEnabled {
                 cell.authorButton.oex_removeAllActions()
                 cell.authorButton.oex_addAction({ [weak self] _ in
-                    OEXRouter.sharedRouter().showProfileForUsername(self, username: item.author, editable: false)
+                    self?.environment.router?.showProfileForUsername(self, username: thread.author, editable: false)
                     }, forEvents: .TouchUpInside)
             }
 
-            if let responseCount = item.responseCount {
+            if let responseCount = thread.responseCount {
                 let icon = Icon.Comment.attributedTextWithStyle(infoTextStyle)
                 let countLabelText = infoTextStyle.attributedStringWithText(Strings.response(count: responseCount))
                 
@@ -531,22 +402,22 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
             else {
                 cell.responseCountLabel.attributedText = nil
             }
+            
+            updateVoteText(cell.voteButton, voteCount: thread.voteCount, voted: thread.voted)
+            updateFollowText(cell.followButton, following: thread.following)
         }
         
         // vote a post (thread) - User can only vote on post and response not on comment.
         cell.voteButton.oex_removeAllActions()
         cell.voteButton.oex_addAction({[weak self] (action : AnyObject!) -> Void in
-            if let owner = self, button = action as? DiscussionCellButton, item = owner.postItem {
+            if let owner = self, button = action as? DiscussionCellButton, thread = owner.thread {
                 button.enabled = false
                 
-                let apiRequest = DiscussionAPI.voteThread(item.voted, threadID: item.threadID)
+                let apiRequest = DiscussionAPI.voteThread(thread.voted, threadID: thread.topicId)
                 
-                owner.environment.networkManager.taskForRequest(apiRequest) { result in
+                owner.environment.networkManager.taskForRequest(apiRequest) {[weak self] result in
                     if let thread: DiscussionThread = result.data {
-                        let voteCount = thread.voteCount
-                        owner.updateVoteText(cell.voteButton, voteCount: voteCount, voted: thread.voted)
-                        owner.postItem?.voteCount = voteCount
-                        owner.postItem?.voted = thread.voted
+                        self?.loadedThread(thread)
                     }
                     button.enabled = true
                 }
@@ -556,8 +427,8 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         // follow a post (thread) - User can only follow original post, not response or comment.
         cell.followButton.oex_removeAllActions()
         cell.followButton.oex_addAction({[weak self] (sender : AnyObject!) -> Void in
-            if let owner = self, item = owner.postItem {
-                let apiRequest = DiscussionAPI.followThread(owner.postFollowing, threadID: item.threadID)
+            if let owner = self, thread = owner.thread {
+                let apiRequest = DiscussionAPI.followThread(owner.postFollowing, threadID: thread.topicId)
                 
                 owner.environment.networkManager.taskForRequest(apiRequest) { result in
                     if let thread: DiscussionThread = result.data {
@@ -568,16 +439,11 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
             }
             }, forEvents: UIControlEvents.TouchUpInside)
         
-        if let item = postItem {
-            updateVoteText(cell.voteButton, voteCount: item.voteCount, voted: item.voted)
-            updateFollowText(cell.followButton, following: item.following)
-        }
-        
         // report (flag) a post (thread) - User can report on post, response, or comment.
         cell.reportButton.oex_removeAllActions()
         cell.reportButton.oex_addAction({[weak self] (action : AnyObject!) -> Void in
-            if let owner = self, item = owner.postItem {
-                let apiRequest = DiscussionAPI.flagThread(item.flagged, threadID: item.threadID)
+            if let owner = self, thread = owner.thread {
+                let apiRequest = DiscussionAPI.flagThread(thread.flagged, threadID: thread.threadID)
                 
                 owner.environment.networkManager.taskForRequest(apiRequest) { result in
                     // TODO: update UI after API is done
@@ -594,7 +460,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         let response = responses[indexPath.row]
         
         
-        cell.bodyTextLabel.attributedText = responseBodyTextStyle.attributedStringWithText(response.body)
+        cell.bodyTextLabel.attributedText = responseBodyTextStyle.attributedStringWithText(response.renderedBody)
         
         let item = responses[indexPath.row]
         cell.authorButton.setAttributedTitle(item.authorLabelForTextStyle(infoTextStyle), forState: .Normal)
@@ -643,7 +509,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         cell.voteButton.oex_addAction({[weak self] (action : AnyObject!) -> Void in
             if let owner = self, button = action as? DiscussionCellButton, row = button.row {
                 let voted = owner.responses[row].voted
-                let apiRequest = DiscussionAPI.voteResponse(voted, responseID: owner.responses[row].responseID)
+                let apiRequest = DiscussionAPI.voteResponse(voted, responseID: owner.responses[row].commentID)
 
                 owner.environment.networkManager.taskForRequest(apiRequest) { result in
                     if let response: DiscussionComment = result.data {
@@ -662,7 +528,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         cell.reportButton.oex_removeAllActions()
         cell.reportButton.oex_addAction({[weak self] (action : AnyObject!) -> Void in
             if let owner = self, button = action as? DiscussionCellButton, row = button.row {
-                let apiRequest = DiscussionAPI.flagComment(owner.responses[row].flagged, commentID: owner.responses[row].responseID)
+                let apiRequest = DiscussionAPI.flagComment(owner.responses[row].flagged, commentID: owner.responses[row].commentID)
                 
                 owner.environment.networkManager.taskForRequest(apiRequest) { result in
                     // result.error: Optional(Error Domain=org.edx.error Code=-100 "Unable to load course content.
@@ -680,7 +546,8 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         switch TableSection(rawValue: indexPath.section) {
         case .Some(.Post):
-            return cellForPostAtIndexPath(indexPath)
+            let cell = tableView.dequeueReusableCellWithIdentifier(DiscussionPostCell.identifier, forIndexPath: indexPath) as! DiscussionPostCell
+            return applyThreadToCell(cell)
         case .Some(.Responses):
             return cellForResponseAtIndexPath(indexPath)
         case .None:
@@ -728,7 +595,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
     
 
 
-extension DiscussionPostItem {
+extension DiscussionThread {
     
     var unendorsedCommentsPaginatedFeed : PaginatedFeed<NetworkRequest<[DiscussionComment]>> {
             return PaginatedFeed() { i in
@@ -750,17 +617,22 @@ extension NSDate {
 }
 
 protocol AuthorLabelProtocol {
-    var createdAt : NSDate {get}
-    var author : String {get}
-    var authorLabel : String? {get}
+    var createdAt : NSDate? { get }
+    var author : String { get }
+    var authorLabel : String? { get }
 }
+
+
+extension DiscussionComment : AuthorLabelProtocol {}
+extension DiscussionThread : AuthorLabelProtocol {}
 
 extension AuthorLabelProtocol {
     func authorLabelForTextStyle(textStyle : OEXTextStyle) -> NSAttributedString {
         var attributedStrings = [NSAttributedString]()
         
-        let displayDate = self.createdAt.displayDate
-        attributedStrings.append(textStyle.attributedStringWithText(displayDate))
+        if let displayDate = self.createdAt?.displayDate {
+            attributedStrings.append(textStyle.attributedStringWithText(displayDate))
+        }
         
         let highlightStyle = OEXMutableTextStyle(textStyle: textStyle)
         if OEXConfig.sharedConfig().shouldEnableProfiles() {
@@ -775,26 +647,6 @@ extension AuthorLabelProtocol {
             attributedStrings.append(textStyle.attributedStringWithText(authorLabel))
         }
         return NSAttributedString.joinInNaturalLayout(attributedStrings)
-    }
-}
-
-extension DiscussionPostItem : AuthorLabelProtocol {
-    
-}
-
-extension DiscussionResponseItem : AuthorLabelProtocol {
-    
-}
-
-private extension DiscussionPostItem {
-    
-    var navigationItemTitle : String {
-        switch self.type {
-        case .Discussion:
-            return Strings.discussion
-        case .Question:
-            return self.hasEndorsed ? Strings.answeredQuestion : Strings.unansweredQuestion
-        }
     }
 }
 

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -107,22 +107,22 @@ extension OEXRouter {
         controller.presentViewController(fullScreenViewController, animated: true, completion: nil)
     }
     
-    func showDiscussionResponsesFromViewController(controller: UIViewController, courseID : String, item : DiscussionPostItem) {
+    func showDiscussionResponsesFromViewController(controller: UIViewController, courseID : String, threadID : String) {
         let storyboard = UIStoryboard(name: "DiscussionResponses", bundle: nil)
         let responsesViewController = storyboard.instantiateInitialViewController() as! DiscussionResponsesViewController
         responsesViewController.environment = environment
         responsesViewController.courseID = courseID
-        responsesViewController.postItem = item
+        responsesViewController.threadID = threadID
         controller.navigationController?.pushViewController(responsesViewController, animated: true)
     }
     
-    func showDiscussionCommentsFromViewController(controller: UIViewController, courseID : String, item : DiscussionResponseItem, closed : Bool) {
-        let commentsVC = DiscussionCommentsViewController(environment: environment, courseID : courseID, responseItem: item, closed: closed)
+    func showDiscussionCommentsFromViewController(controller: UIViewController, courseID : String, response : DiscussionComment, closed : Bool) {
+        let commentsVC = DiscussionCommentsViewController(environment: environment, courseID : courseID, responseItem: response, closed: closed)
         controller.navigationController?.pushViewController(commentsVC, animated: true)
     }
     
-    func showDiscussionNewCommentFromController(controller: UIViewController, courseID : String, item: DiscussionItem) {
-        let newCommentViewController = DiscussionNewCommentViewController(environment: environment, courseID : courseID, item: item)
+    func showDiscussionNewCommentFromController(controller: UIViewController, courseID : String, context: DiscussionNewCommentViewController.Context) {
+        let newCommentViewController = DiscussionNewCommentViewController(environment: environment, courseID : courseID, context: context)
         let navigationController = UINavigationController(rootViewController: newCommentViewController)
         controller.presentViewController(navigationController, animated: true, completion: nil)
     }

--- a/Source/PostsViewController.swift
+++ b/Source/PostsViewController.swift
@@ -8,111 +8,6 @@
 
 import UIKit
 
-
-
-public struct DiscussionPostItem {
-
-    public let title: String
-    public let body: String
-    public let author: String
-    public let authorLabel : String?
-    public let createdAt: NSDate
-    public let count: Int
-    public let threadID: String
-    public let following: Bool
-    public let flagged: Bool
-    public let pinned : Bool
-    public var voted: Bool
-    public var voteCount: Int
-    public var type : PostThreadType
-    public var read = false
-    public let unreadCommentCount : Int
-    public var closed = false
-    public let groupName : String?
-    public var hasEndorsed = false
-    public let responseCount : Int?
-    
-    // Unfortunately there's no way to make the default constructor public
-    public init(
-        title: String,
-        body: String,
-        author: String,
-        authorLabel: String?,
-        createdAt: NSDate,
-        count: Int,
-        threadID: String,
-        following: Bool,
-        flagged: Bool,
-        pinned: Bool,
-        voted: Bool,
-        voteCount: Int,
-        type : PostThreadType,
-        read : Bool,
-        unreadCommentCount : Int,
-        closed : Bool,
-        groupName : String?,
-        hasEndorsed : Bool,
-        responseCount : Int?
-        ) {
-            self.title = title
-            self.body = body
-            self.author = author
-            self.authorLabel = authorLabel
-            self.createdAt = createdAt
-            self.count = count
-            self.threadID = threadID
-            self.following = following
-            self.flagged = flagged
-            self.pinned = pinned
-            self.voted = voted
-            self.voteCount = voteCount
-            self.type = type
-            self.read = read
-            self.unreadCommentCount = unreadCommentCount
-            self.closed = closed
-            self.groupName = groupName
-            self.hasEndorsed = hasEndorsed
-            self.responseCount = responseCount
-    }
-    
-    var hasByText : Bool {
-        return following || pinned || closed || self.authorLabel != nil
-    }
-
-    public init?(thread : DiscussionThread, defaultThreadType : PostThreadType) {
-    guard let rawBody = thread.rawBody,
-        author = thread.author,
-        createdAt = thread.createdAt,
-        title = thread.title,
-        threadID = thread.identifier else {
-            return nil
-        }
-        
-        self.init(
-            title: title,
-            body: rawBody,
-            author: author,
-            authorLabel: thread.authorLabel,
-            createdAt: createdAt,
-            count: thread.commentCount,
-            threadID: threadID,
-            following: thread.following,
-            flagged: thread.flagged,
-            pinned: thread.pinned,
-            voted: thread.voted,
-            voteCount: thread.voteCount,
-            type : thread.type ?? defaultThreadType,
-            read : thread.read,
-            unreadCommentCount : thread.unreadCommentCount,
-            closed : thread.closed,
-            groupName : thread.groupName,
-            hasEndorsed : thread.hasEndorsed,
-            responseCount : thread.responseCount
-        )
-    }
-
-}
-
 class PostsViewControllerEnvironment: NSObject {
     weak var router: OEXRouter?
     let networkManager : NetworkManager?
@@ -184,7 +79,7 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
     let environment: PostsViewControllerEnvironment
     var networkPaginator : NetworkPaginator<DiscussionThread>?
     
-    private var tableView = UITableView(frame: CGRectZero, style: .Plain)
+    private lazy var tableView = UITableView(frame: CGRectZero, style: .Plain)
 
     private let viewSeparator = UIView()
     private let loadController : LoadStateViewController
@@ -204,7 +99,7 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
     
     private var context : Context
     
-    private var posts: [DiscussionPostItem] = []
+    private var posts: [DiscussionThread] = []
     private var selectedFilter: DiscussionPostsFilter = .AllPosts
     private var selectedOrderBy: DiscussionPostsSort = .RecentActivity
     
@@ -486,10 +381,6 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
         }
         self.loadThreadsFromPaginatedFeed(threadsFeed)
     }
-
-    private func postItem(fromDiscussionThread thread: DiscussionThread) -> DiscussionPostItem? {
-        return DiscussionPostItem(thread: thread, defaultThreadType: .Discussion)
-    }
     
     private func loadPostsForTopic(topic : DiscussionTopic?, filter: DiscussionPostsFilter, orderBy: DiscussionPostsSort) {
         let threadsFeed : PaginatedFeed<NetworkRequest<[DiscussionThread]>>
@@ -515,9 +406,7 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
         }
         
         for thread in threads {
-            if let item = self.postItem(fromDiscussionThread: thread) {
-                self.posts.append(item)
-            }
+            self.posts.append(thread)
         }
         self.tableView.reloadData()
         let emptyState = LoadState.empty(icon : nil , message: errorMessage())
@@ -653,13 +542,13 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
     
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCellWithIdentifier(PostTableViewCell.identifier, forIndexPath: indexPath) as! PostTableViewCell
-        cell.usePost(posts[indexPath.row], selectedOrderBy : selectedOrderBy)
+        cell.useThread(posts[indexPath.row], selectedOrderBy : selectedOrderBy)
         cell.applyStandardSeparatorInsets()
             return cell
     }
     
     func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
-        environment.router?.showDiscussionResponsesFromViewController(self, courseID : courseID, item: posts[indexPath.row])
+        environment.router?.showDiscussionResponsesFromViewController(self, courseID : courseID, threadID: posts[indexPath.row].threadID)
     }
 }
 

--- a/Test/DiscussionNewCommentViewControllerTests.swift
+++ b/Test/DiscussionNewCommentViewControllerTests.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 edX. All rights reserved.
 //
 
-import edX
+@testable import edX
 import UIKit
 import XCTest
 
@@ -15,28 +15,35 @@ class DiscussionNewCommentViewControllerTests: SnapshotTestCase {
     func testContentPost() {
         let courseID = OEXCourse.freshCourse().course_id!
         let environment = TestRouterEnvironment()
-        let post = DiscussionPostItem(
+        let thread = DiscussionThread(
+            threadID: "123",
+            type: .Discussion,
+            courseId: "some-course",
+            topicId: "abc",
+            groupId: nil,
+            groupName: nil,
             title: "Some Post",
-            body: "Lorem ipsum dolor sit amet",
+            rawBody: nil,
+            renderedBody: "Lorem ipsum dolor sit amet",
             author: "Test Person",
             authorLabel: "Staff",
-            createdAt: NSDate(timeIntervalSince1970: 12345),
-            count: 3,
-            threadID: "123",
+            commentCount: 0,
+            commentListUrl: nil,
+            hasEndorsed: false,
+            pinned: false,
+            closed: false,
             following: false,
             flagged: false,
-            pinned: false,
+            abuseFlagged: false,
             voted: true,
             voteCount: 4,
-            type : .Discussion,
-            read : true,
+            createdAt: NSDate(timeIntervalSince1970: 12345),
+            updatedAt: nil,
+            editableFields: nil,
+            read: true,
             unreadCommentCount: 0,
-            closed : false,
-            groupName : "Some Group",
-            hasEndorsed : false,
-            responseCount : 0
-        )
-        let controller = DiscussionNewCommentViewController(environment: environment, courseID: courseID, item : DiscussionItem.Post(post))
+            responseCount: 0)
+        let controller = DiscussionNewCommentViewController(environment: environment, courseID: courseID, context : .Thread(thread))
         inScreenNavigationContext(controller, action: {
             assertSnapshotValidWithContent(controller.navigationController!)
         })
@@ -45,22 +52,28 @@ class DiscussionNewCommentViewControllerTests: SnapshotTestCase {
     func testContentResponse() {
         let courseID = OEXCourse.freshCourse().course_id!
         let environment = TestRouterEnvironment()
-        let response = DiscussionResponseItem(
-            body: "Lorem ipsum dolor sit amet",
-            author: "Test Person",
-            createdAt: NSDate(timeIntervalSince1970: 12345),
-            voteCount: 10,
-            responseID: "123",
+        let comment = DiscussionComment(
+            commentID: "123",
+            parentID: nil,
             threadID: "345",
-            flagged: false,
+            rawBody: nil,
+            renderedBody: "Lorem ipsum dolor sit amet",
+            author: "Test Person",
+            authorLabel: nil,
             voted: true,
-            children: [],
-            commentCount: 0,
-            endorsed : true,
-            authorLabel: nil
-        )
-        
-        let controller = DiscussionNewCommentViewController(environment: environment, courseID: courseID, item : DiscussionItem.Response(response))
+            voteCount: 10,
+            createdAt: NSDate(timeIntervalSince1970: 12345),
+            updatedAt: nil,
+            endorsed: true,
+            endorsedBy: nil,
+            endorsedByLabel: nil,
+            endorsedAt: nil,
+            flagged: false,
+            abuseFlagged: false,
+            editableFields: nil,
+            children: [])
+       
+        let controller = DiscussionNewCommentViewController(environment: environment, courseID: courseID, context: .Comment(comment))
         inScreenNavigationContext(controller, action: {
             assertSnapshotValidWithContent(controller.navigationController!)
         })


### PR DESCRIPTION
We had four types:
DiscussionThread, DiscussionComment, DiscussionResponse, DiscussionPost

Plus an enum DiscussionPostItem which was DiscussionPost +
DiscussionResponse.

Further, these types weirdly conflated fields from both threads and
comments.

Based on the types we actually get back, what we actually needed was just:
DiscussionThread and DiscussionComment.

This rips out those unneeded types and removes the redundant information
from the thread being shoved into a response.

There is more renaming that really wants to happen here, but this was
already getting long.