### PR TITLE
Add Time Zone to iOS

### DIFF
--- a/Source/Core/Code/OEXDateFormatting.m
+++ b/Source/Core/Code/OEXDateFormatting.m
@@ -8,7 +8,8 @@
 
 #import "OEXDateFormatting.h"
 
-///The standard date format used all across the edX Platform. Standard ISO 8601
+/// Time zone set by UserPreferenceAPI
+/// The standard date format used all across the edX Platform. Standard ISO 8601
 static NSString* const OEXStandardDateFormat = @"yyyy-MM-dd'T'HH:mm:ss'Z'";
 static NSString* const OEXStandardDateFormatMicroseconds = @"yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'";
 

--- a/Source/DataManager.swift
+++ b/Source/DataManager.swift
@@ -14,13 +14,15 @@ public class DataManager : NSObject {
     let interface : OEXInterface?
     let pushSettings : OEXPushSettingsManager
     let userProfileManager : UserProfileManager
+    let userPreferenceManager: UserPreferenceManager
     
     public init(
         courseDataManager : CourseDataManager,
         enrollmentManager: EnrollmentManager,
         interface : OEXInterface?,
         pushSettings : OEXPushSettingsManager,
-        userProfileManager : UserProfileManager
+        userProfileManager : UserProfileManager,
+        userPreferenceManager: UserPreferenceManager
         )
     {
         self.courseDataManager = courseDataManager
@@ -28,6 +30,7 @@ public class DataManager : NSObject {
         self.pushSettings = pushSettings
         self.interface = interface
         self.userProfileManager = userProfileManager
+        self.userPreferenceManager = userPreferenceManager
     }
     
     

--- a/Source/EnrolledCoursesViewController.swift
+++ b/Source/EnrolledCoursesViewController.swift
@@ -18,10 +18,12 @@ class EnrolledCoursesViewController : OfflineSupportViewController, CoursesTable
     private let refreshController = PullRefreshController()
     private let insetsController = ContentInsetsController()
     private let enrollmentFeed: Feed<[UserCourseEnrollment]?>
-    
-     init(environment: Environment) {
+    private let userPreferencesFeed: Feed<UserPreference?>
+
+    init(environment: Environment) {
         self.tableController = CoursesTableViewController(environment: environment, context: .EnrollmentList)
         self.enrollmentFeed = environment.dataManager.enrollmentManager.feed
+        self.userPreferencesFeed = environment.dataManager.userPreferenceManager.feed
         self.environment = environment
         
         super.init(env: environment)
@@ -64,6 +66,7 @@ class EnrolledCoursesViewController : OfflineSupportViewController, CoursesTable
         )
         
         self.enrollmentFeed.refresh()
+        self.userPreferencesFeed.refresh()
         
         setupListener()
         setupFooter()
@@ -169,6 +172,7 @@ class EnrolledCoursesViewController : OfflineSupportViewController, CoursesTable
     
     func refreshControllerActivated(controller: PullRefreshController) {
         self.enrollmentFeed.refresh()
+        self.userPreferencesFeed.refresh()
     }
     
     override func viewDidLayoutSubviews() {

--- a/Source/OEXEnvironment.m
+++ b/Source/OEXEnvironment.m
@@ -103,6 +103,9 @@
             [[UserProfileManager alloc]
              initWithNetworkManager:env.networkManager
              session:env.session];
+            UserPreferenceManager* userPreferenceManager =
+            [[UserPreferenceManager alloc]
+             initWithNetworkManager:env.networkManager];
             CourseDataManager* courseDataManager =
             [[CourseDataManager alloc]
              initWithAnalytics:env.analytics
@@ -114,7 +117,8 @@
                                                 enrollmentManager:enrollmentManager
                                                         interface:[OEXInterface sharedInterface]
                                                      pushSettings:pushSettingsManager
-                                                   userProfileManager: userProfileManager
+                                               userProfileManager:userProfileManager
+                                            userPreferenceManager:userPreferenceManager
                     ];
         };
         self.networkManagerBuilder = ^(OEXEnvironment* env) {

--- a/Source/UserPreference.swift
+++ b/Source/UserPreference.swift
@@ -1,0 +1,29 @@
+//
+//  UserPreference.swift
+//  edX
+//
+//  Created by Kevin Kim on 7/28/16.
+//  Copyright © 2016 edX. All rights reserved.
+//
+
+import Foundation
+import edXCore
+
+public class UserPreference {
+    
+    enum PreferenceKeys: String, RawStringExtractable {
+        case TimeZone = "time_zone"
+    }
+
+    var timeZone: String?
+    
+    public init?(json: JSON) {
+        timeZone = json[PreferenceKeys.TimeZone].string ?? "UTC"
+        
+        //Set all dates to convert to user time zone chosen on web platform
+        if let timeZoneName = timeZone, validTimeZone = NSTimeZone(name: timeZoneName) {
+            NSTimeZone.setDefaultTimeZone(validTimeZone)
+        }
+    }
+    
+}

--- a/Source/UserPreferenceAPI.swift
+++ b/Source/UserPreferenceAPI.swift
@@ -1,0 +1,30 @@
+//
+//  UserPreferenceAPI.swift
+//  edX
+//
+//  Created by Kevin Kim on 7/28/16.
+//  Copyright © 2016 edX. All rights reserved.
+//
+
+import Foundation
+import edXCore
+
+public class UserPreferenceAPI: NSObject {
+    
+    private static func preferenceDeserializer(response : NSHTTPURLResponse, json : JSON) -> Result<UserPreference> {
+        return UserPreference(json: json).toResult()
+    }
+    
+    private class func path(username:String) -> String {
+        return "/api/user/v1/preferences/{username}".oex_formatWithParameters(["username": username])
+    }
+    
+    class func preferenceRequest(username: String) -> NetworkRequest<UserPreference> {
+        return NetworkRequest(
+            method: HTTPMethod.GET,
+            path : path(username),
+            requiresAuth : true,
+            deserializer: .JSONResponse(preferenceDeserializer))
+    }
+    
+}

--- a/Source/UserPreferenceManager.swift
+++ b/Source/UserPreferenceManager.swift
@@ -1,0 +1,62 @@
+//
+//  UserPreferenceManager.swift
+//  edX
+//
+//  Created by Kevin Kim on 7/28/16.
+//  Copyright © 2016 edX. All rights reserved.
+//
+
+import Foundation
+
+public class UserPreferenceManager : NSObject {
+    
+    private let networkManager : NetworkManager
+    private let preferencesFeed = BackedFeed<UserPreference?>()
+    
+    public init(networkManager : NetworkManager) {
+        self.networkManager = networkManager
+        
+        super.init()
+        
+        addObservers()
+    }
+    
+    public var feed: BackedFeed<UserPreference?> {
+        return preferencesFeed
+    }
+    
+    private func addObservers() {
+        NSNotificationCenter.defaultCenter().oex_addObserver(self, name: OEXSessionEndedNotification) { (_, observer, _) in
+            observer.clearFeed()
+        }
+        
+        NSNotificationCenter.defaultCenter().oex_addObserver(self, name: OEXSessionStartedNotification) { (notification, observer, _) -> Void in
+            if let userDetails = notification.userInfo?[OEXSessionStartedUserDetailsKey] as? OEXUserDetails {
+                observer.setupFeedWithUserDetails(userDetails)
+            }
+        }
+    }
+    
+    private func clearFeed() {
+        let feed = Feed<UserPreference?> { stream in
+            stream.removeAllBackings()
+            stream.send(Success(nil))
+        }
+        
+        preferencesFeed.backWithFeed(feed)
+        preferencesFeed.refresh()
+    }
+    
+    private func setupFeedWithUserDetails(userDetails: OEXUserDetails) {
+        guard let username = userDetails.username else { return }
+        let feed = freshFeedWithUsername(username)
+        preferencesFeed.backWithFeed(feed.map{x in x})
+        preferencesFeed.refresh()
+    }
+    
+    private func freshFeedWithUsername(username: String) -> Feed<UserPreference> {
+        let request = UserPreferenceAPI.preferenceRequest(username)
+        return Feed(request: request, manager: networkManager, persistResponse: true)
+    }
+    
+}

--- a/Test/CourseCardViewModelTests.swift
+++ b/Test/CourseCardViewModelTests.swift
@@ -52,5 +52,34 @@ class CourseCardViewModelTests: XCTestCase {
         let course = OEXCourse.freshCourse(startInfo: startInfo, end: endDate)
         XCTAssertEqual(course.nextRelevantDate, Strings.courseEnded(endDate: OEXDateFormatting.formatAsMonthDayString(endDate)))
     }
+    
+    func testTimeZoneDates() {
+        let argentinaTimeZone = NSTimeZone(name: "America/Argentina/Buenos_Aires")!
+        func setUpDate() -> NSDate {
+            let date = NSDate().dateByAddingDays(2)
+            let utcCalendar = NSCalendar.currentCalendar().copy() as! NSCalendar
+            utcCalendar.timeZone = NSTimeZone(name: "UTC")!
+            return utcCalendar.startOfDayForDate(date)
+        }
+        func setUpCourseWithDate(date: NSDate) -> OEXCourse {
+            let startInfo = OEXCourseStartDisplayInfo(date: date, displayDate: nil, type: .Timestamp)
+            return OEXCourse.freshCourse(startInfo: startInfo, end: NSDate.distantFuture())
+        }
+        func setUpExpectedDate(date: NSDate) -> String {
+            let formatter = NSDateFormatter()
+            formatter.timeZone = argentinaTimeZone
+            formatter.dateFormat = "MMMM dd"
+            return formatter.stringFromDate(date).uppercaseString
+        }
+        
+        let startOfDate = setUpDate()
+        let course = setUpCourseWithDate(startOfDate)
+        let expectedDate = setUpExpectedDate(startOfDate)
+        
+        NSTimeZone.setDefaultTimeZone(NSTimeZone(name: "UTC")!)
+        XCTAssertNotEqual(course.nextRelevantDate, Strings.starting(startDate: expectedDate))
+        NSTimeZone.setDefaultTimeZone(argentinaTimeZone)
+        XCTAssertEqual(course.nextRelevantDate, Strings.starting(startDate: expectedDate))
+    }
 
 }

--- a/Test/TestRouterEnvironment.swift
+++ b/Test/TestRouterEnvironment.swift
@@ -49,8 +49,8 @@ class TestRouterEnvironment : RouterEnvironment {
             enrollmentManager: mockEnrollmentManager,
             interface: interface,
             pushSettings: OEXPushSettingsManager(),
-            userProfileManager:
-            UserProfileManager(networkManager: mockNetworkManager, session: session)
+            userProfileManager:UserProfileManager(networkManager: mockNetworkManager, session: session),
+            userPreferenceManager: UserPreferenceManager(networkManager: mockNetworkManager)
         )
         
         super.init(analytics: analytics,

--- a/Test/UserPreferenceManagerTests.swift
+++ b/Test/UserPreferenceManagerTests.swift
@@ -1,0 +1,45 @@
+//
+//  UserPreferenceManagerTests.swift
+//  edX
+//
+//  Created by Kevin Kim on 8/8/16.
+//  Copyright © 2016 edX. All rights reserved.
+//
+
+import Foundation
+@testable import edX
+
+class UserPreferenceManagerTests : XCTestCase {
+    
+    func testUserPreferencesLoginLogout() {
+        let userPrefernces = UserPreference(json: ["time_zone": "Asia/Tokyo"])
+        
+        XCTAssertNotNil(userPrefernces)
+        
+        let preferences = userPrefernces!
+        
+        let environment = TestRouterEnvironment()
+        environment.mockNetworkManager.interceptWhenMatching({_ in true }) {
+            return (nil, preferences)
+        }
+        
+        let manager = UserPreferenceManager(networkManager: environment.networkManager)
+        let feed = manager.feed
+        // starts empty
+        XCTAssertNil(feed.output.value)
+        
+        // Log in. Preferences should load
+        environment.logInTestUser()
+        feed.refresh()
+        
+        stepRunLoop()
+        
+        waitForStream(feed.output)
+        XCTAssertEqual(feed.output.value??.timeZone, preferences.timeZone)
+        
+        // Log out. Now preferences should be cleared
+        environment.session.closeAndClearSession()
+        XCTAssertNil(feed.output.value!)
+    }
+    
+}

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -480,6 +480,10 @@
 		77FFA2C81AC32EA200B4D69B /* check.png in Resources */ = {isa = PBXBuildFile; fileRef = 77FFA2C61AC32EA200B4D69B /* check.png */; };
 		77FFA2C91AC32EA200B4D69B /* check@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 77FFA2C71AC32EA200B4D69B /* check@2x.png */; };
 		77FFA2CC1AC35CE800B4D69B /* OEXRegistrationStyles.m in Sources */ = {isa = PBXBuildFile; fileRef = 77FFA2CB1AC35CE800B4D69B /* OEXRegistrationStyles.m */; };
+		7C2DD54F1D4A7901006148E0 /* UserPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2DD54E1D4A7901006148E0 /* UserPreference.swift */; };
+		7C2DD5511D4A790F006148E0 /* UserPreferenceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2DD5501D4A790F006148E0 /* UserPreferenceAPI.swift */; };
+		7C2DD5531D4A8669006148E0 /* UserPreferenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C2DD5521D4A8669006148E0 /* UserPreferenceManager.swift */; };
+		7CB46D271D58E567005110AB /* UserPreferenceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB46D251D58E4FF005110AB /* UserPreferenceManagerTests.swift */; };
 		80056C9A1B0CDE1A0004D85C /* DiscussionResponsesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80056C991B0CDE1A0004D85C /* DiscussionResponsesViewController.swift */; };
 		805329101B0E80E50093B177 /* DiscussionResponses.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8053290F1B0E80E50093B177 /* DiscussionResponses.storyboard */; };
 		805329121B0EA2DC0093B177 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 805329111B0EA2DC0093B177 /* QuartzCore.framework */; };
