### PR TITLE
Start deprecation of OEXStatusMessageViewController.

### DIFF
--- a/Source/CourseCatalogDetailViewController.swift
+++ b/Source/CourseCatalogDetailViewController.swift
@@ -103,7 +103,7 @@ class CourseCatalogDetailViewController: UIViewController {
                 self?.showMainScreenWithMessage(message)
             }
             else {
-                self?.loadController.showOverlayError(Strings.findCoursesEnrollmentErrorDescription)
+                self?.showOverlayMessage(Strings.findCoursesEnrollmentErrorDescription)
             }
             completion()
         }
@@ -124,10 +124,6 @@ extension CourseCatalogDetailViewController {
     
     func t_enrollInCourse(completion : () -> Void) {
         enrollInCourse(completion)
-    }
-    
-    var t_isShowingOverlayError : Bool {
-        return self.loadController.isShowingOverlayError
     }
     
 }

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -246,7 +246,7 @@ public class CourseOutlineViewController :
     
     func outlineTableController(controller: CourseOutlineTableController, choseDownloadVideos videos: [OEXHelperVideoDownload], rootedAtBlock block:CourseBlock) {
         guard canDownloadVideo() else {
-            self.loadController.showOverlayError(Strings.noWifiMessage)
+            self.showOverlayMessage(Strings.noWifiMessage)
             return
         }
         
@@ -268,7 +268,7 @@ public class CourseOutlineViewController :
     func outlineTableController(controller: CourseOutlineTableController, choseDownloadVideoForBlock block: CourseBlock) {
         
         guard canDownloadVideo() else {
-            self.loadController.showOverlayError(Strings.noWifiMessage)
+            self.showOverlayMessage(Strings.noWifiMessage)
             return
         }
         

--- a/Source/LoadStateViewController.swift
+++ b/Source/LoadStateViewController.swift
@@ -55,7 +55,7 @@ public enum LoadState {
     }
 }
 
-class LoadStateViewController : UIViewController, OEXStatusMessageControlling {
+class LoadStateViewController : UIViewController {
     
     private let loadingView : UIView
     private var contentView : UIView?
@@ -197,26 +197,6 @@ class LoadStateViewController : UIViewController, OEXStatusMessageControlling {
             self.contentView?.alpha = alphas.content
             self.view.userInteractionEnabled = alphas.touchable
         }
-    }
-    
-    func overlayViewsForStatusController(controller: OEXStatusMessageViewController!) -> [AnyObject]! {
-        return []
-    }
-    
-    func verticalOffsetForStatusController(controller: OEXStatusMessageViewController!) -> CGFloat {
-        return 0
-    }
-    
-    func showOverlayError(message : String) {
-        OEXStatusMessageViewController.sharedInstance().showMessage(message, onViewController: self)
-    }
-    
-    var isShowingOverlayError : Bool {
-        guard OEXStatusMessageViewController.sharedInstance().isVisible else {
-            return false
-        }
-        
-        return OEXStatusMessageViewController.sharedInstance().view.superview == self.view
     }
     
 }

--- a/Source/OEXCourseInfoViewController.m
+++ b/Source/OEXCourseInfoViewController.m
@@ -25,7 +25,6 @@
 #import "OEXNetworkManager.h"
 #import "OEXNetworkConstants.h"
 #import "OEXRouter.h"
-#import "OEXStatusMessageViewController.h"
 #import "OEXStyles.h"
 
 static NSString* const OEXFindCoursesEnrollPath = @"enroll/";

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -36,7 +36,6 @@
 #import "OEXRegistrationStyles.h"
 #import "OEXRegisteringUserDetails.h"
 #import "OEXRouter.h"
-#import "OEXStatusMessageViewController.h"
 #import "OEXStyles.h"
 #import "OEXUserLicenseAgreementViewController.h"
 #import "OEXUsingExternalAuthHeadingView.h"

--- a/Source/OEXStatusMessageViewController.h
+++ b/Source/OEXStatusMessageViewController.h
@@ -8,13 +8,12 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class OEXStatusMessageViewController;
 @class OEXTextStyle;
 
 @protocol OEXStatusMessageControlling <NSObject>
-// TODO: Switch the app to use a custom UINavigationController initWithNavigationBarClass
-// instead of hiding the navigation bar and just using an arbitrary view like we do now.
-// Once this is done, make this property optional and default it to zero
 
 /// How far below the view origin the status message should be displayed
 /// Typically this is the height of the navigation bar (including status bar),
@@ -30,6 +29,7 @@
 
 @end
 
+// DEPRECATED. Instead use the helpers in UIViewController+Overlay.swift
 @interface OEXStatusMessageViewController : UIViewController
 
 + (instancetype)sharedInstance;
@@ -49,3 +49,5 @@
 - (BOOL)t_isStatusViewBelowView:(UIView*)view;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/OEXStatusMessageViewController.m
+++ b/Source/OEXStatusMessageViewController.m
@@ -119,16 +119,6 @@ static CGFloat const OEXStatusMessagePadding = 20;
     } completion:nil];
 }
 
