### PR TITLE
Always use avatar if available

### DIFF
--- a/Source/UserProfileViewController.swift
+++ b/Source/UserProfileViewController.swift
@@ -221,9 +221,9 @@ public class UserProfileViewController: UIViewController {
         usernameLabel.attributedText = usernameStyle.attributedStringWithText(profile.username)
         bioSystemMessage.hidden = true
 
+        avatarImage.remoteImage = profile.image(environment.networkManager)
+
         if profile.sharingLimitedProfile {
-            
-            avatarImage.image = UIImage(named: "avatarPlaceholder")
             
             setMessage(editable ? Strings.Profile.showingLimited : Strings.Profile.learnerHasLimitedProfile(platformName: OEXConfig.sharedConfig().platformName()))
             bioText.text = ""
@@ -236,8 +236,6 @@ public class UserProfileViewController: UIViewController {
             }
         } else {
             setMessage(nil)
-
-            avatarImage.remoteImage = profile.image(environment.networkManager)
 
             if let language = profile.language {
                 let icon = Icon.Comment.attributedTextWithStyle(infoStyle)


### PR DESCRIPTION
We'll naturally get no avatar URL if the profile is limited and a user
should always be able to see their own avatar.

JIRA: https://openedx.atlassian.net/browse/MA-2048