@@ -1275,6 +1279,10 @@
 		77FFA2CA1AC35CE800B4D69B /* OEXRegistrationStyles.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXRegistrationStyles.h; sourceTree = "<group>"; };
 		77FFA2CB1AC35CE800B4D69B /* OEXRegistrationStyles.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OEXRegistrationStyles.m; sourceTree = "<group>"; };
 		77FFAB9B1A8ABDB200F91F08 /* OEXAnalyticsTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OEXAnalyticsTracker.h; sourceTree = "<group>"; };
+		7C2DD54E1D4A7901006148E0 /* UserPreference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserPreference.swift; sourceTree = "<group>"; };
+		7C2DD5501D4A790F006148E0 /* UserPreferenceAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserPreferenceAPI.swift; sourceTree = "<group>"; };
+		7C2DD5521D4A8669006148E0 /* UserPreferenceManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserPreferenceManager.swift; sourceTree = "<group>"; };
+		7CB46D251D58E4FF005110AB /* UserPreferenceManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserPreferenceManagerTests.swift; sourceTree = "<group>"; };
 		80056C991B0CDE1A0004D85C /* DiscussionResponsesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscussionResponsesViewController.swift; sourceTree = "<group>"; };
 		8053290F1B0E80E50093B177 /* DiscussionResponses.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = DiscussionResponses.storyboard; sourceTree = "<group>"; };
 		805329111B0EA2DC0093B177 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
@@ -1872,11 +1880,11 @@
 		1A6B23CE1BAB4A5100FD7309 /* User Profiles */ = {
 			isa = PBXGroup;
 			children = (
-				775716B81CB804E40091AB10 /* UserProfilePresenter.swift */,
 				77C6BBC91CB4BC6F0026C37B /* AccomplishmentsView.swift */,
 				77509D971BE1916600B10CD3 /* UserProfileManager.swift */,
 				1A8AC0BF1BB49EC5009D8F5E /* UserProfile.swift */,
 				1AA79AB91BAC7F710011D381 /* ProfileAPI.swift */,
+				775716B81CB804E40091AB10 /* UserProfilePresenter.swift */,
 				1A7CEA321BABA8C70043A58C /* ProfileImageView.swift */,
 				1A1181E31BB462D700CFE52B /* RemoteImage.swift */,
 				1A5501A11BBA323700D5F9DD /* ProfileBanner.swift */,
@@ -3085,6 +3093,7 @@
 				7742F8D91C3C9785009E555A /* EnrollmentConfigTests.swift */,
 				778B40DC1C2F85BC0009F33E /* FeedTests.swift */,
 				778B40DA1C2F64680009F33E /* EnrollmentManagerTests.swift */,
+				7CB46D251D58E4FF005110AB /* UserPreferenceManagerTests.swift */,
 				77236EEE1C21C3D5006AC1A4 /* PaginatorTests.swift */,
 				77236EF01C21F3B3006AC1A4 /* PaginationControllerTests.swift */,
 				77AFD10C1C1A63C3001985FD /* UserAgentGenerationOperation.swift */,
@@ -3234,6 +3243,9 @@
 				B4B285EB1A9B429200DD603A /* OEXNetworkUtility.h */,
 				B4B285EC1A9B429200DD603A /* OEXNetworkUtility.m */,
 				9ED168AD1B29A4ED00AA7B5B /* UserAPI.swift */,
+				7C2DD54E1D4A7901006148E0 /* UserPreference.swift */,
+				7C2DD5501D4A790F006148E0 /* UserPreferenceAPI.swift */,
+				7C2DD5521D4A8669006148E0 /* UserPreferenceManager.swift */,
 				9EDCC51D1B395BDE00A4F39D /* CourseInfoAPI.swift */,
 				F22A0ABA1CE60D5E00D50DFF /* NetworkManager+Authenticators.swift */,
 			);
@@ -3900,6 +3912,7 @@
 				7772BEA71AFA68330081CA7A /* ConstraintRelation.swift in Sources */,
 				9E1D952E1B678E4700ABE764 /* AccessibilityCLButton.swift in Sources */,
 				7765025F1C7CEBC5007384E7 /* SingleChildContainingViewController.swift in Sources */,
+				7C2DD54F1D4A7901006148E0 /* UserPreference.swift in Sources */,
 				1A3AFFE51BD56370002846F3 /* CropViewController.swift in Sources */,
 				7731813B1B6C1442000CC050 /* SeparatorInsetable.swift in Sources */,
 				B4B285DC1A9A490400DD603A /* OEXFacebookConfig.m in Sources */,
@@ -3986,6 +3999,7 @@
 				1918AFB11948359300F40345 /* OEXCourseDetailTableViewCell.m in Sources */,
 				77AFD11C1C1B76D0001985FD /* NSObject+SafeKVO.swift in Sources */,
 				9EE684CB1B3D5FAB00C7B157 /* CourseHandoutsViewController.swift in Sources */,
+				7C2DD5511D4A790F006148E0 /* UserPreferenceAPI.swift in Sources */,
 				9E0D4BD31B0C84F800B2417D /* CourseUnknownBlockViewController.swift in Sources */,
 				19E1F02B1A272DDC00C2E1BE /* LastAccessed.m in Sources */,
 				7784C68B1B03BA1E00529C7C /* LoadStateViewController.swift in Sources */,
@@ -3993,6 +4007,7 @@
 				778C72F11B17C30000FC3F68 /* Dictionary+Functional.swift in Sources */,
 				773A04781AF2D5DE0076532C /* CourseOutlineViewController.swift in Sources */,
 				B4D5C7EB1A6FBAA300427D1D /* OEXAccessToken.m in Sources */,
+				7C2DD5531D4A8669006148E0 /* UserPreferenceManager.swift in Sources */,
 				BE45DA8F192623F4003BD39B /* OEXTabBarItemsCell.m in Sources */,
 				777DE71A1C1656ED0068E280 /* CourseCatalogDetailView.swift in Sources */,
 				775EB3AC1B1FC37C009526A8 /* SpinnerView.swift in Sources */,
@@ -4237,6 +4252,7 @@
 				770A27AA1A70261F00DFC6FF /* NSObject+OEXReplaceNullTests.m in Sources */,
 				770A279F1A6F164800DFC6FF /* OEXVideoPathEntryTests.m in Sources */,
 				77691FAB1B3C74AF003922F2 /* OpenOnWebControllerTests.swift in Sources */,
+				7CB46D271D58E567005110AB /* UserPreferenceManagerTests.swift in Sources */,
 				77D705FC1B7C0DEC00ABCB70 /* OEXCourseTests.swift in Sources */,
 				77567B551AC5F06F00877A7B /* OEXSafeCastTests.m in Sources */,
 				7742F8DB1C3C9788009E555A /* EnrollmentConfigTests.swift in Sources */,


### PR DESCRIPTION
### Description
 
[TNL-5106](https://openedx.atlassian.net/browse/TNL-5106)

Previously, app used phone's local time zone for all dates. Now, it uses the user's time zone set on the web platform, or UTC if unset.

### Testing
You can use Kevin's Test Course on mobile-dev sandbox to test dates.

The course end date is 09/01/2016 0:00 UTC. 

Depending on the User's time zone preference (set on the sandbox) it should be reflected in the course card. 


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @BenjiLee 
- [x] Code review: @danialzahid94  