### PR TITLE
Add fallbacks to OEXColors

### DIFF
--- a/Source/OEXColors.swift
+++ b/Source/OEXColors.swift
@@ -48,7 +48,9 @@ public class OEXColors: NSObject {
             let color = UIColor(hexString: hexValue, alpha: alpha)
             return color
         }
-        return UIColor.whiteColor()
+        //Assert to crash on development, and return a random color for distribution
+        assert(false, "Could not find the required color in colors.json")
+        return UIColor(hexString: "#FABA12", alpha: 1.0)
     }
     
 }

--- a/Source/OEXColors.swift
+++ b/Source/OEXColors.swift
@@ -26,7 +26,8 @@ public class OEXColors: NSObject {
         }
         if let data = NSData(contentsOfFile: filePath) {
             var error : NSError?
-            if let json = NSJSONSerialization.oex_JSONObjectWithData(data, error: &error) as? [String: AnyObject] {
+            
+            if let json = JSON(data: data, error: &error).dictionaryObject{
                 return json
             }
             return fallbackColors

--- a/Source/OEXColors.swift
+++ b/Source/OEXColors.swift
@@ -21,15 +21,21 @@ public class OEXColors: NSObject {
     }
     
     private func initializeColorsDictionary() -> [String: AnyObject] {
-        guard let filePath = NSBundle.mainBundle().pathForResource("colors", ofType: "json") else { assert(false, "Could not find colors.json") }
+        guard let filePath = NSBundle.mainBundle().pathForResource("colors", ofType: "json") else {
+            return fallbackColors
+        }
         if let data = NSData(contentsOfFile: filePath) {
             var error : NSError?
             if let json = NSJSONSerialization.oex_JSONObjectWithData(data, error: &error) as? [String: AnyObject] {
                 return json
             }
-                assert(error == nil, "Could not parse colors.json")
+            return fallbackColors
         }
-        assert(false, "Could not load colors.json")
+        return fallbackColors
+    }
+    
+    private var fallbackColors: [String: AnyObject] {
+        return OEXColorsDataFactory.colors
     }
     
     public func colorForIdentifier(identifier: String) -> UIColor {
@@ -41,7 +47,7 @@ public class OEXColors: NSObject {
             let color = UIColor(hexString: hexValue, alpha: alpha)
             return color
         }
-        assert(false, "Could not find the required color in colors.json")
+        return UIColor.whiteColor()
     }
     
 }

--- a/Source/OEXColorsDataFactory.swift
+++ b/Source/OEXColorsDataFactory.swift
@@ -1,0 +1,47 @@
+//
+//  OEXColorsDataFactory.swift
+//  edX
+//
+//  Created by Danial Zahid on 9/28/16.
+//  Copyright © 2016 edX. All rights reserved.
+//
+
+import Foundation
+
+class OEXColorsDataFactory {
+    
+    static let colors = ["primaryXDarkColor":"#003654",
+                         "primaryDarkColor":"#005483",
+                         "primaryBaseColor":"#0079BC",
+                         "primaryLightColor":"#4CA1D0",
+                         "primaryXLightColor":"#D9EBF5",
+                         
+                         "secondaryXDarkColor":"#5B283F",
+                         "secondaryDarkColor":"#8E3E62",
+                         "secondaryBaseColor":"#CB598D",
+                         "secondaryLightColor":"#DA8AAF",
+                         "secondaryXLightColor":"#EFCDDC",
+                         
+                         "neutralBlack":"#101010",
+                         "neutralBlackT":"#000000",
+                         "neutralXDark":"#424141",
+                         "neutralDark":"#646262",
+                         "neutralBase":"#A7A4A4",
+                         "neutralLight":"#D3D1D1",
+                         "neutralXLight":"#E9E8E8",
+                         "neutralXXLight":"#F2F2F2",
+                         "neutralWhite":"#FCFCFC",
+                         "neutralWhiteT":"#FFFFFF",
+                         
+                         "utilitySuccessDark":"#1E8142",
+                         "utilitySuccessBase":"#25B85A",
+                         "utilitySuccessLight":"#6CCF90",
+                         "warningDark":"#A97D39",
+                         "warningBase":"#FDBC56",
+                         "warningLight":"#FDD28D",
+                         "errorDark":"#77040A",
+                         "errorBase":"#B20610",
+                         "errorLight":"#CB585E",
+                         "banner":"#7DC88F"]
+    
+}

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		6960892B1D53935500EE66DD /* courseCertificate.png in Resources */ = {isa = PBXBuildFile; fileRef = 696089281D53935500EE66DD /* courseCertificate.png */; };
 		6960892C1D53935500EE66DD /* courseCertificate@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 696089291D53935500EE66DD /* courseCertificate@2x.png */; };
 		6960892D1D53935500EE66DD /* courseCertificate@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6960892A1D53935500EE66DD /* courseCertificate@3x.png */; };