-- (void)viewDidLoad {
-    [super viewDidLoad];
-    [self errorMessagesAccessibilityIdentifiers];
-    // Do any additional setup after loading the view from its nib.
-}
-
-- (void)errorMessagesAccessibilityIdentifiers {
-    self.statusLabel.accessibilityLabel = @"floatingMessages";
-}
-
 - (BOOL)isVisible {
     return self.isViewLoaded && self.view.window != nil;
 }

--- a/Source/UIViewController+Overlay.swift
+++ b/Source/UIViewController+Overlay.swift
@@ -1,0 +1,107 @@
+//
+//  UIViewController+Overlay.swift
+//  edX
+//
+//  Created by Akiva Leffert on 12/23/15.
+//  Copyright © 2015 edX. All rights reserved.
+//
+
+import Foundation
+
+private var StatusMessageHideActionKey = "StatusMessageHideActionKey"
+
+private typealias StatusMessageRemovalInfo = (action : () -> Void, container : UIView)
+
+private class StatusMessageView : UIView {
+    
+    private let messageLabel = UILabel()
+    private let margin = 20
+    
+    init(message: String) {
+        super.init(frame: CGRectZero)
+        
+        addSubview(messageLabel)
+        
+        self.backgroundColor = UIColor.blackColor().colorWithAlphaComponent(0.75)
+        messageLabel.attributedText = OEXStatusMessageViewController.statusMessageStyle().attributedStringWithText(message)
+        messageLabel.snp_makeConstraints { make in
+            make.top.equalTo(self).offset(margin)
+            make.leading.equalTo(self).offset(margin)
+            make.trailing.equalTo(self).offset(-margin)
+            make.bottom.equalTo(self).offset(-margin)
+        }
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private let visibleDuration: NSTimeInterval = 5.0
+private let animationDuration: NSTimeInterval = 1.0
+
+extension UIViewController {
+    
+    func showOverlayMessageView(messageView : UIView) {
+        let container = PassthroughView()
+        container.clipsToBounds = true
+        view.addSubview(container)
+        container.addSubview(messageView)
+        
+        container.snp_makeConstraints {make in
+            make.top.equalTo(topLayoutGuide)
+            make.leading.equalTo(view)
+            make.trailing.equalTo(view)
+        }
+        messageView.snp_makeConstraints {make in
+            make.edges.equalTo(container)
+        }
+        
+        let size = messageView.systemLayoutSizeFittingSize(CGSizeMake(view.bounds.width, CGFloat.max))
+        messageView.transform = CGAffineTransformMakeTranslation(0, -size.height)
+        container.layoutIfNeeded()
+        
+        let hideAction = {[weak self] in
+            let hideInfo = objc_getAssociatedObject(self, &StatusMessageHideActionKey) as? Box<StatusMessageRemovalInfo>
+            if hideInfo?.value.container == container {
+                objc_setAssociatedObject(self, &StatusMessageHideActionKey, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            }
+            
+            UIView.animateWithDuration(animationDuration, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 0.1, options: .CurveEaseOut, animations: {
+                messageView.transform = CGAffineTransformMakeTranslation(0, -size.height)
+                }, completion: { _ in
+                    container.removeFromSuperview()
+            })
+        }
+        
+        // show
+        UIView.animateWithDuration(animationDuration, delay: 0, usingSpringWithDamping: 1, initialSpringVelocity: 0.1, options: .CurveEaseIn, animations: { () -> Void in
+            messageView.transform = CGAffineTransformIdentity
+            }, completion: {_ in
+                let delay = dispatch_time(DISPATCH_TIME_NOW, Int64(visibleDuration * NSTimeInterval(NSEC_PER_SEC)))
+                dispatch_after(delay, dispatch_get_main_queue()) {
+                    hideAction()
+                }
+        })
+        
+        let info : StatusMessageRemovalInfo = (action: hideAction, container: container)
+        objc_setAssociatedObject(self, &StatusMessageHideActionKey, Box(info), .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+    
+    func showOverlayMessage(string : String) {
+        let hideInfo = objc_getAssociatedObject(self, &StatusMessageHideActionKey) as? Box<StatusMessageRemovalInfo>
+        hideInfo?.value.action()
+        let view = StatusMessageView(message: string)
+        showOverlayMessageView(view)
+    }
+}
+
+
+// For use in testing only
+extension UIViewController {
+    
+    var t_isShowingOverlayMessage : Bool {
+        return objc_getAssociatedObject(self, &StatusMessageHideActionKey) as? Box<StatusMessageRemovalInfo> != nil
+    }
+    
+}

--- a/Source/VideoBlockViewController.swift
+++ b/Source/VideoBlockViewController.swift
@@ -163,7 +163,7 @@ class VideoBlockViewController : UIViewController, CourseBlockViewController, OE
             UIAlertView(title: Strings.videoContentNotAvailable, message: "", delegate: nil, cancelButtonTitle: nil, otherButtonTitles: Strings.close).show()
         }
         else {
-            loadController.showOverlayError(Strings.timeoutCheckInternetConnection)
+            self.showOverlayMessage(Strings.timeoutCheckInternetConnection)
         }
     }
     

--- a/Test/CourseCatalogDetailViewControllerTests.swift
+++ b/Test/CourseCatalogDetailViewControllerTests.swift
@@ -120,7 +120,7 @@ class CourseCatalogDetailViewControllerTests: SnapshotTestCase {
             
             let expectation = expectationWithDescription("enrollment finishes")
             controller.t_enrollInCourse({ () -> Void in
-                XCTAssertTrue(controller.t_isShowingOverlayError)
+                XCTAssertTrue(controller.t_isShowingOverlayMessage)
                 expectation.fulfill()
             })
             waitForExpectations()

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 		77D7FD281B04FEC8002ACA8C /* SnapshotTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D7FD271B04FEC8002ACA8C /* SnapshotTestCase.swift */; };
 		77DC295E1ABC9D4400FAD22C /* NSObject+OEXReplaceNull.m in Sources */ = {isa = PBXBuildFile; fileRef = B4A9EA221966A2FA00AAB3DB /* NSObject+OEXReplaceNull.m */; };
 		77DC29601ABCA0F200FAD22C /* OEXLoginSplashViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 77DC295F1ABCA0F200FAD22C /* OEXLoginSplashViewController.xib */; };
+		77DCD23D1C2B434200CAEBB5 /* UIViewController+Overlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DCD23C1C2B434200CAEBB5 /* UIViewController+Overlay.swift */; };
 		77E00B711B82A06F00573622 /* GrowingTextViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E00B701B82A06F00573622 /* GrowingTextViewController.swift */; };
 		77E00B731B83997E00573622 /* DiscussionNewCommentViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E00B721B83997E00573622 /* DiscussionNewCommentViewControllerTests.swift */; };
 		77E2097F1AF032CC0071316D /* UIControl+OEXBlockActionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 77E2097E1AF032CC0071316D /* UIControl+OEXBlockActionsTests.m */; };
