### PR TITLE
Travis docker setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: objective-c  
 
+sudo: false # Explicitly use container-based infrastructure http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+
 osx_image: xcode7
 
 script:


### PR DESCRIPTION
@aleffert 

Per the travis email thread, docker doesn't look like it is enabled on this repo. I was told setting sudo to false would do the trick which is what I also found in the android teapot.