### PR TITLE
Fix crash with KVO lifecycle

### DIFF
--- a/Source/NSObject+SafeKVO.swift
+++ b/Source/NSObject+SafeKVO.swift
@@ -13,6 +13,7 @@ protocol NSObjectExtensions {}
 private class KVOListener : NSObject, Removable {
     let action : AnyObject -> Void
     var removeAction : (KVOListener -> Void)?
+    var token = malloc(1)
     
     init(action : AnyObject -> Void) {
         self.action = action
@@ -31,30 +32,35 @@ private class KVOListener : NSObject, Removable {
     
     deinit {
         self.removeAction?(self)
+        free(token)
     }
 }
 
 extension NSObject : NSObjectExtensions {}
 
 extension NSObjectExtensions where Self : NSObject {
-    
+
+    /// Adds ``observer`` as a KVO watcher for the receiver. Note that this causes the observer to retain the
+    /// observed object.
+    // We have to do this retain because the KVO system will crash if you don't remove an observer
+    // before deallocating the observed object.
+    // There's no cycle here though, since the observed object only retains the observer weakly
     func oex_addObserver<Observer : NSObject>(observer : Observer, forKeyPath keyPath: String, action: (Observer, Self, AnyObject) -> Void) -> Removable {
-        var listener = KVOListener{[weak observer, weak self] v in
-            if let observer = observer, owner = self {
-                action(observer, owner, v)
+        let listener = KVOListener{[weak observer] v in
+            if let observer = observer {
+                action(observer, self, v)
             }
         }
-        objc_setAssociatedObject(observer, &listener, listener, .OBJC_ASSOCIATION_RETAIN)
-        self.addObserver(listener, forKeyPath: keyPath, options: .New, context: &listener)
+        objc_setAssociatedObject(observer, listener.token, listener, .OBJC_ASSOCIATION_RETAIN)
+        self.addObserver(listener, forKeyPath: keyPath, options: .New, context: listener.token)
         let deallocRemover = observer.oex_performActionOnDealloc { [weak listener] in
             listener?.remove()
         }
         
         listener.removeAction = {[weak observer, weak self] listener in
-            var listener = listener
             self?.removeObserver(listener, forKeyPath: keyPath)
             if let observer = observer {
-                objc_setAssociatedObject(observer, &listener, nil, .OBJC_ASSOCIATION_RETAIN)
+                objc_setAssociatedObject(observer, listener.token, nil, .OBJC_ASSOCIATION_RETAIN)
             }
             deallocRemover.remove()
         }

--- a/Test/NSObject+SafeKVOTests.swift
+++ b/Test/NSObject+SafeKVOTests.swift
@@ -69,9 +69,25 @@ class KVOListenerTests: XCTestCase {
         
         autoreleasepool {
             scope(observed)
-            XCTAssertTrue(updated.value)
-            observed.value = "new"
         }
+        XCTAssertTrue(updated.value)
+        observed.value = "new"
+    }
+
+    func testObserverOwnsObserved() {
+        let cleared = MutableBox(false)
+        func scope() {
+            let observed = ListenableObject()
+            observed.oex_addObserver(self, forKeyPath: "value") { (observer, object, value) -> Void in }
+            observed.oex_performActionOnDealloc { () -> Void in
+                cleared.value = true
+            }
+        }
+
+        autoreleasepool {
+            scope()
+        }
+        XCTAssertFalse(cleared.value)
     }
 
 }


### PR DESCRIPTION
KVO has a stupid system where you have to remove an observer before the
observed object gets deallocated. We were being too clever about weak
references and so the observed object could get deallocated before the
observer. Ideally, we'd just nuke the listener in that case, but we
can't trigger an event *just before* the observed object gets
deallocated (at least without swizzling, which seems excessive).

So instead, we update the pattern to explicitly retain the observer.
This is typically how lifetimes work anyway, so it shouldn't be an
issue.

Also uses a new way to get a unique id for the association with better guarantees about addresses not changing.

Unfortunately, I couldn't actually reproduce the related crash, but it's
clear from the stack trace that this is the underlying issue. The test I
added crashes on the old implementation.

JIRA: https://openedx.atlassian.net/browse/MA-2136