@@ -1059,6 +1060,7 @@
 		77D7FD251B04ED45002ACA8C /* Icon.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Icon.swift; sourceTree = "<group>"; };
 		77D7FD271B04FEC8002ACA8C /* SnapshotTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotTestCase.swift; sourceTree = "<group>"; };
 		77DC295F1ABCA0F200FAD22C /* OEXLoginSplashViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = OEXLoginSplashViewController.xib; sourceTree = "<group>"; };
+		77DCD23C1C2B434200CAEBB5 /* UIViewController+Overlay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Overlay.swift"; sourceTree = "<group>"; };
 		77E00B701B82A06F00573622 /* GrowingTextViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrowingTextViewController.swift; sourceTree = "<group>"; };
 		77E00B721B83997E00573622 /* DiscussionNewCommentViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscussionNewCommentViewControllerTests.swift; sourceTree = "<group>"; };
 		77E2097E1AF032CC0071316D /* UIControl+OEXBlockActionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIControl+OEXBlockActionsTests.m"; sourceTree = "<group>"; };
@@ -1849,6 +1851,7 @@
 		776459831A0968F0008404CC /* Library Additions */ = {
 			isa = PBXGroup;
 			children = (
+				77DCD23C1C2B434200CAEBB5 /* UIViewController+Overlay.swift */,
 				7706AAC01BCFEEBF00728432 /* NSAttributedString+Formatting.swift */,
 				778CC8231BBECD9100DCCAE4 /* JSON+RawValueExtractable.swift */,
 				7727EC341BBC73F300C9987F /* RevealViewController.swift */,
@@ -3268,6 +3271,7 @@
 				9EEB85A71BD6564E000F3E9E /* PressableCustomButton.swift in Sources */,
 				B4B6D62C1A949F1B000F44E8 /* OEXRegistrationFieldPasswordController.m in Sources */,
 				1A3671F51BB03C7A00704032 /* OEXRearTableViewController.swift in Sources */,
+				77DCD23D1C2B434200CAEBB5 /* UIViewController+Overlay.swift in Sources */,
 				198826E81952FE39005D4D8A /* OEXOpenInBrowserViewController.m in Sources */,
 				770848BA1B200C76002FEEEE /* ViewTopMessageController.swift in Sources */,
 				778B82EC1A520F2A0040D9E0 /* OEXEnvironment.m in Sources */,


### PR DESCRIPTION
Provide standard way to show an overlay message on a view controller.
Does *not* update all messages to be in that style or use that API. In
particular, some of the Objective-C based screens still use the weird
custom nav bar stuff and so depend on the extra stuff
OEXStatusMessageViewController is doing. And the error in the profile
editor was sufficiently different in style and behavior that I didn't
want to mess with it at at this moment.

This new implementation doesn't rely on a singleton, supports custom
views displayed in a standard way, and is desgined around autolayout.

This is really just going to be used to make it easier to show the
large offline info message when we modernize the course list.