### PR TITLE
Set uses non-exempt encryption key to false

### DIFF
--- a/Source/edX-Info.plist
+++ b/Source/edX-Info.plist
@@ -43,6 +43,8 @@
 	<string>2.3.1</string>
 	<key>FacebookDisplayName</key>
 	<string>edX</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>fbapi</string>


### PR DESCRIPTION
This is a new thing in iTunesConnect that lets you bypass those
repetitive are you using crypto screens. Since we don't use any
non-exempt crypto, this seemed like an easy thing to do.