### PR TITLE
Remove "edX" string from localizable.strings

### DIFF
--- a/Source/CertificateViewController.swift
+++ b/Source/CertificateViewController.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class CertificateViewController: UIViewController, UIWebViewDelegate, InterfaceOrientationOverriding {
 
-    typealias Environment = protocol<OEXAnalyticsProvider>
+    typealias Environment = protocol<OEXAnalyticsProvider, OEXConfigProvider>
     private let environment: Environment
 
     private let loadController = LoadStateViewController()
@@ -72,7 +72,7 @@ class CertificateViewController: UIViewController, UIWebViewDelegate, InterfaceO
 
     func share() {
         guard let url = request?.URL else { return }
-        let text = Strings.Certificates.shareText
+        let text = Strings.Certificates.shareText(platformName: environment.config.platformName())
         let controller = shareTextAndALink(text, url: url) { analyticsType in
             self.environment.analytics.trackCertificateShared(url.absoluteString, type: analyticsType)
         }

--- a/Source/JSONFormBuilder.swift
+++ b/Source/JSONFormBuilder.swift
@@ -176,8 +176,9 @@ class JSONFormBuilder {
         }
         
         func applyData(field: Field, data: FormData) {
-            choiceView.titleText = Strings.formLabel(label: field.title!)
-            choiceView.valueText = data.valueForField(field.name) ?? field.placeholder ?? ""
+            choiceView.titleText = Strings.formLabel(label: field.title ?? "")
+            let placeHoder = field.placeholder?.stringByReplacingOccurrencesOfString("edX", withString: OEXConfig.sharedConfig().platformName())
+            choiceView.valueText = data.valueForField(field.name) ?? placeHoder ?? ""
         }
     }
     
@@ -241,7 +242,7 @@ class JSONFormBuilder {
         let type: FieldType
         let name: String
         var cellIdentifier: String { return type.cellIdentifier }
-        let title: String?
+        var title: String?
         
         let instructions: String?
         let subInstructions: String?
@@ -255,6 +256,7 @@ class JSONFormBuilder {
             type = FieldType(jsonVal: json["type"].string)!
             title = json["label"].string
             name = json["name"].string!
+            title = title?.stringByReplacingOccurrencesOfString("edX", withString: OEXConfig.sharedConfig().platformName())
             
             instructions = json["instructions"].string
             subInstructions = json["sub_instructions"].string

--- a/Source/JSONFormBuilderTextEditor.swift
+++ b/Source/JSONFormBuilderTextEditor.swift
@@ -28,9 +28,13 @@ class JSONFormBuilderTextEditorViewController: UIViewController {
 
         
         textView.text = text ?? ""
-        if let placeholder = placeholder {
-            textView.placeholder = placeholder
+        
+        var placeHolder: String?
+        if let _ = placeholder {
+            placeHolder = placeholder?.stringByReplacingOccurrencesOfString("edX", withString: OEXConfig.sharedConfig().platformName())
+            textView.placeholder = placeHolder ?? ""
         }
+
         textView.delegate = self
         
         setupViews()

--- a/Source/OEXRegistrationFormField.m
+++ b/Source/OEXRegistrationFormField.m
@@ -9,6 +9,7 @@
 #import "OEXRegistrationFormField.h"
 
 #import "NSArray+OEXFunctional.h"
+#import "OEXConfig.h"
 
 @interface OEXRegistrationFormField ()
 
@@ -42,6 +43,7 @@
         self.defaultValue = dictionary[@"defaultValue"];
         self.instructions = dictionary[@"instructions"];
         self.label = dictionary[@"label"];
+        self.label = [self.label stringByReplacingOccurrencesOfString:@"edX" withString:[[OEXConfig sharedConfig] platformName]];
         self.type = dictionary[@"type"];
         self.fieldType = [self registrationFieldType:dictionary[@"type"]];
         self.errorMessage = [[OEXRegistrationErrorMessage alloc] initWithDictionary:dictionary[@"errorMessages"]];

--- a/Source/OEXRegistrationFormField.m
+++ b/Source/OEXRegistrationFormField.m
@@ -45,7 +45,7 @@
         self.label = dictionary[@"label"];
         NSString *platformName = [[OEXConfig sharedConfig] platformName];
         if (platformName) {
-            self.label = [self.label stringByReplacingOccurrencesOfString:@"edX" withString:[[OEXConfig sharedConfig] platformName]];
+            self.label = [self.label stringByReplacingOccurrencesOfString:@"edX" withString:platformName];
         }
         self.type = dictionary[@"type"];
         self.fieldType = [self registrationFieldType:dictionary[@"type"]];

--- a/Source/OEXRegistrationFormField.m
+++ b/Source/OEXRegistrationFormField.m
@@ -43,7 +43,10 @@
         self.defaultValue = dictionary[@"defaultValue"];
         self.instructions = dictionary[@"instructions"];
         self.label = dictionary[@"label"];
-        self.label = [self.label stringByReplacingOccurrencesOfString:@"edX" withString:[[OEXConfig sharedConfig] platformName]];
+        NSString *platformName = [[OEXConfig sharedConfig] platformName];
+        if (platformName) {
+            self.label = [self.label stringByReplacingOccurrencesOfString:@"edX" withString:[[OEXConfig sharedConfig] platformName]];
+        }
         self.type = dictionary[@"type"];
         self.fieldType = [self registrationFieldType:dictionary[@"type"]];
         self.errorMessage = [[OEXRegistrationErrorMessage alloc] initWithDictionary:dictionary[@"errorMessages"]];

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -107,7 +107,7 @@
 /* Get certificate button text. */
 "CERTIFICATES.GET_CERTIFICATE"="View certificate";
 /* Text to share on FB & Twitter when sharing a course cert */
-"CERTIFICATES.SHARE_TEXT"="I just earned a Certificate on edX! Check it out:";
+"CERTIFICATES.SHARE_TEXT"="I just earned a Certificate on {platform_name}! Check it out:";
 /* Title bar when viewing an actual certificate */
 "CERTIFICATES.VIEW_CERT_TITLE"="Certificate";
 /* Title of course announcements section */


### PR DESCRIPTION
Removing edX from localizable strings.
Replacing edX with platform name if it is being used from json files like registration.json and profiles.json when view is populating 

Jira: https://openedx.atlassian.net/browse/MA-2472