### PR TITLE
Prefer fallback video to youtube

### DIFF
--- a/Source/OEXVideoEncoding.h
+++ b/Source/OEXVideoEncoding.h
@@ -10,6 +10,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString* const OEXVideoEncodingFallback;
+
 @interface OEXVideoEncoding : NSObject
 
 - (id)initWithDictionary:(NSDictionary*)dictionary name:(NSString*)name;
@@ -22,8 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// [String], ordered by preference
 + (NSArray*)knownEncodingNames;
-
-+ (NSString*)fallbackEncodingName;
 
 @end
 

--- a/Source/OEXVideoEncoding.m
+++ b/Source/OEXVideoEncoding.m
@@ -12,6 +12,8 @@ static NSString* const OEXVideoEncodingYoutube = @"youtube";
 static NSString* const OEXVideoEncodingMobileHigh = @"mobile_high";
 static NSString* const OEXVideoEncodingMobileLow = @"mobile_low";
 
+NSString* const OEXVideoEncodingFallback = @"fallback";
+
 @interface OEXVideoEncoding ()
 
 @property (copy, nonatomic) NSString* name;
@@ -23,11 +25,7 @@ static NSString* const OEXVideoEncodingMobileLow = @"mobile_low";
 @implementation OEXVideoEncoding
 
 + (NSArray*)knownEncodingNames {
-    return @[OEXVideoEncodingMobileLow, OEXVideoEncodingMobileHigh, OEXVideoEncodingYoutube];
-}
-
-+ (NSString*)fallbackEncodingName {
-    return @"fallback";
+    return @[OEXVideoEncodingMobileLow, OEXVideoEncodingMobileHigh, OEXVideoEncodingFallback, OEXVideoEncodingYoutube];
 }
 
 - (id)initWithDictionary:(NSDictionary*)dictionary name:(NSString*)name {

--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -77,7 +77,10 @@
             OEXVideoEncoding* encoding = [[OEXVideoEncoding alloc] initWithDictionary:encodingInfo name:name];
             [encodings safeSetObject:encoding forKey:name];
         }];
-        self.encodings = (rawEncodings != nil) ? encodings : @{@"fallback" : [[OEXVideoEncoding alloc] initWithName:nil URL:videoURL size:videoSize]};
+        if(!encodings[OEXVideoEncodingFallback]) {
+            [encodings safeSetObject:[[OEXVideoEncoding alloc] initWithName:OEXVideoEncodingFallback URL:videoURL size:videoSize] forKey:OEXVideoEncodingFallback];
+        }
+        self.encodings = encodings;
 
         self.videoThumbnailURL = [summary objectForKey:@"video_thumbnail_url"];
         self.videoID = [summary objectForKey:@"id"] ;
@@ -122,7 +125,7 @@
 }
 
 - (OEXVideoEncoding*)preferredEncoding {
-    for(NSString* name in [[OEXVideoEncoding knownEncodingNames] arrayByAddingObject:[OEXVideoEncoding fallbackEncodingName]]) {
+    for(NSString* name in [OEXVideoEncoding knownEncodingNames]) {
         OEXVideoEncoding* encoding = self.encodings[name];
         if (encoding != nil) {
             return encoding;

--- a/Test/OEXVideoSummaryTests.m
+++ b/Test/OEXVideoSummaryTests.m
@@ -9,6 +9,7 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
+#import "OEXVideoEncoding.h"
 #import "OEXVideoPathEntry.h"
 #import "OEXVideoSummary.h"
 
@@ -103,6 +104,22 @@
                            };
     OEXVideoSummary* summary = [[OEXVideoSummary alloc] initWithDictionary:info];
     XCTAssertEqual(summary.displayPath.count, 0);
+}
+
+- (void)testUsesFallbackBeforeYoutube {
+    NSDictionary* info = @{@"summary":
+                                 @{@"encoded_videos": @{
+                                                       @"youtube": @{
+                                                               @"url": @"http://youtube.com/whatever",
+                                                               @"size": @(2)
+                                                               }
+                                                       },
+                                     @"video_url":@"http://example.com/whatever",
+                                     @"file_size":@(47)
+                                 }
+                           };
+    OEXVideoSummary* summary = [[OEXVideoSummary alloc] initWithDictionary:info];
+    XCTAssertEqualObjects(summary.preferredEncoding.name, @"fallback");
 }
 
 @end


### PR DESCRIPTION
When we added the youtube redirect profile, we prioritized that ahead of
the fallback video (unprocessed video of unknown size). This seemed kind
of reasonable since some of those videos are quite large and don't work
well on mobile. But we're getting user complaints about offline videos
vanishing and obviously the youtube videos obviously don't work offline,
so swap this back around. This is also more consistent with what Android
is doing.

JIRA: https://openedx.atlassian.net/browse/MA-2256