+		697652261D9BA7C80031FF8B /* OEXColorsDataFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697652251D9BA7C80031FF8B /* OEXColorsDataFactory.swift */; };
 		697B5A011D92D9CD002C3ABD /* TestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775391321C973CEC00FA959C /* TestCredentials.swift */; };
 		697B5A021D92DA17002C3ABD /* RegistrationAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775391831CA0600700FA959C /* RegistrationAPITests.swift */; };
 		697B5A031D92DA2F002C3ABD /* RegistrationAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775391471C97A70700FA959C /* RegistrationAPI.swift */; };
@@ -894,6 +895,7 @@
 		696089281D53935500EE66DD /* courseCertificate.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = courseCertificate.png; sourceTree = "<group>"; };
 		696089291D53935500EE66DD /* courseCertificate@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "courseCertificate@2x.png"; sourceTree = "<group>"; };
 		6960892A1D53935500EE66DD /* courseCertificate@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "courseCertificate@3x.png"; sourceTree = "<group>"; };
+		697652251D9BA7C80031FF8B /* OEXColorsDataFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OEXColorsDataFactory.swift; sourceTree = "<group>"; };
 		697B5A081D92DB3F002C3ABD /* RegistrationFormAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RegistrationFormAPI.swift; path = Source/Core/Code/RegistrationFormAPI.swift; sourceTree = SOURCE_ROOT; };
 		6987A86A1D6C57C100E9D183 /* OEXColorsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OEXColorsTests.swift; sourceTree = "<group>"; };
 		6987A86C1D6C67DB00E9D183 /* colors.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = colors.json; sourceTree = "<group>"; };
@@ -2953,6 +2955,7 @@
 				BE28A6A8192E01CA004A0E7B /* OEXConstants.h */,
 				9E1081071B8B7EEC00888746 /* PaginatedFeed.swift */,
 				775E5A801BE1C88A0046B26B /* LiveObjectCache.swift */,
+				697652251D9BA7C80031FF8B /* OEXColorsDataFactory.swift */,
 			);
 			name = Data;
 			sourceTree = "<group>";
@@ -4088,6 +4091,7 @@
 				199B9B721935C8AC00081A09 /* OEXCourseVideosTableViewCell.m in Sources */,
 				772619B71ADDA8ED005BD7E4 /* OEXPushSettingsManager.m in Sources */,
 				77ADF49E1AC1ACAA00AC8955 /* OEXExternalRegistrationOptionsView.m in Sources */,
+				697652261D9BA7C80031FF8B /* OEXColorsDataFactory.swift in Sources */,
 				B4B6D63F1A952D1C000F44E8 /* OEXRegistrationAgreementView.m in Sources */,
 				77AF07771CB42AC400A42704 /* TabContainerView.swift in Sources */,
 				199B9B751935E35D00081A09 /* OEXHelperVideoDownload.m in Sources */,


### PR DESCRIPTION
### Description

[MA-2877](https://openedx.atlassian.net/browse/MA-2877)

Fallback data factory and colors have been added to all respective methods in the OEXColors.swift instead of assertions as assertions do not work on distribution builds.

### Notes

Following the merge of this PR, if the main color scheme is changed for a project it is also recommended to update OEXColorsDataFactory.swift (contains fallback colors) with the same values to have a more reliable fallback color scheme.

### How to test this PR

1. Try removing colors.json to see if the app picks up the fallback colors
2. Try corrupting the data in colors.json to see if the app picks up the fallback colors
3. Try giving a random color key to see if the app returns the proper fallback color

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @saeedbashir 
- [ ] Code review: @BenjiLee 
