### PR TITLE
Do not always logout for empty response

### DIFF
--- a/Source/Core/Code/NetworkManager.swift
+++ b/Source/Core/Code/NetworkManager.swift
@@ -168,7 +168,7 @@ public class NetworkManager : NSObject {
     public static let NETWORK = "NETWORK" // Logger key
     
     public typealias JSONInterceptor = (response : NSHTTPURLResponse, json : JSON) -> Result<JSON>
-    public typealias Authenticator = (response: NSHTTPURLResponse, data: NSData) -> AuthenticationAction
+    public typealias Authenticator = (response: NSHTTPURLResponse?, data: NSData) -> AuthenticationAction
     
     public let baseURL : NSURL
     
@@ -318,7 +318,7 @@ public class NetworkManager : NSObject {
             let task = Manager.sharedInstance.request(URLRequest)
             
             let serializer = { (URLRequest : NSURLRequest, response : NSHTTPURLResponse?, data : NSData?) -> (AnyObject?, NSError?) in
-                switch authenticator?(response: response!, data: data!) ?? .Proceed {
+                switch authenticator?(response: response, data: data!) ?? .Proceed {
                 case .Proceed:
                     let result = NetworkManager.deserialize(networkRequest.deserializer, interceptors: interceptors, response: response, data: data, error: NetworkManager.unknownError)
                     return (Box(DeserializationResult.DeserializedResult(value : result, original : data)), result.error)

--- a/Source/Core/Test/Code/NetworkManagerTests.swift
+++ b/Source/Core/Test/Code/NetworkManagerTests.swift
@@ -256,7 +256,7 @@ class NetworkManagerTests: XCTestCase {
         
         
         manager.authenticator = { (response, data) -> AuthenticationAction in
-            if response.statusCode == 401 {
+            if response!.statusCode == 401 {
                 return AuthenticationAction.Authenticate({ (networkManager, completion) in
                     OHHTTPStubs.removeStub(stub401Response)
                     return completion(success: true)

--- a/Source/NetworkManager+Authenticators.swift
+++ b/Source/NetworkManager+Authenticators.swift
@@ -11,6 +11,7 @@ import Foundation
 import edXCore
 
 extension NetworkManager {
+    
     public func addRefreshTokenAuthenticator(router:OEXRouter, session:OEXSession, clientId:String) {
         let invalidAccessAuthenticator = {[weak router] response, data in
             NetworkManager.invalidAccessAuthenticator(router, session: session, clientId:clientId, response: response, data: data)
@@ -43,11 +44,15 @@ extension NetworkManager {
             if error.isAPIError(.OAuth2Expired) {
                 return refreshAccessToken(clientId, refreshToken: refreshToken, session: session)
             }
+            
+            // This case should not happen on production. It is useful for devs
+            // when switching between development environments.
             if error.isAPIError(.OAuth2Nonexistent) {
                 return logout(router)
             }
         }
-        return logout(router)
+        Logger.logError("Network Authenticator", "Request failed: " + response.debugDescription)
+        return AuthenticationAction.Proceed
     }
 }
 

--- a/Test/NetworkManager+AuthenticatorTests.swift
+++ b/Test/NetworkManager+AuthenticatorTests.swift
@@ -60,7 +60,7 @@ class NetworkManager_AuthenticationTests : XCTestCase {
         let data = "I AM NOT A JSON".dataUsingEncoding(NSUTF8StringEncoding)!
         let result = authenticatorResponseForRequest(response!, data: data, session: session, router: router, waitForLogout: true)
         XCTAssertTrue(result.isProceed)
-        XCTAssertTrue(router.logoutCalled)
+        XCTAssertFalse(router.logoutCalled)
     }
     
     func testExpiredAccessTokenReturnsAuthenticate() {


### PR DESCRIPTION
The Oauth refresh work made it so that all requests with an
empty response will log the user out. Instead, we let the
request proceed and post a debug message.

@mikekatz Please review