### PR TITLE
Work around login crash

### DIFF
--- a/Source/LoggingAnalyticsTracker.swift
+++ b/Source/LoggingAnalyticsTracker.swift
@@ -11,7 +11,7 @@ import UIKit
 class LoggingAnalyticsTracker: NSObject, OEXAnalyticsTracker {
     private let ANALYTICS = "ANALYTICS"
     
-    func identifyUser(user: OEXUserDetails) {
+    func identifyUser(user: OEXUserDetails?) {
         Logger.logInfo(ANALYTICS, "Identified User: \(user)")
     }
     

--- a/Source/OEXAnalyticsTracker.h
+++ b/Source/OEXAnalyticsTracker.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol OEXAnalyticsTracker <NSObject>
 
-- (void)identifyUser:(OEXUserDetails*)user;
+- (void)identifyUser:(nullable OEXUserDetails*)user;
 - (void)clearIdentifiedUser;
 
 - (void)trackEvent:(OEXAnalyticsEvent*)event forComponent:(nullable NSString*)component withProperties:(NSDictionary<NSString*, id>*)properties;

--- a/Source/OEXAuthentication.m
+++ b/Source/OEXAuthentication.m
@@ -9,6 +9,7 @@
 #import "OEXAuthentication.h"
 
 #import "NSDictionary+OEXEncoding.h"
+#import "NSError+OEXKnownErrors.h"
 #import "NSMutableDictionary+OEXSafeAccess.h"
 #import "NSString+OEXFormatting.h"
 
@@ -189,7 +190,16 @@ OEXNSDataTaskRequestHandler OEXWrapURLCompletion(OEXURLRequestHandler completion
         if(httpResp.statusCode == 200) {
             NSDictionary* dictionary = [NSJSONSerialization JSONObjectWithData:userdata options:kNilOptions error:nil];
             OEXUserDetails* userDetails = [[OEXUserDetails alloc] initWithUserDictionary:dictionary];
-            [[OEXSession sharedSession] saveAccessToken:token userDetails:userDetails];
+            if(token != nil && userDetails != nil) {
+                [[OEXSession sharedSession] saveAccessToken:token userDetails:userDetails];
+            }
+            else {
+                // On the off chance that something messed up and we have nil
+                // for token or user details,
+                // stub in some error values
+                usererror = [NSError oex_unknownError];
+                userresponse = [[NSHTTPURLResponse alloc] initWithURL:userresponse.URL statusCode:OEXHTTPStatusCode400BadRequest HTTPVersion:nil headerFields:nil];
+            }
         }
         dispatch_async(dispatch_get_main_queue(), ^{
                 OEXWrapURLCompletion(completionHandler)(userdata, userresponse, usererror);

--- a/Source/OEXSession.m
+++ b/Source/OEXSession.m
@@ -61,7 +61,12 @@ static NSString* OEXSessionClearedCache = @"OEXSessionClearedCache";
 - (void)saveAccessToken:(OEXAccessToken*)token userDetails:(OEXUserDetails*)userDetails {
     [self.credentialStore clear];
     [self.credentialStore saveAccessToken:token userDetails:userDetails];
-    [self loadTokenFromStore];
+
+    self.token = token;
+    self.currentUser = userDetails;
+    if(token != nil && userDetails != nil) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:OEXSessionStartedNotification object:nil userInfo:@{OEXSessionStartedUserDetailsKey : userDetails}];
+    }
 }
 
 - (void)loadTokenFromStore {

--- a/Source/SegmentAnalyticsTracker.swift
+++ b/Source/SegmentAnalyticsTracker.swift
@@ -25,13 +25,13 @@ class SegmentAnalyticsTracker : NSObject, OEXAnalyticsTracker {
         }
     }
 
-    func identifyUser(user : OEXUserDetails) {
-        if let userID = user.userId {
+    func identifyUser(user : OEXUserDetails?) {
+        if let userID = user?.userId {
             var traits : [String:AnyObject] = [:]
-            if let email = user.email {
+            if let email = user?.email {
                 traits[key_email] = email
             }
-            if let username = user.username {
+            if let username = user?.username {
                 traits[key_username] = username
             }
             SEGAnalytics.sharedAnalytics().identify(userID.description, traits:traits)

--- a/Test/MockAnalyticsTracker.swift
+++ b/Test/MockAnalyticsTracker.swift
@@ -61,7 +61,7 @@ class MockAnalyticsTracker : NSObject, OEXAnalyticsTracker {
     
     let eventStream = Sink<MockAnalyticsRecord>()
     
-    func identifyUser(user: OEXUserDetails) {
+    func identifyUser(user: OEXUserDetails?) {
         currentUser = user
     }
     


### PR DESCRIPTION
We can't reproduce but there's a suspicion that the keychain isn't
saving properly for some users. This unfortunately doesn't fix that
problem, but it should hopefully allow them to log in for a session +
prevent the app from crashing.