### PR TITLE
Fix crash reading cache entries.

### DIFF
--- a/Source/Core/Code/PersistentResponseCache.swift
+++ b/Source/Core/Code/PersistentResponseCache.swift
@@ -16,7 +16,9 @@ import UIKit
 // TODO: Migrate off of NSCoding and instead write JSON blobs
 // It's less convenient, but as a format it's less tied to our code at a specific
 // moment in time
-public class ResponseCacheEntry : NSObject, NSCoding {
+// Use @objc so that if we move this between modules again, any new cache entries
+// will reference the same class
+@objc(OEXResponseCacheEntry) public class ResponseCacheEntry : NSObject, NSCoding {
     public let data : NSData?
     public let headers : [String:String]
     public let statusCode : Int
@@ -76,7 +78,7 @@ public func responseCacheKeyForRequest(request : NSURLRequest) -> String? {
     func pathForRequestKey(key: String?) -> NSURL?
 }
 
-@objc public class PersistentResponseCache : NSObject, ResponseCache, NSKeyedUnarchiverDelegate {
+public class PersistentResponseCache : NSObject, ResponseCache, NSKeyedUnarchiverDelegate {
 
     // We need a valid class that implements NSCoding to return in case unarchiving fails
     // because it can't find the class to unarchive.

--- a/Source/Core/Code/PersistentResponseCache.swift
+++ b/Source/Core/Code/PersistentResponseCache.swift
@@ -8,6 +8,14 @@
 
 import UIKit
 
+// Be careful renaming this class or moving it between modules
+// since we archive instances of it to disk using NSCoding
+// which figures out how to inflate a class by looking it up by name.
+// Note that different swift modules will result in different class names even if the
+// class name string didn't change
+// TODO: Migrate off of NSCoding and instead write JSON blobs
+// It's less convenient, but as a format it's less tied to our code at a specific
+// moment in time
 public class ResponseCacheEntry : NSObject, NSCoding {
     public let data : NSData?
     public let headers : [String:String]
@@ -68,7 +76,22 @@ public func responseCacheKeyForRequest(request : NSURLRequest) -> String? {
     func pathForRequestKey(key: String?) -> NSURL?
 }
 
-@objc public class PersistentResponseCache : NSObject, ResponseCache {
+@objc public class PersistentResponseCache : NSObject, ResponseCache, NSKeyedUnarchiverDelegate {
+
+    // We need a valid class that implements NSCoding to return in case unarchiving fails
+    // because it can't find the class to unarchive.
+    // Since it has no properties, it should work no matter what type is used
+    // This will lose the cache entry when we try to cast to an actual cache entry type
+    // but it's better than crashing
+    private class DummyCodeableObject: NSObject, NSCoding {
+        @objc required init?(coder aDecoder: NSCoder) {
+            return nil
+        }
+
+        @objc private func encodeWithCoder(aCoder: NSCoder) {
+            // do nothing
+        }
+    }
     
     private let queue : dispatch_queue_t
     private let pathProvider : PathProvider
@@ -77,13 +100,30 @@ public func responseCacheKeyForRequest(request : NSURLRequest) -> String? {
         queue = dispatch_queue_create("org.edx.request-cache", DISPATCH_QUEUE_SERIAL)
         self.pathProvider = provider
     }
+
+    // When you move a class between modules it gets a different class name from the perspective of
+    // unarchiving. This catches that case and reroutes the unarchiver to the correct class
+    public func unarchiver(unarchiver: NSKeyedUnarchiver, cannotDecodeObjectOfClassName name: String, originalClasses classNames: [String]) -> AnyClass? {
+        if name.containsString("Entry") {
+            return ResponseCacheEntry.classForKeyedUnarchiver()
+        }
+
+        return DummyCodeableObject.classForKeyedUnarchiver()
+    }
+
+    private func unarchiveEntryWithData(data : NSData) -> ResponseCacheEntry? {
+        let unarchiver = NSKeyedUnarchiver(forReadingWithData: data)
+        unarchiver.delegate = self
+        let result = unarchiver.decodeObjectForKey(NSKeyedArchiveRootObjectKey) as? ResponseCacheEntry
+        return result
+    }
     
     public func fetchCacheEntryWithRequest(request : NSURLRequest, completion : ResponseCacheEntry? -> Void) {
         let path = self.pathProvider.pathForRequestKey(responseCacheKeyForRequest(request))
         dispatch_async(queue) {
             if let path = path,
                 data = try? NSData(contentsOfURL: path, options: NSDataReadingOptions()),
-                entry = NSKeyedUnarchiver.unarchiveObjectWithData(data) as? ResponseCacheEntry {
+                entry = self.unarchiveEntryWithData(data) {
                     dispatch_async(dispatch_get_main_queue()) {
                         completion(entry)
                     }

--- a/Source/Core/Test/Code/OEXMetaClassHelpers.h
+++ b/Source/Core/Test/Code/OEXMetaClassHelpers.h
@@ -1,0 +1,17 @@
+//
+//  OEXMetaClassHelpers.h
+//  edX
+//
+//  Created by Akiva Leffert on 4/6/16.
+//  Copyright © 2016 edX. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface OEXMetaClassHelpers : NSObject
+
+// Calls the no argument init method of the class with the given name
+// Should really only be used for testing or debugging
++ (id)instanceOfClassNamed:(NSString*)name;
+
+@end

--- a/Source/Core/Test/Code/OEXMetaClassHelpers.m
+++ b/Source/Core/Test/Code/OEXMetaClassHelpers.m
@@ -1,0 +1,18 @@
+//
+//  OEXMetaClassHelpers.m
+//  edX
+//
+//  Created by Akiva Leffert on 4/6/16.
+//  Copyright © 2016 edX. All rights reserved.
+//
+
+#import "OEXMetaClassHelpers.h"
+
+@implementation OEXMetaClassHelpers
+
++ (id)instanceOfClassNamed:(NSString*)name {
+    Class klass = NSClassFromString(name);
+    return [[klass alloc] init];
+}
+
+@end

--- a/Source/Core/Test/SupportingFiles/edXCoreTests-Bridging-Header.h
+++ b/Source/Core/Test/SupportingFiles/edXCoreTests-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "OEXMetaClassHelpers.h"

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -264,6 +264,7 @@
 		775391841CA0600700FA959C /* RegistrationAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775391831CA0600700FA959C /* RegistrationAPITests.swift */; };
 		77542CD61CB6A398006CA428 /* JSON+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77542CD51CB6A398006CA428 /* JSON+Formatting.swift */; };
 		77542CD81CB6A3AA006CA428 /* BadgesAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77542CD71CB6A3AA006CA428 /* BadgesAPITests.swift */; };
+		77542CDB1CB6A463006CA428 /* OEXMetaClassHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 77542CDA1CB6A463006CA428 /* OEXMetaClassHelpers.m */; };
 		775434831AD7394D00635A40 /* OEXPushNotificationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 775434821AD7394D00635A40 /* OEXPushNotificationManager.m */; };
 		775434861AD73D1900635A40 /* OEXParseConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 775434851AD73D1900635A40 /* OEXParseConfig.m */; };
 		775434891AD8121200635A40 /* OEXParsePushProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 775434881AD8121200635A40 /* OEXParsePushProvider.m */; };
@@ -995,6 +996,9 @@
 		775391831CA0600700FA959C /* RegistrationAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RegistrationAPITests.swift; path = Source/Core/Test/Code/RegistrationAPITests.swift; sourceTree = SOURCE_ROOT; };
 		77542CD51CB6A398006CA428 /* JSON+Formatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "JSON+Formatting.swift"; path = "Source/Core/Code/JSON+Formatting.swift"; sourceTree = SOURCE_ROOT; };
 		77542CD71CB6A3AA006CA428 /* BadgesAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BadgesAPITests.swift; path = Source/Core/Test/Code/BadgesAPITests.swift; sourceTree = SOURCE_ROOT; };
+		77542CD91CB6A463006CA428 /* OEXMetaClassHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OEXMetaClassHelpers.h; path = Source/Core/Test/Code/OEXMetaClassHelpers.h; sourceTree = SOURCE_ROOT; };
+		77542CDA1CB6A463006CA428 /* OEXMetaClassHelpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = OEXMetaClassHelpers.m; path = Source/Core/Test/Code/OEXMetaClassHelpers.m; sourceTree = SOURCE_ROOT; };
+		77542CDC1CB6A504006CA428 /* edXCoreTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "edXCoreTests-Bridging-Header.h"; path = "Source/Core/Test/SupportingFiles/edXCoreTests-Bridging-Header.h"; sourceTree = SOURCE_ROOT; };
 		775434801AD738AD00635A40 /* OEXPushProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXPushProvider.h; sourceTree = "<group>"; };
 		775434811AD7394D00635A40 /* OEXPushNotificationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXPushNotificationManager.h; sourceTree = "<group>"; };
 		775434821AD7394D00635A40 /* OEXPushNotificationManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXPushNotificationManager.m; sourceTree = "<group>"; };
@@ -2382,6 +2386,7 @@
 		77E647B41C90C22D00B6740D /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				77542CDC1CB6A504006CA428 /* edXCoreTests-Bridging-Header.h */,
 				77E648281C90DE4700B6740D /* Info.plist */,
 			);
 			name = "Supporting Files";
@@ -2501,6 +2506,8 @@
 			isa = PBXGroup;
 			children = (
 				77E648A11C91EB4900B6740D /* MockResponseCache.swift */,
+				77542CD91CB6A463006CA428 /* OEXMetaClassHelpers.h */,
+				77542CDA1CB6A463006CA428 /* OEXMetaClassHelpers.m */,
 				7753913D1C9758A300FA959C /* Result+Assertions.swift */,
 			);
 			name = Helpers;
@@ -3690,6 +3697,7 @@
 				7753913C1C97579000FA959C /* PersistentResponseCacheTests.swift in Sources */,
 				77E648A01C91EB2000B6740D /* NetworkManagerTests.swift in Sources */,
 				7753913F1C9758D400FA959C /* XCTestCase+Async.swift in Sources */,
+				77542CDB1CB6A463006CA428 /* OEXMetaClassHelpers.m in Sources */,
 				77E648A21C91EB4900B6740D /* MockResponseCache.swift in Sources */,
 				77E648991C91CC0700B6740D /* NSObject+OEXDeallocActionTests.m in Sources */,
 				77E6489C1C91CC6700B6740D /* Array+FunctionalTests.swift in Sources */,
@@ -4461,6 +4469,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.edx.edXCoreTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Source/Core/Test/SupportingFiles/edXCoreTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -4481,6 +4490,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.edx.edXCoreTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Source/Core/Test/SupportingFiles/edXCoreTests-Bridging-Header.h";
 			};
 			name = Release;
 		};
@@ -4500,6 +4510,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.edx.edXCoreTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Source/Core/Test/SupportingFiles/edXCoreTests-Bridging-Header.h";
 			};
 			name = Profile;
 		};


### PR DESCRIPTION
This is pretty unfortunate. When we moved the PersistentResponseCache
from the "edX" module to the edXCore module, it broke unarchiving cache
entries - since NSCoding looks things up by class name and being in a
different module secretly gives you a different class name - even though
that's not visible to the user.

This change adds some rerouting logic for the unarchiver to better
handle missing classes and route the cache entries to a class that
actually exists.