### PR TITLE
Native error messages used for Sign In

### DIFF
--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -392,12 +392,10 @@
     }
     else {
         // error
-        UIAlertView* alert = [[UIAlertView alloc] initWithTitle:[Strings networkNotAvailableTitle]
-                                                        message:[Strings networkNotAvailableMessageTrouble]
-                                                       delegate:nil
-                                              cancelButtonTitle:nil
-                                              otherButtonTitles:[Strings ok], nil];
-        [alert show];
+        
+        [[UIAlertController alloc] showAlertWithTitle:[Strings networkNotAvailableTitle]
+                                              message:[Strings networkNotAvailableMessageTrouble]
+                                     onViewController:self];
     }
 }
 
@@ -405,11 +403,11 @@
     [self.view setUserInteractionEnabled:NO];
 
     if(!self.reachable) {
-        [[UIAlertController alloc] showErrorWithTitle:[Strings networkNotAvailableTitle]
-                                                                message:[Strings networkNotAvailableMessage]
-                                                       onViewController:self.navigationController
+        [[UIAlertController alloc] showAlertWithTitle:[Strings networkNotAvailableTitle]
+                                              message:[Strings networkNotAvailableMessage]
+                                     onViewController:self.navigationController
                                                             ];
-
+        
         [self.view setUserInteractionEnabled:YES];
 
         return;
@@ -417,7 +415,7 @@
 
     //Validation
     if([self.tf_EmailID.text length] == 0) {
-        [[UIAlertController alloc] showErrorWithTitle:[Strings floatingErrorLoginTitle]
+        [[UIAlertController alloc] showAlertWithTitle:[Strings floatingErrorLoginTitle]
                                                                 message:[Strings enterEmail]
                                                        onViewController:self.navigationController
                                                             ];
@@ -425,7 +423,7 @@
         [self.view setUserInteractionEnabled:YES];
     }
     else if([self.tf_Password.text length] == 0) {
-        [[UIAlertController alloc] showErrorWithTitle:[Strings floatingErrorLoginTitle]
+        [[UIAlertController alloc] showAlertWithTitle:[Strings floatingErrorLoginTitle]
                                                                 message:[Strings enterPassword]
                                                        onViewController:self.navigationController
                                                             ];
@@ -477,7 +475,7 @@
 - (void)externalLoginWithProvider:(id <OEXExternalAuthProvider>)provider {
     self.authProvider = provider;
     if(!self.reachable) {
-        [[UIAlertController alloc] showErrorWithTitle:[Strings networkNotAvailableTitle]
+        [[UIAlertController alloc] showAlertWithTitle:[Strings networkNotAvailableTitle]
                                                                 message:[Strings networkNotAvailableMessage]
                                                        onViewController:self.navigationController
                                                             ];
@@ -542,12 +540,12 @@
     [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
 
     if(title) {
-        [[UIAlertController alloc] showErrorWithTitle:title
+        [[UIAlertController alloc] showAlertWithTitle:title
                                       message:errorStr
                              onViewController:self.navigationController];
     }
     else {
-        [[UIAlertController alloc] showErrorWithTitle:[Strings floatingErrorLoginTitle]
+        [[UIAlertController alloc] showAlertWithTitle:[Strings floatingErrorLoginTitle]
                                       message:errorStr
                              onViewController:self.navigationController];
     }
@@ -598,7 +596,7 @@
 
         if(buttonIndex == 1) {
             if([EmailtextField.text length] == 0 || ![EmailtextField.text oex_isValidEmailAddress]) {
-                [[UIAlertController alloc] showErrorWithTitle:[Strings floatingErrorTitle] message:[Strings invalidEmailMessage] onViewController:self.navigationController];
+                [[UIAlertController alloc] showAlertWithTitle:[Strings floatingErrorTitle] message:[Strings invalidEmailMessage] onViewController:self.navigationController];
             }
             else {
                 self.str_ForgotEmail = [[NSString alloc] init];
@@ -607,7 +605,7 @@
 
                 [self.view setUserInteractionEnabled:NO];
 
-                [[UIAlertController alloc] showErrorWithTitle:[Strings resetPasswordTitle]
+                [[UIAlertController alloc] showAlertWithTitle:[Strings resetPasswordTitle]
                                               message:[Strings waitingForResponse]
                                      onViewController:self.navigationController];
                 [self resetPassword];
@@ -637,18 +635,18 @@
                         NSDictionary* dictionary = [NSJSONSerialization oex_JSONObjectWithData:data error:nil];
                         NSString* responseStr = [[dictionary objectForKey:@"email"] firstObject];
                         [[UIAlertController alloc]
-                         showErrorWithTitle:[Strings floatingErrorTitle]
+                         showAlertWithTitle:[Strings floatingErrorTitle]
                                     message:responseStr onViewController:self.navigationController];
                     }
                     else if(httpResp.statusCode > 500) {
                         NSString* responseStr = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-                        [[UIAlertController alloc] showErrorWithTitle:[Strings floatingErrorTitle] message:responseStr onViewController:self.navigationController];
+                        [[UIAlertController alloc] showAlertWithTitle:[Strings floatingErrorTitle] message:responseStr onViewController:self.navigationController];
                         
                     }
                 }
                 else {
                     [[UIAlertController alloc]
-                     showErrorWithTitle:[Strings floatingErrorTitle] message:[error localizedDescription] onViewController:self.navigationController];
+                     showAlertWithTitle:[Strings floatingErrorTitle] message:[error localizedDescription] onViewController:self.navigationController];
                 }
             });
     }];

--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -357,11 +357,11 @@
         [self.btn_Login applyButtonStyle:[[OEXStyles sharedStyles] filledPrimaryButtonStyle] withTitle:[self signInButtonText]];
 
         [self.activityIndicator stopAnimating];
-
-        [[OEXFlowErrorViewController sharedInstance] showErrorWithTitle:[Strings networkNotAvailableTitle]
+        
+        [[UIAlertController alloc] showErrorWithTitle:[Strings networkNotAvailableTitle]
                                                                 message:[Strings networkNotAvailableMessage]
-                                                       onViewController:self.view
-                                                             shouldHide:YES];
+                                                       onViewController:self.navigationController
+                                                            ];
     }
 }
 
@@ -410,10 +410,10 @@
     [self.view setUserInteractionEnabled:NO];
 
     if(!self.reachable) {
-        [[OEXFlowErrorViewController sharedInstance] showErrorWithTitle:[Strings networkNotAvailableTitle]
+        [[UIAlertController alloc] showErrorWithTitle:[Strings networkNotAvailableTitle]
                                                                 message:[Strings networkNotAvailableMessage]
-                                                       onViewController:self.navigationController.view
-                                                             shouldHide:YES];
+                                                       onViewController:self.navigationController
+                                                            ];
 
         [self.view setUserInteractionEnabled:YES];
 
@@ -422,18 +422,18 @@
 
     //Validation
     if([self.tf_EmailID.text length] == 0) {
-        [[OEXFlowErrorViewController sharedInstance] showErrorWithTitle:[Strings floatingErrorLoginTitle]
+        [[UIAlertController alloc] showErrorWithTitle:[Strings floatingErrorLoginTitle]
                                                                 message:[Strings enterEmail]
-                                                       onViewController:self.navigationController.view
-                                                             shouldHide:YES];
+                                                       onViewController:self.navigationController
+                                                            ];
 
         [self.view setUserInteractionEnabled:YES];
     }
     else if([self.tf_Password.text length] == 0) {
-        [[OEXFlowErrorViewController sharedInstance] showErrorWithTitle:[Strings floatingErrorLoginTitle]
+        [[UIAlertController alloc] showErrorWithTitle:[Strings floatingErrorLoginTitle]
                                                                 message:[Strings enterPassword]
-                                                       onViewController:self.navigationController.view
-                                                             shouldHide:YES];
+                                                       onViewController:self.navigationController
+                                                            ];
 
         [self.view setUserInteractionEnabled:YES];
     }
@@ -482,10 +482,10 @@
 - (void)externalLoginWithProvider:(id <OEXExternalAuthProvider>)provider {
     self.authProvider = provider;
     if(!self.reachable) {
-        [[OEXFlowErrorViewController sharedInstance] showErrorWithTitle:[Strings networkNotAvailableTitle]
+        [[UIAlertController alloc] showErrorWithTitle:[Strings networkNotAvailableTitle]
                                                                 message:[Strings networkNotAvailableMessage]
-                                                       onViewController:self.navigationController.view
-                                                             shouldHide:YES];
+                                                       onViewController:self.navigationController
+                                                            ];
         self.authProvider = nil;
         return;
     }
@@ -547,14 +547,14 @@
     [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
 
     if(title) {
-        [[OEXFlowErrorViewController sharedInstance] showErrorWithTitle:title
-                                                                message:errorStr onViewController:self.navigationController.view shouldHide:YES];
+        [[UIAlertController alloc] showErrorWithTitle:title
+                                      message:errorStr
+                             onViewController:self.navigationController];
     }
     else {
-        [[OEXFlowErrorViewController sharedInstance] showErrorWithTitle:[Strings floatingErrorLoginTitle]
-                                                                message:errorStr
-                                                       onViewController:self.navigationController.view
-                                                             shouldHide:YES];
+        [[UIAlertController alloc] showErrorWithTitle:[Strings floatingErrorLoginTitle]
+                                      message:errorStr
+                             onViewController:self.navigationController];
     }
 
     [self.activityIndicator stopAnimating];
@@ -603,9 +603,7 @@
 
         if(buttonIndex == 1) {
             if([EmailtextField.text length] == 0 || ![EmailtextField.text oex_isValidEmailAddress]) {
-                [[OEXFlowErrorViewController sharedInstance]
-                 showErrorWithTitle:[Strings floatingErrorTitle]
-                            message:[Strings invalidEmailMessage] onViewController:self.navigationController.view shouldHide:YES];
+                [[UIAlertController alloc] showErrorWithTitle:[Strings floatingErrorTitle] message:[Strings invalidEmailMessage] onViewController:self.navigationController];
             }
             else {
                 self.str_ForgotEmail = [[NSString alloc] init];
@@ -614,9 +612,9 @@
 
                 [self.view setUserInteractionEnabled:NO];
 
-                [[OEXFlowErrorViewController sharedInstance] showErrorWithTitle:[Strings resetPasswordTitle]
-                                                                        message:[Strings waitingForResponse]
-                                                               onViewController:self.navigationController.view shouldHide:NO];
+                [[UIAlertController alloc] showErrorWithTitle:[Strings resetPasswordTitle]
+                                              message:[Strings waitingForResponse]
+                                     onViewController:self.navigationController];
                 [self resetPassword];
             }
         }
@@ -643,21 +641,19 @@
                     else if(httpResp.statusCode <= 400 && httpResp.statusCode < 500) {
                         NSDictionary* dictionary = [NSJSONSerialization oex_JSONObjectWithData:data error:nil];
                         NSString* responseStr = [[dictionary objectForKey:@"email"] firstObject];
-                        [[OEXFlowErrorViewController sharedInstance]
+                        [[UIAlertController alloc]
                          showErrorWithTitle:[Strings floatingErrorTitle]
-                                    message:responseStr onViewController:self.view shouldHide:YES];
+                                    message:responseStr onViewController:self.navigationController];
                     }
                     else if(httpResp.statusCode > 500) {
                         NSString* responseStr = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-                        [[OEXFlowErrorViewController sharedInstance]
-                         showErrorWithTitle:[Strings floatingErrorTitle]
-                                    message:responseStr onViewController:self.view shouldHide:YES];
+                        [[UIAlertController alloc] showErrorWithTitle:[Strings floatingErrorTitle] message:responseStr onViewController:self.navigationController];
+                        
                     }
                 }
                 else {
-                    [[OEXFlowErrorViewController sharedInstance]
-                     showErrorWithTitle:[Strings floatingErrorTitle]
-                                message:[error localizedDescription] onViewController:self.view shouldHide:YES];
+                    [[UIAlertController alloc]
+                     showErrorWithTitle:[Strings floatingErrorTitle] message:[error localizedDescription] onViewController:self.navigationController];
                 }
             });
     }];

--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -357,11 +357,6 @@
         [self.btn_Login applyButtonStyle:[[OEXStyles sharedStyles] filledPrimaryButtonStyle] withTitle:[self signInButtonText]];
 
         [self.activityIndicator stopAnimating];
-        
-        [[UIAlertController alloc] showErrorWithTitle:[Strings networkNotAvailableTitle]
-                                                                message:[Strings networkNotAvailableMessage]
-                                                       onViewController:self.navigationController
-                                                            ];
     }
 }
 

--- a/Source/UIAlertController+OEXBlockActions.swift
+++ b/Source/UIAlertController+OEXBlockActions.swift
@@ -84,24 +84,32 @@ extension UIAlertController {
         
         return self.showAlertWithTitle(title,
                                        message: message,
-                                       cancelButtonTitle: OEXLocalizedString("OK", nil),
+                                       cancelButtonTitle: Strings.ok,
                                        onViewController: viewController)
         
     }
     
     //MARK:- Add Action Methods
     
-    func addActionButtonWithTitle(title: String,
+    func addButtonWithTitle(title: String,
                                   style: UIAlertActionStyle,
                                   actionBlock: ((action: UIAlertAction) -> ())?) {
-        
         let alertAction = UIAlertAction(title: title, style: style, handler: { (action) in
             if let tap = actionBlock {
                 tap(action: action)
             }
         })
         self.addAction(alertAction)
-        
+    }
+    
+    func addButtonWithTitle(title: String,
+                            actionBlock: ((action: UIAlertAction) -> ())?) {
+        let alertAction = UIAlertAction(title: title, style: UIAlertActionStyle.Default, handler: { (action) in
+            if let tap = actionBlock {
+                tap(action: action)
+            }
+        })
+        self.addAction(alertAction)
     }
     
     //MARK:- Helper Variables

--- a/Source/UIAlertController+OEXBlockActions.swift
+++ b/Source/UIAlertController+OEXBlockActions.swift
@@ -14,6 +14,8 @@ private let UIAlertControllerBlocksFirstOtherButtonIndex = 2
 
 extension UIAlertController {
     
+    //MARK:- Init Methods
+    
     func showInViewController(viewController: UIViewController,
                               title: String?,
                               message: String?,
@@ -60,38 +62,49 @@ extension UIAlertController {
         
     }
     
-    func showAlertInViewController(viewController: UIViewController,
-                                   title: String?,
-                                   message: String?,
-                                   cancelButtonTitle: String?,
-                                   destructiveButtonTitle: String?,
-                                   otherButtonsTitle: [String]?,
-                                   tapBlock: ((controller: UIAlertController, action: UIAlertAction, buttonIndex: Int) -> ())?) -> UIAlertController{
-        
+    func showAlertWithTitle(title: String?,
+                            message: String?,
+                            cancelButtonTitle: String?,
+                            onViewController viewController: UIViewController) -> UIAlertController{
+
         return self.showInViewController(viewController,
                                          title: title,
                                          message: message,
                                          preferredStyle: UIAlertControllerStyle.Alert,
                                          cancelButtonTitle: cancelButtonTitle,
-                                         destructiveButtonTitle: destructiveButtonTitle,
-                                         otherButtonsTitle: otherButtonsTitle,
-                                         tapBlock: tapBlock)
+                                         destructiveButtonTitle: nil,
+                                         otherButtonsTitle: nil,
+                                         tapBlock: nil)
         
     }
     
-    func showErrorWithTitle(title: String?,
+    func showAlertWithTitle(title: String?,
                             message: String?,
                             onViewController viewController: UIViewController) -> UIAlertController{
         
-        return self.showAlertInViewController(viewController,
-                                              title: title,
-                                              message: message,
-                                              cancelButtonTitle: "OK",
-                                              destructiveButtonTitle: nil,
-                                              otherButtonsTitle: nil,
-                                              tapBlock: nil)
+        return self.showAlertWithTitle(title,
+                                       message: message,
+                                       cancelButtonTitle: OEXLocalizedString("OK", nil),
+                                       onViewController: viewController)
         
     }
+    
+    //MARK:- Add Action Methods
+    
+    func addActionButtonWithTitle(title: String,
+                                  style: UIAlertActionStyle,
+                                  actionBlock: ((action: UIAlertAction) -> ())?) {
+        
+        let alertAction = UIAlertAction(title: title, style: style, handler: { (action) in
+            if let tap = actionBlock {
+                tap(action: action)
+            }
+        })
+        self.addAction(alertAction)
+        
+    }
+    
+    //MARK:- Helper Variables
     
     var visible : Bool {
         return self.view.superview != nil;

--- a/Source/UIAlertController+OEXBlockActions.swift
+++ b/Source/UIAlertController+OEXBlockActions.swift
@@ -1,0 +1,112 @@
+//
+//  UIAlertController+OEXBlockActions.swift
+//  edX
+//
+//  Created by Danial Zahid on 8/30/16.
+//  Copyright © 2016 edX. All rights reserved.
+//
+
+import Foundation
+
+private let UIAlertControllerBlocksCancelButtonIndex = 0
+private let UIAlertControllerBlocksDestructiveButtonIndex = 1
+private let UIAlertControllerBlocksFirstOtherButtonIndex = 2
+
+extension UIAlertController {
+    
+    func showInViewController(viewController: UIViewController,
+                              title: String?,
+                              message: String?,
+                              preferredStyle: UIAlertControllerStyle,
+                              cancelButtonTitle: String?,
+                              destructiveButtonTitle: String?,
+                              otherButtonsTitle: [String]?,
+                              tapBlock: ((controller: UIAlertController, action: UIAlertAction, buttonIndex: Int) -> ())?) -> UIAlertController{
+        
+        let controller = UIAlertController(title: title, message: message, preferredStyle: preferredStyle)
+        
+        if let cancelText = cancelButtonTitle {
+            let cancelAction = UIAlertAction(title: cancelText, style: UIAlertActionStyle.Cancel, handler: { (action) in
+                if let tap = tapBlock {
+                    tap(controller: controller, action: action, buttonIndex: UIAlertControllerBlocksCancelButtonIndex)
+                }
+            })
+            controller.addAction(cancelAction)
+        }
+        
+        if let destructiveText = destructiveButtonTitle {
+            let destructiveAction = UIAlertAction(title: destructiveText, style: UIAlertActionStyle.Destructive, handler: { (action) in
+                if let tap = tapBlock {
+                    tap(controller: controller, action: action, buttonIndex: UIAlertControllerBlocksDestructiveButtonIndex)
+                }
+            })
+            controller.addAction(destructiveAction)
+        }
+        
+        if let otherButtonsText = otherButtonsTitle {
+            for otherTitle in otherButtonsText {
+                let otherAction = UIAlertAction(title: otherTitle, style: UIAlertActionStyle.Default, handler: { (action) in
+                    if let tap = tapBlock {
+                        tap(controller: controller, action: action, buttonIndex: UIAlertControllerBlocksDestructiveButtonIndex)
+                    }
+                })
+                controller.addAction(otherAction)
+            }
+        }
+        
+        viewController.presentViewController(controller, animated: true, completion: nil)
+        
+        return controller
+        
+    }
+    
+    func showAlertInViewController(viewController: UIViewController,
+                                   title: String?,
+                                   message: String?,
+                                   cancelButtonTitle: String?,
+                                   destructiveButtonTitle: String?,
+                                   otherButtonsTitle: [String]?,
+                                   tapBlock: ((controller: UIAlertController, action: UIAlertAction, buttonIndex: Int) -> ())?) -> UIAlertController{
+        
+        return self.showInViewController(viewController,
+                                         title: title,
+                                         message: message,
+                                         preferredStyle: UIAlertControllerStyle.Alert,
+                                         cancelButtonTitle: cancelButtonTitle,
+                                         destructiveButtonTitle: destructiveButtonTitle,
+                                         otherButtonsTitle: otherButtonsTitle,
+                                         tapBlock: tapBlock)
+        
+    }
+    
+    func showErrorWithTitle(title: String?,
+                            message: String?,
+                            onViewController viewController: UIViewController) -> UIAlertController{
+        
+        return self.showAlertInViewController(viewController,
+                                              title: title,
+                                              message: message,
+                                              cancelButtonTitle: "OK",
+                                              destructiveButtonTitle: nil,
+                                              otherButtonsTitle: nil,
+                                              tapBlock: nil)
+        
+    }
+    
+    var visible : Bool {
+        return self.view.superview != nil;
+    }
+    
+    var cancelButtonIndex : Int {
+        return UIAlertControllerBlocksCancelButtonIndex;
+    }
+    
+    var firstOtherButtonIndex : Int {
+        return UIAlertControllerBlocksFirstOtherButtonIndex;
+    }
+    
+    var destructiveButtonIndex : Int{
+        return UIAlertControllerBlocksDestructiveButtonIndex;
+    }
+    
+}

--- a/Test/UIAlertController+OEXBlockActionsTests.swift
+++ b/Test/UIAlertController+OEXBlockActionsTests.swift
@@ -23,7 +23,7 @@ class UIAlertController_OEXBlockActionsTests: XCTestCase {
         let alert = UIAlertController().showAlertWithTitle("Error Title", message: "Error Message", onViewController: controller)
         XCTAssertNotNil(alert)
         XCTAssertEqual(alert.actions.count, 1)
-        XCTAssertEqual(alert.actions.first?.title, "OK")
+        XCTAssertEqual(alert.actions.first?.title, Strings.ok)
     }
     
 

--- a/Test/UIAlertController+OEXBlockActionsTests.swift
+++ b/Test/UIAlertController+OEXBlockActionsTests.swift
@@ -13,14 +13,14 @@ class UIAlertController_OEXBlockActionsTests: XCTestCase {
     
     func testAlertController() {
         let controller = UIViewController()
-        let alert = UIAlertController().showAlertInViewController(controller, title: "Test Title", message: "Test Message", cancelButtonTitle: "Cancel", destructiveButtonTitle: "Delete", otherButtonsTitle: ["Button 1","Button 2"], tapBlock: nil)
+        let alert = UIAlertController().showInViewController(controller, title: "Test Title", message: "Test Message",preferredStyle: UIAlertControllerStyle.Alert, cancelButtonTitle: "Cancel", destructiveButtonTitle: "Delete", otherButtonsTitle: ["Button 1","Button 2"], tapBlock: nil)
         XCTAssertNotNil(alert)
         XCTAssertEqual(alert.actions.count, 4)
     }
     
     func testErrorAlertController() {
         let controller = UIViewController()
-        let alert = UIAlertController().showErrorWithTitle("Error Title", message: "Error Message", onViewController: controller)
+        let alert = UIAlertController().showAlertWithTitle("Error Title", message: "Error Message", onViewController: controller)
         XCTAssertNotNil(alert)
         XCTAssertEqual(alert.actions.count, 1)
         XCTAssertEqual(alert.actions.first?.title, "OK")

--- a/Test/UIAlertController+OEXBlockActionsTests.swift
+++ b/Test/UIAlertController+OEXBlockActionsTests.swift
@@ -1,0 +1,30 @@
+//
+//  UIAlertController+OEXBlockActionsTests.swift
+//  edX
+//
+//  Created by Danial Zahid on 8/31/16.
+//  Copyright © 2016 edX. All rights reserved.
+//
+
+import XCTest
+@testable import edX
+
+class UIAlertController_OEXBlockActionsTests: XCTestCase {
+    
+    func testAlertController() {
+        let controller = UIViewController()
+        let alert = UIAlertController().showAlertInViewController(controller, title: "Test Title", message: "Test Message", cancelButtonTitle: "Cancel", destructiveButtonTitle: "Delete", otherButtonsTitle: ["Button 1","Button 2"], tapBlock: nil)
+        XCTAssertNotNil(alert)
+        XCTAssertEqual(alert.actions.count, 4)
+    }
+    
+    func testErrorAlertController() {
+        let controller = UIViewController()
+        let alert = UIAlertController().showErrorWithTitle("Error Title", message: "Error Message", onViewController: controller)
+        XCTAssertNotNil(alert)
+        XCTAssertEqual(alert.actions.count, 1)
+        XCTAssertEqual(alert.actions.first?.title, "OK")
+    }
+    
+
+}

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		6926CDAF1D59BE3600A16E22 /* ic_progressbar.png in Resources */ = {isa = PBXBuildFile; fileRef = 6926CDA81D59BE3600A16E22 /* ic_progressbar.png */; };
 		6926CDB01D59BE3600A16E22 /* ic_seek_thumb.png in Resources */ = {isa = PBXBuildFile; fileRef = 6926CDA91D59BE3600A16E22 /* ic_seek_thumb.png */; };
 		6926CDB11D59BE3600A16E22 /* ic_seek_thumb@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6926CDAA1D59BE3600A16E22 /* ic_seek_thumb@2x.png */; };
+		694D34A01D75BDF80047F3F4 /* UIAlertController+OEXBlockActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694D349F1D75BDF80047F3F4 /* UIAlertController+OEXBlockActions.swift */; };
+		694D34A21D76B75F0047F3F4 /* UIAlertController+OEXBlockActionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 694D34A11D76B75F0047F3F4 /* UIAlertController+OEXBlockActionsTests.swift */; };
 		6960892B1D53935500EE66DD /* courseCertificate.png in Resources */ = {isa = PBXBuildFile; fileRef = 696089281D53935500EE66DD /* courseCertificate.png */; };
 		6960892C1D53935500EE66DD /* courseCertificate@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 696089291D53935500EE66DD /* courseCertificate@2x.png */; };
 		6960892D1D53935500EE66DD /* courseCertificate@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6960892A1D53935500EE66DD /* courseCertificate@3x.png */; };
@@ -887,6 +889,8 @@
 		6926CDA81D59BE3600A16E22 /* ic_progressbar.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = ic_progressbar.png; sourceTree = "<group>"; };
 		6926CDA91D59BE3600A16E22 /* ic_seek_thumb.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = ic_seek_thumb.png; sourceTree = "<group>"; };
 		6926CDAA1D59BE3600A16E22 /* ic_seek_thumb@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "ic_seek_thumb@2x.png"; sourceTree = "<group>"; };
+		694D349F1D75BDF80047F3F4 /* UIAlertController+OEXBlockActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertController+OEXBlockActions.swift"; sourceTree = "<group>"; };
+		694D34A11D76B75F0047F3F4 /* UIAlertController+OEXBlockActionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertController+OEXBlockActionsTests.swift"; sourceTree = "<group>"; };
 		696089281D53935500EE66DD /* courseCertificate.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = courseCertificate.png; sourceTree = "<group>"; };
 		696089291D53935500EE66DD /* courseCertificate@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "courseCertificate@2x.png"; sourceTree = "<group>"; };
 		6960892A1D53935500EE66DD /* courseCertificate@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "courseCertificate@3x.png"; sourceTree = "<group>"; };
@@ -2453,6 +2457,7 @@
 			isa = PBXGroup;
 			children = (
 				199B9B761935EA5200081A09 /* ErrorView */,
+				694D349F1D75BDF80047F3F4 /* UIAlertController+OEXBlockActions.swift */,
 				77AF07761CB42AC400A42704 /* TabContainerView.swift */,
 				E03E6A161D38EB9000944AAA /* SnackbarViews.swift */,
 			);
@@ -3209,6 +3214,7 @@
 				E00A33C01D3CEB3400963D8F /* SnackbarViewsTests.swift */,
 				1A6D90921D0A05D500D01BEA /* StartupViewControllerTests.swift */,
 				E0A246201D5DB3FD0066C766 /* AppUpgradeConfigTests.swift */,
+				694D34A11D76B75F0047F3F4 /* UIAlertController+OEXBlockActionsTests.swift */,
 				77FDF4171B0269FA00E8C639 /* Test Data */,
 				77FFA2C41AC30D6300B4D69B /* Data Factories */,
 				7772BE901AF90C8A0081CA7A /* Helpers */,
@@ -4249,6 +4255,7 @@
 				B4B6C80D1A9C7AEA004F0FAF /* OEXPlaceholderTextView.m in Sources */,
 				77E648781C91330D00B6740D /* Result+Conveniences.swift in Sources */,
 				9EF21A9E1B4697CA000048F8 /* CourseLastAccessedController.swift in Sources */,
+				694D34A01D75BDF80047F3F4 /* UIAlertController+OEXBlockActions.swift in Sources */,
 				BECB7B1B1924C0C3009C77F1 /* main.m in Sources */,
 				77691F981B38A09B003922F2 /* NSAttributedString+Combination.swift in Sources */,
 				77ADF4B31AC1FACC00AC8955 /* OEXTextStyle.m in Sources */,
@@ -4276,6 +4283,7 @@
 				7772BE821AF822500081CA7A /* UIBarButtonItem+OEXBlockActionsTests.m in Sources */,
 				775981FD1C30975A00CDBC4A /* MockEnrollmentManager.swift in Sources */,
 				9CA725F41A8E1B56009244A6 /* OEXFindCoursesTests.m in Sources */,
+				694D34A21D76B75F0047F3F4 /* UIAlertController+OEXBlockActionsTests.swift in Sources */,
 				1A373E8F1C457DBB00E3AAAA /* MockRouter.swift in Sources */,
 				77236EEF1C21C3D5006AC1A4 /* PaginatorTests.swift in Sources */,
 				77AFD11D1C1B7721001985FD /* NSObject+SafeKVOTests.swift in Sources */,


### PR DESCRIPTION
### Description

[MA-2345](https://openedx.atlassian.net/browse/MA-2345)

A `UIAlertController` extension created for error messages to be used for a11y. Native error messages implemented on the Sign In screen.

### How to test this PR

1. Navigate to the Sign In screen
2. Enter wrong credentials or disconnect from the internet
3. Click the Sign In button
4. Error message should be displayed in `UIAlertController`

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @saeedbashir 
- [x] Code review: @BenjiLee 

