### PR TITLE
Use the right name for the repo owner

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -3,7 +3,7 @@
 
 nick: ios
 oeps: {}
-owner: edx/mobile-push
+owner: edx/edx-mobile-push
 tags:
   - mobile
   - ios


### PR DESCRIPTION
### Description

This fixes the owner of the repo to be a group that actually exists on github.

### How to test this PR

No testing needed.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @BenjiLee

