### PR TITLE
Get reachability for offline header from environment

### DIFF
--- a/Source/ContentInsetsController.swift
+++ b/Source/ContentInsetsController.swift
@@ -96,8 +96,8 @@ public class ContentInsetsController: NSObject, ContentInsetsSourceDelegate {
 // Common additions
 extension ContentInsetsController {
     
-    func supportOfflineMode() {
-        let controller = OfflineModeController()
+    func supportOfflineMode(reachability: Reachability) {
+        let controller = OfflineModeController(reachability: reachability)
         addSource(controller)
         
         if let owner = owner {

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -99,7 +99,7 @@ public class CourseOutlineViewController :
         tableController.refreshController.delegate = self
         
         insetsController.setupInController(self, scrollView : self.tableController.tableView)
-        insetsController.supportOfflineMode()
+        insetsController.supportOfflineMode(environment.reachability)
         insetsController.addSource(tableController.refreshController)
         
         self.view.setNeedsUpdateConstraints()

--- a/Source/OfflineModeController.swift
+++ b/Source/OfflineModeController.swift
@@ -16,7 +16,7 @@ import UIKit
 public class OfflineModeController: ViewTopMessageController {
     let reachability : Reachability
     
-    public init(reachability : Reachability = InternetReachability()) {
+    public init(reachability : Reachability) {
         let messageView = OfflineModeView(frame : CGRectZero)
         self.reachability = reachability
         


### PR DESCRIPTION
This way if you run the tests while offline you won't display an offline
header unless you deliberately mean to.