### PR TITLE
Filter out missing children instead of failing

### DIFF
--- a/Source/CourseOutline.swift
+++ b/Source/CourseOutline.swift
@@ -115,9 +115,9 @@ public struct CourseOutline {
 public enum CourseBlockType {
     case Unknown(String)
     case Course
-    case Chapter
-    case Section
-    case Unit
+    case Chapter // child of course
+    case Section // child of chapter
+    case Unit // child of section
     case Video(OEXVideoSummary)
     case Problem
     case HTML

--- a/Source/CourseOutlineQuerier.swift
+++ b/Source/CourseOutlineQuerier.swift
@@ -284,9 +284,9 @@ public class CourseOutlineQuerier : NSObject {
     }
     
     private func childrenOfBlockWithID(blockID : CourseBlockID?, forMode mode : CourseOutlineMode, inOutline outline : CourseOutline) -> BlockGroup? {
-        if let block = self.blockWithID(blockID ?? outline.root, inOutline: outline),
-            blocks = block.children.mapOrFailIfNil({ self.blockWithID($0, inOutline: outline) })
+        if let block = self.blockWithID(blockID ?? outline.root, inOutline: outline)
         {
+            let blocks = block.children.flatMap({ self.blockWithID($0, inOutline: outline) })
             let filtered = self.filterBlocks(blocks, forMode: mode)
             return BlockGroup(block : block, children : filtered)
         }

--- a/Test/CourseOutlineQuerierTests.swift
+++ b/Test/CourseOutlineQuerierTests.swift
@@ -139,4 +139,22 @@ class CourseOutlineQuerierTests: XCTestCase {
         removable.remove()
         
     }
+    
+    func testMissingChildFilteredOut() {
+        let outline = CourseOutline(root: "root", blocks:
+            [
+                "root": CourseBlock(type: CourseBlockType.Section,
+                    children: ["found", "missing"], blockID: "root", name: "Root!", multiDevice: true),
+                "found": CourseBlock(type: CourseBlockType.Section,
+                    children: [], blockID: "found", name: "Child!", multiDevice: true)
+            ]
+        )
+        let querier = CourseOutlineQuerier(courseID: courseID, outline: outline)
+        let childStream = querier.childrenOfBlockWithID(nil, forMode: .Full)
+        childStream.listenOnce(self) {
+            XCTAssertEqual($0.value!.children.count, 1)
+            XCTAssertEqual($0.value!.children[0].blockID, "found")
+        }
+        waitForStream(childStream)
+    }
 }


### PR DESCRIPTION
If there's bad data coming in from the server, we might end up in a case
where we get asked for a child that doesn't exist. Instead of giving up
in that case, we should just filter it out.

JIRA: https://openedx.atlassian.net/browse/MA-1972