### PR TITLE
Remove MockNav from My Videos

### DIFF
--- a/Source/OEXMyVideosSubSectionViewController.h
+++ b/Source/OEXMyVideosSubSectionViewController.h
@@ -7,6 +7,7 @@
 //
 
 @class OEXCourse;
+@class RouterEnvironment;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -14,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) NSMutableArray* arr_CourseData;
 @property (nonatomic, strong) OEXCourse* course;
+@property (strong, nonatomic) RouterEnvironment* environment;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/OEXMyVideosSubSectionViewController.m
+++ b/Source/OEXMyVideosSubSectionViewController.m
@@ -154,7 +154,7 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
     
     //Set Navigation Buttons
     self.selectAllButton = [[OEXCheckBox alloc] initWithFrame:CGRectMake(0, 0, 40, 40)];
-    self.progressController = [[ProgressController alloc] initWithOwner:self router:[OEXRouter sharedRouter] dataInterface:[OEXInterface sharedInterface]];
+    self.progressController = [[ProgressController alloc] initWithOwner:self router:self.environment.router dataInterface:self.environment.interface];
     self.navigationItem.rightBarButtonItem = [self.progressController navigationItem];
     [self.progressController hideProgessView];
 
@@ -1071,10 +1071,6 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
 }
 
 #pragma mark - Actions
-
-- (IBAction)downloadButtonPressed:(id)sender {
-    [[OEXRouter sharedRouter] showDownloadsFromViewController:self];
-}
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
     return [OEXStyles sharedStyles].standardStatusBarStyle;

--- a/Source/OEXMyVideosSubSectionViewController.m
+++ b/Source/OEXMyVideosSubSectionViewController.m
@@ -69,44 +69,33 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
 @property (weak, nonatomic) IBOutlet UIView* video_containerView;
 @property (strong, nonatomic) IBOutlet NSLayoutConstraint* videoViewHeight;
 @property   (weak, nonatomic) IBOutlet UIView* videoVideo;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint* TrailingSpaceCustomProgress;
 
-@property (weak, nonatomic) IBOutlet OEXCustomNavigationView* customNavigation;
 @property (weak, nonatomic) IBOutlet UITableView* table_SubSectionVideos;
-@property (weak, nonatomic) IBOutlet DACircularProgressView* customProgressBar;
-@property (weak, nonatomic) IBOutlet UIButton* btn_Downloads;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint* contraintEditingView;
 @property (weak, nonatomic) IBOutlet OEXCustomEditingView* customEditing;
-@property (weak, nonatomic) IBOutlet OEXCheckBox* selectAllButton;
+
+@property (strong, nonatomic) OEXCheckBox* selectAllButton;
+@property (strong, nonatomic) ProgressController *progressController;
 
 @end
 
 @implementation OEXMyVideosSubSectionViewController
 
 - (CGFloat)verticalOffsetForStatusController:(OEXStatusMessageViewController*)controller {
-    return CGRectGetMaxY(self.customNavigation.frame);
+    return CGRectGetMaxY(self.navigationController.navigationBar.frame);
 }
 
 - (NSArray*)overlayViewsForStatusController:(OEXStatusMessageViewController*)controller {
     NSMutableArray* result = [[NSMutableArray alloc] init];
-    [result oex_safeAddObjectOrNil:self.customNavigation];
-    [result oex_safeAddObjectOrNil:self.customProgressBar];
     [result oex_safeAddObjectOrNil:self.selectAllButton];
-    [result oex_safeAddObjectOrNil:self.btn_Downloads];
     return result;
 }
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    [self.navigationController setNavigationBarHidden:true animated:animated];
 
     //Add oserver
     [self addObservers];
-
-    if(_isTableEditing) {
-        self.TrailingSpaceCustomProgress.constant = ORIGINAL_RIGHT_SPACE_PROGRESSBAR + SHIFT_LEFT;
-    }
-
 
     if(_videoPlayerInterface) {
         [self.videoPlayerInterface videoPlayerShouldRotate];
@@ -148,30 +137,11 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
     // Do any additional setup after loading the view.
 
     //set exclusive touch for all btns
-    self.customNavigation.btn_Back.exclusiveTouch = YES;
-    self.btn_Downloads.exclusiveTouch = YES;
     self.view.exclusiveTouch = YES;
     self.videoVideo.exclusiveTouch = YES;
 
-    //Hide back button
-    [self.navigationItem setHidesBackButton:YES];
-    self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@" " style:UIBarButtonItemStylePlain target:nil action:nil];
-    [self.navigationController.navigationBar setTranslucent:NO];
-
-    // Set custom navigation properties
-    self.customNavigation.lbl_TitleView.text = self.course.name;
-    [self.customNavigation.btn_Back addTarget:self action:@selector(navigateBack) forControlEvents:UIControlEventTouchUpInside];
-    self.customNavigation.lbl_Offline.hidden = YES;
-
-    // Initialize the interface for API calling
-    self.dataInterface = [OEXInterface sharedInterface];
-    //set custom progress bar properties
-
-    [self.customProgressBar setProgressTintColor:PROGRESSBAR_PROGRESS_TINT_COLOR];
-
-    [self.customProgressBar setTrackTintColor:PROGRESSBAR_TRACK_TINT_COLOR];
-
-    [self.customProgressBar setProgress:_dataInterface.totalProgress animated:YES];
+    [self setTitle:self.course.name];
+    self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@" " style:UIBarButtonItemStylePlain target:self action:@selector(navigateBack)];
 
     //Init video view and video player
     self.videoPlayerInterface = [[OEXVideoPlayerInterface alloc] init];
@@ -181,17 +151,18 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
     _videoPlayerInterface.videoPlayerVideoView = self.videoVideo;
     self.videoViewHeight.constant = 0;
     self.videoVideo.exclusiveTouch = YES;
+    
+    //Set Navigation Buttons
+    self.selectAllButton = [[OEXCheckBox alloc] initWithFrame:CGRectMake(0, 0, 40, 40)];
+    self.progressController = [[ProgressController alloc] initWithOwner:self router:[OEXRouter sharedRouter] dataInterface:[OEXInterface sharedInterface]];
+    self.navigationItem.rightBarButtonItem = [self.progressController navigationItem];
+    [self.progressController hideProgessView];
 
     //Fix for 20px issue for the table view
     self.automaticallyAdjustsScrollViewInsets = NO;
 
     // Call to populate data
     [self getSubsectionVideoDataFromArray];
-
-    [[self.dataInterface progressViews] addObject:self.customProgressBar];
-    [[self.dataInterface progressViews] addObject:self.btn_Downloads];
-    [self.customProgressBar setHidden:YES];
-    [self.btn_Downloads setHidden:YES];
 
     // Used for autorotation
     [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
@@ -208,11 +179,6 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
     
     self.isTableEditing = NO;           // Check Edit button is clicked
     self.selectAll = NO;        // Check if all are selected
-    
-    [[OEXStyles sharedStyles] applyMockBackButtonStyleToButton:self.customNavigation.btn_Back];
-    [[OEXStyles sharedStyles] applyMockNavigationBarStyleToView:self.customNavigation label:self.customNavigation.lbl_TitleView leftIconButton:self.customNavigation.btn_Back];
-    
-    [self.btn_Downloads tintColor:[[OEXStyles sharedStyles] navigationItemTintColor]];
     
 }
 
@@ -248,7 +214,7 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
 }
 
 - (void)updateTotalDownloadProgress:(NSNotification* )notification {
-    [self.customProgressBar setProgress:_dataInterface.totalProgress animated:YES];
+    [self updateNavigationItemButtons];
 }
 
 - (void)getSubsectionVideoDataFromArray {
@@ -276,7 +242,7 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
     for(NSDictionary* dict in arrCourseAndVideo) {
         OEXCourse* course = [dict objectForKey:CAV_KEY_COURSE];
 
-        if([course.name isEqualToString:self.customNavigation.lbl_TitleView.text]) {
+        if([course.name isEqualToString:self.title]) {
             self.arr_CourseData = [dict objectForKey:CAV_KEY_VIDEOS];
         }
     }
@@ -801,9 +767,6 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
 
     [self disableDeleteButton];
 
-    // SHIFT THE PROGRESS TO LEFT
-    self.TrailingSpaceCustomProgress.constant = ORIGINAL_RIGHT_SPACE_PROGRESSBAR;
-
     [self hideComponentsOnEditing:NO];
     [self.table_SubSectionVideos reloadData];
 }
@@ -818,6 +781,8 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
     self.customEditing.imgSeparator.hidden = !hide;
 
     self.selectAll = NO;
+    
+    [self updateNavigationItemButtons];
 }
 
 - (void)deleteTableClicked:(id)sender {
@@ -834,9 +799,6 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
 
 - (void)editTableClicked:(id)sender {
     self.arr_SelectedObjects = [[NSMutableArray alloc] init];
-
-    // SHIFT THE PROGRESS TO LEFT
-    self.TrailingSpaceCustomProgress.constant = ORIGINAL_RIGHT_SPACE_PROGRESSBAR + SHIFT_LEFT;
 
     [self hideComponentsOnEditing:YES];
 
@@ -935,6 +897,19 @@ typedef NS_ENUM (NSUInteger, OEXAlertType) {
     [self.table_SubSectionVideos reloadData];
 
     [self disableDeleteButton];
+}
+
+- (void)updateNavigationItemButtons {
+    NSMutableArray *barButtons = [[NSMutableArray alloc] init];
+    if(_isTableEditing) {
+        [barButtons addObject:[[UIBarButtonItem alloc] initWithCustomView:self.selectAllButton]];
+    }
+    if(![self.progressController progressView].hidden){
+        [barButtons addObject:[self.progressController navigationItem]];
+    }
+    if(barButtons.count != self.navigationItem.rightBarButtonItems.count) {
+        self.navigationItem.rightBarButtonItems = barButtons;
+    }
 }
 
 #pragma mark videoPlayer Delegate

--- a/Source/OEXMyVideosSubSectionViewController.storyboard
+++ b/Source/OEXMyVideosSubSectionViewController.storyboard
@@ -1,9 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
         <!--My Videos Sub Section View Controller-->
@@ -15,61 +14,11 @@
                         <viewControllerLayoutGuide type="bottom" id="13t-1C-Pk9"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="L2G-qJ-vah">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="64" width="600" height="536"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d4r-cB-zL0" customClass="OEXCustomNavigationView">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="64" id="Vtl-4E-g87"/>
-                                    <constraint firstAttribute="width" constant="320" id="hjD-wD-7ae"/>
-                                </constraints>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="hjD-wD-7ae"/>
-                                    </mask>
-                                </variation>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="M8w-rr-UlB" customClass="DACircularProgressView">
-                                <rect key="frame" x="562" y="26" width="30" height="30"/>
-                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="30" id="bSf-SR-WdP"/>
-                                    <constraint firstAttribute="height" constant="30" id="yGV-Jl-Pbm"/>
-                                </constraints>
-                            </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gGs-i8-ViO" userLabel="Button - download">
-                                <rect key="frame" x="557" y="20" width="41" height="41"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="41" id="7gw-JF-Pkb"/>
-                                    <constraint firstAttribute="width" constant="41" id="DFR-zk-Hgn"/>
-                                </constraints>
-                                <inset key="contentEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
-                                <state key="normal" image="ic_download_arrow.png">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <connections>
-                                    <action selector="downloadButtonPressed:" destination="77t-wy-jpA" eventType="touchUpInside" id="sWl-DZ-4eX"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mqq-R6-tEu" userLabel="Select All Button" customClass="OEXCheckBox" customModule="edX" customModuleProvider="target">
-                                <rect key="frame" x="557" y="21" width="40" height="40"/>
-                                <accessibility key="accessibilityConfiguration" label=""/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="40" id="IHA-vQ-Psw"/>
-                                    <constraint firstAttribute="height" constant="40" id="WlQ-cx-m55"/>
-                                </constraints>
-                                <inset key="contentEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
-                                <state key="normal">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <connections>
-                                    <action selector="selectAllChanged:" destination="77t-wy-jpA" eventType="valueChanged" id="S1a-rE-8Vh"/>
-                                </connections>
-                            </button>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" showsSelectionImmediatelyOnTouchBegin="NO" rowHeight="60" sectionHeaderHeight="50" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="hps-DD-rdY" userLabel="Table View - RECENT">
-                                <rect key="frame" x="0.0" y="289" width="600" height="261"/>
+                                <rect key="frame" x="0.0" y="225" width="600" height="261"/>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="CellCourseVideo" rowHeight="60" id="c58-e8-zWO" customClass="OEXCourseVideosTableViewCell">
                                         <rect key="frame" x="0.0" y="50" width="600" height="60"/>
@@ -176,14 +125,14 @@
                                 </connections>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dpj-Iu-Y6r" customClass="OEXCustomEditingView">
-                                <rect key="frame" x="0.0" y="550" width="600" height="50"/>
+                                <rect key="frame" x="0.0" y="486" width="600" height="50"/>
                                 <color key="backgroundColor" red="0.24313725489999999" green="0.25882352939999997" blue="0.2784313725" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="bI2-oc-5yT"/>
                                 </constraints>
                             </view>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3i1-PG-mvc" userLabel="playback view">
-                                <rect key="frame" x="0.0" y="64" width="600" height="225"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="225"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="F6Y-u1-2mf" userLabel="videoview">
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="225"/>
@@ -233,15 +182,9 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstAttribute="right" secondItem="M8w-rr-UlB" secondAttribute="right" constant="8" id="4mm-bV-dWO"/>
-                            <constraint firstItem="d4r-cB-zL0" firstAttribute="leading" secondItem="L2G-qJ-vah" secondAttribute="leadingMargin" constant="-20" id="5XU-8x-j2p"/>
-                            <constraint firstItem="M8w-rr-UlB" firstAttribute="right" secondItem="gGs-i8-ViO" secondAttribute="right" constant="-6" id="7lP-Gm-8eQ"/>
-                            <constraint firstAttribute="centerX" secondItem="d4r-cB-zL0" secondAttribute="centerX" id="9Iy-BN-AiK"/>
-                            <constraint firstItem="mqq-R6-tEu" firstAttribute="top" secondItem="rHB-QQ-N5l" secondAttribute="bottom" constant="1" id="D2w-Do-dCH"/>
+                            <constraint firstItem="3i1-PG-mvc" firstAttribute="top" secondItem="rHB-QQ-N5l" secondAttribute="bottom" id="C4p-wf-A9p"/>
                             <constraint firstAttribute="trailing" secondItem="dpj-Iu-Y6r" secondAttribute="trailing" id="DKI-dG-4PP"/>
                             <constraint firstItem="hps-DD-rdY" firstAttribute="top" secondItem="3i1-PG-mvc" secondAttribute="bottom" id="FeL-wF-Nxh"/>
-                            <constraint firstItem="d4r-cB-zL0" firstAttribute="top" secondItem="L2G-qJ-vah" secondAttribute="top" id="G7S-zw-meD"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="d4r-cB-zL0" secondAttribute="trailing" constant="-20" id="Hz3-1h-xzs"/>
                             <constraint firstAttribute="trailing" secondItem="3i1-PG-mvc" secondAttribute="trailing" id="Jka-td-gMt"/>
                             <constraint firstItem="3i1-PG-mvc" firstAttribute="leading" secondItem="L2G-qJ-vah" secondAttribute="leading" id="KKl-aC-WBM"/>
                             <constraint firstItem="hps-DD-rdY" firstAttribute="leading" secondItem="L2G-qJ-vah" secondAttribute="leading" id="LPl-CH-vT4"/>
@@ -249,21 +192,13 @@
                             <constraint firstItem="dpj-Iu-Y6r" firstAttribute="leading" secondItem="L2G-qJ-vah" secondAttribute="leading" id="TSb-Vh-sEZ"/>
                             <constraint firstItem="dpj-Iu-Y6r" firstAttribute="top" secondItem="hps-DD-rdY" secondAttribute="bottom" id="TVO-yX-qeL"/>
                             <constraint firstItem="13t-1C-Pk9" firstAttribute="top" secondItem="dpj-Iu-Y6r" secondAttribute="bottom" id="VrR-dg-tdd"/>
-                            <constraint firstAttribute="right" secondItem="mqq-R6-tEu" secondAttribute="right" constant="3" id="dKd-4I-sKe"/>
-                            <constraint firstItem="3i1-PG-mvc" firstAttribute="top" secondItem="d4r-cB-zL0" secondAttribute="bottom" id="dM4-2M-kWJ"/>
-                            <constraint firstItem="M8w-rr-UlB" firstAttribute="top" secondItem="rHB-QQ-N5l" secondAttribute="bottom" constant="6" id="hvz-Hi-Cyl"/>
-                            <constraint firstItem="gGs-i8-ViO" firstAttribute="top" secondItem="rHB-QQ-N5l" secondAttribute="bottom" id="tmB-6H-gGl"/>
                         </constraints>
                     </view>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <connections>
-                        <outlet property="TrailingSpaceCustomProgress" destination="4mm-bV-dWO" id="fkA-qQ-hDd"/>
-                        <outlet property="btn_Downloads" destination="gGs-i8-ViO" id="Y2q-UT-fde"/>
                         <outlet property="contraintEditingView" destination="bI2-oc-5yT" id="zK7-gd-egP"/>
                         <outlet property="customEditing" destination="dpj-Iu-Y6r" id="S9i-n8-745"/>
-                        <outlet property="customNavigation" destination="d4r-cB-zL0" id="Ez4-fT-G4L"/>
-                        <outlet property="customProgressBar" destination="M8w-rr-UlB" id="cqW-z0-rby"/>
                         <outlet property="lbl_videoHeader" destination="1jC-Zi-BOc" id="SJt-DM-hOe"/>
-                        <outlet property="selectAllButton" destination="mqq-R6-tEu" id="hLN-HA-5xc"/>
                         <outlet property="table_SubSectionVideos" destination="hps-DD-rdY" id="0ww-bj-NXa"/>
                         <outlet property="videoVideo" destination="F6Y-u1-2mf" id="aqa-6i-NXp"/>
                         <outlet property="videoViewHeight" destination="h4r-MW-QWX" id="OJF-Qt-QgF"/>
@@ -275,7 +210,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="ic_download_arrow.png" width="44" height="44"/>
         <image name="ic_partiallywatched.png" width="12" height="12"/>
     </resources>
 </document>

--- a/Source/OEXMyVideosViewController.h
+++ b/Source/OEXMyVideosViewController.h
@@ -11,20 +11,11 @@ NS_ASSUME_NONNULL_BEGIN
 @class NetworkManager;
 @class OEXInterface;
 @class OEXRouter;
-
-@interface OEXMyVideosViewControllerEnvironment : NSObject
-
-- (id)initWithInterface:(OEXInterface*)interface networkManager:(NetworkManager*)networkManager router:(OEXRouter*)router;
-
-@property (strong, nonatomic) OEXInterface* interface;
-@property (strong, nonatomic) NetworkManager* networkManager;
-@property (weak, nonatomic, nullable) OEXRouter* router;
-
-@end
+@class RouterEnvironment;
 
 @interface OEXMyVideosViewController : UIViewController
 
-@property (strong, nonatomic) OEXMyVideosViewControllerEnvironment* environment;
+@property (strong, nonatomic) RouterEnvironment* environment;
 
 @end
 

--- a/Source/OEXMyVideosViewController.m
+++ b/Source/OEXMyVideosViewController.m
@@ -27,7 +27,6 @@
 #import "OEXFrontTableViewCell.h"
 #import "OEXHelperVideoDownload.h"
 #import "OEXNetworkConstants.h"
-#import "OEXStatusMessageViewController.h"
 #import "OEXTabBarItemsCell.h"
 #import "OEXVideoPathEntry.h"
 #import "OEXVideoPlayerInterface.h"
@@ -46,19 +45,6 @@
 #define ORIGINAL_RIGHT_SPACE_PROGRESSBAR 8
 #define ORIGINAL_RIGHT_SPACE_OFFLINE 15
 
-@implementation OEXMyVideosViewControllerEnvironment
-
-- (id)initWithInterface:(OEXInterface *)interface networkManager:(NetworkManager *)networkManager router:(OEXRouter *)router {
-    if(self != nil) {
-        self.interface = interface;
-        self.networkManager = networkManager;
-        self.router = router;
-    }
-    return self;
-}
-
-@end
-
 typedef  enum OEXAlertType
 {
     OEXAlertTypeNextVideoAlert,
@@ -69,7 +55,7 @@ typedef  enum OEXAlertType
     OEXAlertTypePlayBackContentUnAvailable
 }OEXAlertType;
 
-@interface OEXMyVideosViewController () <OEXVideoPlayerInterfaceDelegate, OEXStatusMessageControlling, UITableViewDataSource, UITableViewDelegate, UICollectionViewDataSource, UICollectionViewDelegate>
+@interface OEXMyVideosViewController () <OEXVideoPlayerInterfaceDelegate, UITableViewDataSource, UITableViewDelegate, UICollectionViewDataSource, UICollectionViewDelegate>
 {
     NSInteger cellSelectedIndex;
     NSIndexPath* clickedIndexpath;
@@ -114,25 +100,7 @@ typedef  enum OEXAlertType
 
 @implementation OEXMyVideosViewController
 
-
-- (IBAction)downloadsButtonPressed:(id)sender {
-     [[OEXRouter sharedRouter] showDownloadsFromViewController:self];
-}
-
-
 #pragma mark Status Overlay
-
-- (CGFloat)verticalOffsetForStatusController:(OEXStatusMessageViewController*)controller {
-    return CGRectGetMaxY(self.tabView.frame);
-}
-
-- (NSArray*)overlayViewsForStatusController:(OEXStatusMessageViewController*)controller {
-    NSMutableArray* result = [[NSMutableArray alloc] init];
-    [result oex_safeAddObjectOrNil:self.tabView];
-    [result oex_safeAddObjectOrNil:self.btn_SelectAllEditing];
-    return result;
-}
-
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
@@ -429,7 +397,7 @@ typedef  enum OEXAlertType
     // Navigate to nextview and pass array of HelperVideoDownload obj...
     [_videoPlayerInterface resetPlayer];
     _videoPlayerInterface = nil;
-    [[OEXRouter sharedRouter] showVideoSubSectionFromViewController:self forCourse:course withCourseData:nil];
+    [self.environment.router showVideoSubSectionFromViewController:self forCourse:course withCourseData:nil];
 }
 
 - (UITableViewCell*)tableView:(UITableView*)tableView cellForRowAtIndexPath:(NSIndexPath*)indexPath {
@@ -1183,10 +1151,7 @@ typedef  enum OEXAlertType
 
 - (void)movieTimedOut {
     if(!_videoPlayerInterface.moviePlayerController.isFullscreen) {
-        [[OEXStatusMessageViewController sharedInstance] showMessage:[Strings timeoutCheckInternetConnection]
-                                                    onViewController:self
-        ];
-
+        [self showOverlayMessage:[Strings timeoutCheckInternetConnection]];
         [_videoPlayerInterface.moviePlayerController stop];
     }
     else {
@@ -1258,7 +1223,7 @@ typedef  enum OEXAlertType
             [self.table_MyVideos reloadData];
 
             NSString* message = [Strings videosDeletedWithCount:deleteCount formatted:nil];
-            [[OEXStatusMessageViewController sharedInstance] showMessage:message onViewController:self];
+            [self showOverlayMessage:message];
 
             // clear all objects form array after deletion.
             // To obtain correct count on next deletion process.

--- a/Source/OEXMyVideosViewController.m
+++ b/Source/OEXMyVideosViewController.m
@@ -101,13 +101,9 @@ typedef  enum OEXAlertType
 @property(nonatomic, strong) IBOutlet NSLayoutConstraint* recentEditViewHeight;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint* TrailingSpaceCustomProgress;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint* ConstraintRecentTop;
-@property (weak, nonatomic) IBOutlet UIView* view_NavBG;
 
 @property (weak, nonatomic) IBOutlet UITableView* table_MyVideos;
-@property (weak, nonatomic) IBOutlet UIButton* btn_LeftNavigation;
 @property (weak, nonatomic) IBOutlet DACircularProgressView* customProgressView;
-@property (weak, nonatomic) IBOutlet UIButton* btn_Download;
-@property (weak, nonatomic) IBOutlet UILabel* lbl_NavTitle;
 @property (weak, nonatomic) IBOutlet UIView* tabView;
 @property (weak, nonatomic) IBOutlet UICollectionView* collectionView;
 @property (weak, nonatomic) IBOutlet UITableView* table_RecentVideos;
@@ -132,10 +128,7 @@ typedef  enum OEXAlertType
 
 - (NSArray*)overlayViewsForStatusController:(OEXStatusMessageViewController*)controller {
     NSMutableArray* result = [[NSMutableArray alloc] init];
-    [result oex_safeAddObjectOrNil:self.view_NavBG];
     [result oex_safeAddObjectOrNil:self.tabView];
-    [result oex_safeAddObjectOrNil:self.btn_LeftNavigation];
-    [result oex_safeAddObjectOrNil:self.lbl_NavTitle];
     [result oex_safeAddObjectOrNil:self.btn_SelectAllEditing];
     [result oex_safeAddObjectOrNil:self.customProgressView];
     [result oex_safeAddObjectOrNil:self.btn_Downloads];
@@ -148,7 +141,7 @@ typedef  enum OEXAlertType
     //Analytics Screen record
     [[OEXAnalytics sharedAnalytics] trackScreenWithName: @"My Videos - All Videos"];
 
-    [self.navigationController setNavigationBarHidden:true animated:animated];
+    [self.navigationController setNavigationBarHidden:false animated:animated];
 
     // Add Observer
     [self addObservers];
@@ -166,7 +159,7 @@ typedef  enum OEXAlertType
 
     //While editing goto downloads then comes back Progressview overlaps checkbox.
     // To avoid this check this.
-    if(_isTableEditing) {
+    if(8) {
         self.TrailingSpaceCustomProgress.constant = ORIGINAL_RIGHT_SPACE_PROGRESSBAR + SHIFT_LEFT;
     }
     else {
@@ -175,7 +168,7 @@ typedef  enum OEXAlertType
         }
     }
 
-    self.navigationController.navigationBarHidden = YES;
+    self.navigationController.navigationBarHidden = NO;
 
     self.table_RecentVideos.separatorInset = UIEdgeInsetsZero;
 #ifdef __IPHONE_8_0
@@ -220,21 +213,19 @@ typedef  enum OEXAlertType
 
     // Do any additional setup after loading the view.
     //Hide back button
-    [self.navigationItem setHidesBackButton:YES];
+    self.navigationController.navigationBarHidden = NO;
     self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@" " style:UIBarButtonItemStylePlain target:nil action:nil];
-    [self.navigationController.navigationBar setTranslucent:NO];
+    self.title = @"My Videos";
 
     //Set exclusive touch for all buttons
-    self.btn_LeftNavigation.exclusiveTouch = YES;
     self.videoVideo.exclusiveTouch = YES;
     self.table_RecentVideos.exclusiveTouch = YES;
     self.table_MyVideos.exclusiveTouch = YES;
-
-    //set navigation title font
-    self.lbl_NavTitle.font = [UIFont fontWithName:@"OpenSans-Semibold" size:16.0];
-
-    // Mock NavStyle
-    [[OEXStyles sharedStyles] applyMockNavigationBarStyleToView:self.view_NavBG label:self.lbl_NavTitle leftIconButton: self.btn_LeftNavigation];
+    
+    //Set Accessibility Elements
+    self.btn_Downloads.accessibilityLabel = [Strings accessibilityDownloadProgressButtonWithPercentComplete:0 formatted:nil];
+    self.btn_Downloads.accessibilityHint = [Strings accessibilityDownloadProgressButtonHint];
+    self.btn_Downloads.accessibilityTraits = UIAccessibilityTraitButton | UIAccessibilityTraitUpdatesFrequently;
     
     // Initialize array of data to show on table
     self.arr_SubsectionData = [[NSMutableArray alloc] init];
@@ -243,8 +234,9 @@ typedef  enum OEXAlertType
     self.dataInterface = [OEXInterface sharedInterface];
 
     //Add custom button for drawer
-    [self.btn_LeftNavigation setImage:[UIImage MenuIcon] forState:UIControlStateNormal];
-    [self.btn_LeftNavigation addTarget:self action:@selector(leftNavigationBtnClicked) forControlEvents:UIControlEventTouchUpInside];
+    UIBarButtonItem *closeButton = [[UIBarButtonItem alloc] initWithImage:[UIImage MenuIcon] style:UIBarButtonItemStylePlain target:self action:@selector(leftNavigationBtnClicked)];
+    closeButton.accessibilityLabel = [Strings accessibilityMenu];
+    self.navigationItem.leftBarButtonItem = closeButton;
 
     //set custom progress bar properties
     [self.customProgressView setProgressTintColor:PROGRESSBAR_PROGRESS_TINT_COLOR];
@@ -326,6 +318,10 @@ typedef  enum OEXAlertType
 
 - (void)updateTotalDownloadProgress:(NSNotification* )notification {
     [self.customProgressView setProgress:_dataInterface.totalProgress animated:YES];
+    
+    NSInteger numericPercentage = _dataInterface.totalProgress * 100;
+    NSString *percentString = [NSString stringWithFormat:@"%ld percent",numericPercentage];
+    self.btn_Downloads.accessibilityLabel = [Strings accessibilityDownloadProgressButtonWithPercentComplete:numericPercentage formatted:percentString];
 }
 
 - (void)getMyVideosTableData {
@@ -859,7 +855,7 @@ typedef  enum OEXAlertType
     cellSelectedIndex = indexPath.row;
     self.currentTappedVideo = nil;
     _selectedIndexPath = nil;
-    self.lbl_NavTitle.textAlignment = NSTextAlignmentCenter;
+//    self.lbl_NavTitle.textAlignment = NSTextAlignmentCenter;
     [self resetPlayer];
 
     switch(indexPath.row)

--- a/Source/OEXMyVideosViewController.m
+++ b/Source/OEXMyVideosViewController.m
@@ -33,7 +33,6 @@
 #import "OEXVideoPlayerInterface.h"
 #import "OEXVideoSummary.h"
 #import "OEXRouter.h"
-#import "Reachability.h"
 #import "SWRevealViewController.h"
 #import "OEXStyles.h"
 
@@ -159,7 +158,7 @@ typedef  enum OEXAlertType
 
     //While editing goto downloads then comes back Progressview overlaps checkbox.
     // To avoid this check this.
-    if(8) {
+    if(_isTableEditing) {
         self.TrailingSpaceCustomProgress.constant = ORIGINAL_RIGHT_SPACE_PROGRESSBAR + SHIFT_LEFT;
     }
     else {
@@ -215,7 +214,7 @@ typedef  enum OEXAlertType
     //Hide back button
     self.navigationController.navigationBarHidden = NO;
     self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@" " style:UIBarButtonItemStylePlain target:nil action:nil];
-    self.title = @"My Videos";
+    self.title = [Strings myVideos];
 
     //Set exclusive touch for all buttons
     self.videoVideo.exclusiveTouch = YES;
@@ -855,7 +854,6 @@ typedef  enum OEXAlertType
     cellSelectedIndex = indexPath.row;
     self.currentTappedVideo = nil;
     _selectedIndexPath = nil;
-//    self.lbl_NavTitle.textAlignment = NSTextAlignmentCenter;
     [self resetPlayer];
 
     switch(indexPath.row)
@@ -1157,8 +1155,6 @@ typedef  enum OEXAlertType
 
     [[NSNotificationCenter defaultCenter] removeObserver:self name:OEXDownloadProgressChangedNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:DOWNLOAD_PROGRESS_NOTIFICATION object:nil];
-
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:kReachabilityChangedNotification object:nil];
 }
 
 - (void)addPlayerObserver {

--- a/Source/OEXMyVideosViewController.m
+++ b/Source/OEXMyVideosViewController.m
@@ -220,8 +220,9 @@ typedef  enum OEXAlertType
     self.table_RecentVideos.exclusiveTouch = YES;
     self.table_MyVideos.exclusiveTouch = YES;
     
-    //Set Progress Controller
+    //Set Navigation Buttons
     self.btn_SelectAllEditing = [[OEXCheckBox alloc] initWithFrame:CGRectMake(0, 0, 40, 40)];
+    [self.btn_SelectAllEditing addTarget:self action:@selector(selectAllChanged:) forControlEvents:UIControlEventTouchUpInside];
     self.progressController = [[ProgressController alloc] initWithOwner:self router:self.environment.router dataInterface:self.environment.interface];
     self.navigationItem.rightBarButtonItem = [self.progressController navigationItem];
     [self.progressController hideProgessView];
@@ -797,7 +798,6 @@ typedef  enum OEXAlertType
     if(barButtons.count != self.navigationItem.rightBarButtonItems.count) {
         self.navigationItem.rightBarButtonItems = barButtons;
     }
-    
 }
 
 #pragma mark - CollectionView Delegate

--- a/Source/OEXMyVideosViewController.storyboard
+++ b/Source/OEXMyVideosViewController.storyboard
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="Navigation items with more than one left or right bar item" minToolsVersion="7.0"/>
     </dependencies>
     <scenes>
         <!--My Videos-->
@@ -15,11 +15,11 @@
                         <viewControllerLayoutGuide type="bottom" id="2zw-QW-AUq"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="PMR-ii-iVV">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="64" width="600" height="536"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iFC-95-ZX8" userLabel="RecentVideoView">
-                                <rect key="frame" x="0.0" y="109" width="600" height="491"/>
+                                <rect key="frame" x="0.0" y="45" width="600" height="491"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h57-PP-XUC" userLabel="playback view">
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="225"/>
@@ -70,7 +70,7 @@
                                                 <rect key="frame" x="0.0" y="50" width="600" height="60"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="yH3-lk-slx" id="2nC-WH-FoH">
-                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="60"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="59.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" tag="501" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Introduction to giving with purpose" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1XH-jH-Bdl" customClass="OEXCustomLabel">
@@ -186,12 +186,8 @@
                                     <constraint firstAttribute="trailing" secondItem="h57-PP-XUC" secondAttribute="trailing" id="z6E-Ci-vgB"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pYo-Nb-vrw">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="64"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aIT-EB-vrS" userLabel="TabView">
-                                <rect key="frame" x="0.0" y="64" width="600" height="45"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="45"/>
                                 <subviews>
                                     <collectionView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" minimumZoomScale="0.0" maximumZoomScale="0.0" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="WFv-LH-THx">
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="45"/>
@@ -204,7 +200,7 @@
                                         </collectionViewFlowLayout>
                                         <cells>
                                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="tabCell" id="a0q-S3-Lpw" customClass="OEXTabBarItemsCell">
-                                                <rect key="frame" x="0.0" y="1" width="165" height="44"/>
+                                                <rect key="frame" x="0.0" y="0.5" width="165" height="44"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                                     <rect key="frame" x="0.0" y="0.0" width="165" height="44"/>
@@ -263,7 +259,7 @@
                                 </variation>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" showsSelectionImmediatelyOnTouchBegin="NO" rowHeight="188" sectionHeaderHeight="8" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="tEo-nb-KXu" userLabel="Table View - ALL VIDEOS">
-                                <rect key="frame" x="0.0" y="109" width="600" height="491"/>
+                                <rect key="frame" x="0.0" y="45" width="600" height="491"/>
                                 <color key="backgroundColor" red="0.8862745098" green="0.89019607840000003" blue="0.8980392157" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="320" id="U7W-1v-F4n"/>
@@ -319,68 +315,8 @@
                                     <outlet property="delegate" destination="0fg-49-r6S" id="RDa-HR-T8h"/>
                                 </connections>
                             </tableView>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="My Videos" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KPs-bm-5ba">
-                                <rect key="frame" x="240" y="30" width="120" height="21"/>
-                                <accessibility key="accessibilityConfiguration" label="myVideosHeader"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="21" id="YEO-lS-uqh"/>
-                                    <constraint firstAttribute="width" constant="120" id="oDD-QN-Pd7"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.27058823529999998" green="0.28627450980000002" blue="0.31764705879999999" alpha="1" colorSpace="calibratedRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QZ2-mJ-Hgt">
-                                <rect key="frame" x="10" y="22" width="80" height="38"/>
-                                <accessibility key="accessibilityConfiguration" label="btnNavigation"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="80" id="RbX-OR-YBu"/>
-                                    <constraint firstAttribute="height" constant="38" id="g15-SV-XJu"/>
-                                </constraints>
-                                <inset key="contentEdgeInsets" minX="8" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                <state key="normal">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                            </button>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tiu-x9-6gY" customClass="DACircularProgressView">
-                                <rect key="frame" x="562" y="26" width="30" height="30"/>
-                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="30" id="Zrl-IR-fAZ"/>
-                                    <constraint firstAttribute="height" constant="30" id="cvg-Ff-mOO"/>
-                                </constraints>
-                            </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qkd-gT-5H9">
-                                <rect key="frame" x="557" y="20" width="41" height="41"/>
-                                <accessibility key="accessibilityConfiguration" label="btnDownloadScreen"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="41" id="wdK-7X-oII"/>
-                                    <constraint firstAttribute="width" constant="41" id="ydO-68-cBE"/>
-                                </constraints>
-                                <inset key="contentEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
-                                <state key="normal" image="ic_download_arrow.png">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <connections>
-                                    <action selector="downloadsButtonPressed:" destination="0fg-49-r6S" eventType="touchUpInside" id="V1h-RQ-hxC"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O7e-Gg-Spv" userLabel="Select All Button" customClass="OEXCheckBox" customModule="edX" customModuleProvider="target">
-                                <rect key="frame" x="550" y="21" width="40" height="40"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="40" id="ANs-cc-mDF"/>
-                                    <constraint firstAttribute="height" constant="40" id="YMu-Lx-M1b"/>
-                                </constraints>
-                                <inset key="contentEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
-                                <state key="normal">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <connections>
-                                    <action selector="selectAllChanged:" destination="0fg-49-r6S" eventType="valueChanged" id="Vlj-Tj-pTJ"/>
-                                </connections>
-                            </button>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="There are currently no videos downloaded" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="K8K-cn-EfC">
-                                <rect key="frame" x="160" y="275" width="280" height="50"/>
+                                <rect key="frame" x="160" y="243" width="280" height="50"/>
                                 <accessibility key="accessibilityConfiguration" label=""/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="280" id="Lo7-Cb-W7H"/>
@@ -393,61 +329,87 @@
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="pYo-Nb-vrw" firstAttribute="trailing" secondItem="aIT-EB-vrS" secondAttribute="trailing" id="4ns-PK-nLA"/>
                             <constraint firstItem="K8K-cn-EfC" firstAttribute="leading" secondItem="PMR-ii-iVV" secondAttribute="leading" constant="20" id="4uZ-rf-Jpz"/>
                             <constraint firstAttribute="centerX" secondItem="tEo-nb-KXu" secondAttribute="centerX" id="7oZ-zL-9hy"/>
-                            <constraint firstItem="KPs-bm-5ba" firstAttribute="top" secondItem="Oii-9F-lJE" secondAttribute="bottom" constant="10" id="8Qk-QN-rzf"/>
                             <constraint firstItem="iFC-95-ZX8" firstAttribute="top" secondItem="aIT-EB-vrS" secondAttribute="bottom" id="9ZA-1z-Zcf"/>
                             <constraint firstItem="2zw-QW-AUq" firstAttribute="top" secondItem="iFC-95-ZX8" secondAttribute="bottom" id="BG7-Nc-rjZ"/>
-                            <constraint firstItem="pYo-Nb-vrw" firstAttribute="leading" secondItem="aIT-EB-vrS" secondAttribute="leading" id="BUP-RJ-013"/>
-                            <constraint firstItem="qkd-gT-5H9" firstAttribute="top" secondItem="Oii-9F-lJE" secondAttribute="bottom" id="Fcc-lK-zEh"/>
-                            <constraint firstItem="aIT-EB-vrS" firstAttribute="top" secondItem="O7e-Gg-Spv" secondAttribute="bottom" constant="3" id="FeT-fT-cDR"/>
                             <constraint firstItem="2zw-QW-AUq" firstAttribute="top" secondItem="tEo-nb-KXu" secondAttribute="bottom" id="GLf-QX-3cn"/>
                             <constraint firstAttribute="trailing" secondItem="iFC-95-ZX8" secondAttribute="trailing" id="HRW-06-c4H"/>
-                            <constraint firstAttribute="right" secondItem="tiu-x9-6gY" secondAttribute="right" constant="8" id="JHj-wK-BBZ"/>
                             <constraint firstItem="iFC-95-ZX8" firstAttribute="leading" secondItem="PMR-ii-iVV" secondAttribute="leading" id="Spk-fZ-Snf"/>
-                            <constraint firstItem="tiu-x9-6gY" firstAttribute="left" secondItem="qkd-gT-5H9" secondAttribute="left" constant="5" id="Sr0-c5-l2i"/>
-                            <constraint firstItem="iFC-95-ZX8" firstAttribute="top" secondItem="Oii-9F-lJE" secondAttribute="bottom" constant="89" id="VMb-Vd-Ocm"/>
+                            <constraint firstItem="iFC-95-ZX8" firstAttribute="top" secondItem="Oii-9F-lJE" secondAttribute="bottom" constant="45" id="VMb-Vd-Ocm"/>
                             <constraint firstItem="aIT-EB-vrS" firstAttribute="leading" secondItem="iFC-95-ZX8" secondAttribute="leading" id="VcD-gU-aSz"/>
                             <constraint firstAttribute="centerX" secondItem="K8K-cn-EfC" secondAttribute="centerX" id="WeO-rZ-DMV"/>
-                            <constraint firstAttribute="right" secondItem="O7e-Gg-Spv" secondAttribute="right" constant="10" id="YzO-xI-GnH"/>
-                            <constraint firstItem="aIT-EB-vrS" firstAttribute="top" secondItem="QZ2-mJ-Hgt" secondAttribute="bottom" constant="4" id="Zs6-8Q-h40"/>
-                            <constraint firstItem="KPs-bm-5ba" firstAttribute="centerX" secondItem="aIT-EB-vrS" secondAttribute="centerX" id="czk-HX-DuF"/>
                             <constraint firstAttribute="centerY" secondItem="K8K-cn-EfC" secondAttribute="centerY" id="fRX-1c-qSo"/>
                             <constraint firstItem="tEo-nb-KXu" firstAttribute="top" secondItem="aIT-EB-vrS" secondAttribute="bottom" id="kQM-HE-uGE"/>
-                            <constraint firstItem="QZ2-mJ-Hgt" firstAttribute="top" secondItem="Oii-9F-lJE" secondAttribute="bottom" constant="2" id="nS0-WP-Cr2"/>
-                            <constraint firstItem="KPs-bm-5ba" firstAttribute="left" secondItem="QZ2-mJ-Hgt" secondAttribute="right" constant="20" id="oMd-py-XJc"/>
-                            <constraint firstItem="O7e-Gg-Spv" firstAttribute="leading" secondItem="KPs-bm-5ba" secondAttribute="trailing" constant="57" id="pCO-bv-OSL"/>
-                            <constraint firstItem="aIT-EB-vrS" firstAttribute="top" secondItem="pYo-Nb-vrw" secondAttribute="bottom" id="sGg-qt-7y4"/>
                             <constraint firstItem="K8K-cn-EfC" firstAttribute="centerX" secondItem="PMR-ii-iVV" secondAttribute="centerX" id="uzP-jR-fNl"/>
-                            <constraint firstItem="tiu-x9-6gY" firstAttribute="top" secondItem="Oii-9F-lJE" secondAttribute="bottom" constant="6" id="ve2-9e-2B2"/>
-                            <constraint firstItem="QZ2-mJ-Hgt" firstAttribute="leading" secondItem="PMR-ii-iVV" secondAttribute="leadingMargin" constant="-10" id="veQ-gJ-s8p"/>
-                            <constraint firstItem="pYo-Nb-vrw" firstAttribute="top" secondItem="PMR-ii-iVV" secondAttribute="top" id="vnQ-1B-426"/>
                             <constraint firstAttribute="centerX" secondItem="aIT-EB-vrS" secondAttribute="centerX" id="wXg-WM-BJp"/>
                             <constraint firstItem="tEo-nb-KXu" firstAttribute="leading" secondItem="iFC-95-ZX8" secondAttribute="leading" id="yhh-6T-sTK"/>
                             <constraint firstAttribute="trailing" secondItem="K8K-cn-EfC" secondAttribute="trailing" constant="20" id="ywS-Fd-JBs"/>
                         </constraints>
                         <variation key="default">
                             <mask key="constraints">
-                                <exclude reference="oMd-py-XJc"/>
                                 <exclude reference="4uZ-rf-Jpz"/>
                                 <exclude reference="WeO-rZ-DMV"/>
                                 <exclude reference="ywS-Fd-JBs"/>
-                                <exclude reference="pCO-bv-OSL"/>
                             </mask>
                         </variation>
                     </view>
-                    <navigationItem key="navigationItem" title="My Videos" id="pdG-Pb-PFK"/>
+                    <navigationItem key="navigationItem" title="My Videos" id="pdG-Pb-PFK">
+                        <rightBarButtonItems>
+                            <barButtonItem id="mRn-zz-JeH">
+                                <view key="customView" contentMode="scaleToFill" id="tiu-x9-6gY" customClass="DACircularProgressView">
+                                    <rect key="frame" x="550" y="7" width="30" height="30"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qkd-gT-5H9">
+                                            <rect key="frame" x="-5" y="-6" width="41" height="41"/>
+                                            <inset key="contentEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
+                                            <state key="normal" image="ic_download_arrow.png">
+                                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="downloadsButtonPressed:" destination="0fg-49-r6S" eventType="touchUpInside" id="V1h-RQ-hxC"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                    <constraints>
+                                        <constraint firstItem="qkd-gT-5H9" firstAttribute="leading" secondItem="tiu-x9-6gY" secondAttribute="leading" constant="-5" id="P1W-hG-XOW"/>
+                                        <constraint firstItem="qkd-gT-5H9" firstAttribute="top" secondItem="tiu-x9-6gY" secondAttribute="top" constant="-6" id="VUX-3c-elT"/>
+                                        <constraint firstAttribute="width" constant="30" id="Zrl-IR-fAZ"/>
+                                        <constraint firstAttribute="height" constant="30" id="cvg-Ff-mOO"/>
+                                        <constraint firstAttribute="bottom" secondItem="qkd-gT-5H9" secondAttribute="bottom" constant="-5" id="guK-8o-X8A"/>
+                                        <constraint firstAttribute="trailing" secondItem="qkd-gT-5H9" secondAttribute="trailing" constant="-6" id="hLx-oF-6PV"/>
+                                    </constraints>
+                                </view>
+                            </barButtonItem>
+                            <barButtonItem id="CDJ-MU-bev">
+                                <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="O7e-Gg-Spv" userLabel="Select All Button" customClass="OEXCheckBox" customModule="edX" customModuleProvider="target">
+                                    <rect key="frame" x="502" y="2" width="40" height="40"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="40" id="ANs-cc-mDF"/>
+                                        <constraint firstAttribute="height" constant="40" id="YMu-Lx-M1b"/>
+                                    </constraints>
+                                    <inset key="contentEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
+                                    <state key="normal">
+                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="selectAllChanged:" destination="0fg-49-r6S" eventType="valueChanged" id="Vlj-Tj-pTJ"/>
+                                    </connections>
+                                </button>
+                            </barButtonItem>
+                        </rightBarButtonItems>
+                    </navigationItem>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <connections>
                         <outlet property="ConstraintRecentTop" destination="VMb-Vd-Ocm" id="u9H-Oh-UnC"/>
-                        <outlet property="TrailingSpaceCustomProgress" destination="JHj-wK-BBZ" id="L0Q-XR-sfj"/>
                         <outlet property="btn_Downloads" destination="qkd-gT-5H9" id="QuH-yR-v1C"/>
-                        <outlet property="btn_LeftNavigation" destination="QZ2-mJ-Hgt" id="JXr-Dq-fCx"/>
                         <outlet property="btn_SelectAllEditing" destination="O7e-Gg-Spv" id="q8Z-rk-lgB"/>
                         <outlet property="collectionView" destination="WFv-LH-THx" id="Wzj-eG-S4X"/>
                         <outlet property="customEditing" destination="yZm-m7-fVH" id="i77-KH-FeW"/>
                         <outlet property="customProgressView" destination="tiu-x9-6gY" id="jLI-hS-iqJ"/>
-                        <outlet property="lbl_NavTitle" destination="KPs-bm-5ba" id="j6S-jJ-fS9"/>
                         <outlet property="lbl_NoVideo" destination="K8K-cn-EfC" id="Mw6-f3-g6J"/>
                         <outlet property="lbl_videoHeader" destination="vAF-sO-Tjz" id="FUk-fz-52x"/>
                         <outlet property="recentEditViewHeight" destination="y59-fs-o6j" id="N7H-bz-46v"/>
@@ -458,7 +420,6 @@
                         <outlet property="videoVideo" destination="rNo-KV-qy8" id="7Ne-ky-sKm"/>
                         <outlet property="videoViewHeight" destination="E5T-iI-bXL" id="3Kb-Lg-pNA"/>
                         <outlet property="video_containerView" destination="h57-PP-XUC" id="AAe-yZ-A5h"/>
-                        <outlet property="view_NavBG" destination="pYo-Nb-vrw" id="9df-8N-zUx"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ewI-Ns-cyJ" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Source/OEXMyVideosViewController.storyboard
+++ b/Source/OEXMyVideosViewController.storyboard
@@ -3,7 +3,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
-        <capability name="Navigation items with more than one left or right bar item" minToolsVersion="7.0"/>
     </dependencies>
     <scenes>
         <!--My Videos-->
@@ -354,62 +353,12 @@
                             </mask>
                         </variation>
                     </view>
-                    <navigationItem key="navigationItem" title="My Videos" id="pdG-Pb-PFK">
-                        <rightBarButtonItems>
-                            <barButtonItem id="mRn-zz-JeH">
-                                <view key="customView" contentMode="scaleToFill" id="tiu-x9-6gY" customClass="DACircularProgressView">
-                                    <rect key="frame" x="550" y="7" width="30" height="30"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    <subviews>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qkd-gT-5H9">
-                                            <rect key="frame" x="-5" y="-6" width="41" height="41"/>
-                                            <inset key="contentEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
-                                            <state key="normal" image="ic_download_arrow.png">
-                                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                            </state>
-                                            <connections>
-                                                <action selector="downloadsButtonPressed:" destination="0fg-49-r6S" eventType="touchUpInside" id="V1h-RQ-hxC"/>
-                                            </connections>
-                                        </button>
-                                    </subviews>
-                                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                                    <constraints>
-                                        <constraint firstItem="qkd-gT-5H9" firstAttribute="leading" secondItem="tiu-x9-6gY" secondAttribute="leading" constant="-5" id="P1W-hG-XOW"/>
-                                        <constraint firstItem="qkd-gT-5H9" firstAttribute="top" secondItem="tiu-x9-6gY" secondAttribute="top" constant="-6" id="VUX-3c-elT"/>
-                                        <constraint firstAttribute="width" constant="30" id="Zrl-IR-fAZ"/>
-                                        <constraint firstAttribute="height" constant="30" id="cvg-Ff-mOO"/>
-                                        <constraint firstAttribute="bottom" secondItem="qkd-gT-5H9" secondAttribute="bottom" constant="-5" id="guK-8o-X8A"/>
-                                        <constraint firstAttribute="trailing" secondItem="qkd-gT-5H9" secondAttribute="trailing" constant="-6" id="hLx-oF-6PV"/>
-                                    </constraints>
-                                </view>
-                            </barButtonItem>
-                            <barButtonItem id="CDJ-MU-bev">
-                                <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="O7e-Gg-Spv" userLabel="Select All Button" customClass="OEXCheckBox" customModule="edX" customModuleProvider="target">
-                                    <rect key="frame" x="502" y="2" width="40" height="40"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="40" id="ANs-cc-mDF"/>
-                                        <constraint firstAttribute="height" constant="40" id="YMu-Lx-M1b"/>
-                                    </constraints>
-                                    <inset key="contentEdgeInsets" minX="5" minY="5" maxX="5" maxY="5"/>
-                                    <state key="normal">
-                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                    </state>
-                                    <connections>
-                                        <action selector="selectAllChanged:" destination="0fg-49-r6S" eventType="valueChanged" id="Vlj-Tj-pTJ"/>
-                                    </connections>
-                                </button>
-                            </barButtonItem>
-                        </rightBarButtonItems>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" title="My Videos" id="pdG-Pb-PFK"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <connections>
                         <outlet property="ConstraintRecentTop" destination="VMb-Vd-Ocm" id="u9H-Oh-UnC"/>
-                        <outlet property="btn_Downloads" destination="qkd-gT-5H9" id="QuH-yR-v1C"/>
-                        <outlet property="btn_SelectAllEditing" destination="O7e-Gg-Spv" id="q8Z-rk-lgB"/>
                         <outlet property="collectionView" destination="WFv-LH-THx" id="Wzj-eG-S4X"/>
                         <outlet property="customEditing" destination="yZm-m7-fVH" id="i77-KH-FeW"/>
-                        <outlet property="customProgressView" destination="tiu-x9-6gY" id="jLI-hS-iqJ"/>
                         <outlet property="lbl_NoVideo" destination="K8K-cn-EfC" id="Mw6-f3-g6J"/>
                         <outlet property="lbl_videoHeader" destination="vAF-sO-Tjz" id="FUk-fz-52x"/>
                         <outlet property="recentEditViewHeight" destination="y59-fs-o6j" id="N7H-bz-46v"/>
@@ -429,7 +378,6 @@
     </scenes>
     <resources>
         <image name="bt_scrollbar_tap.png" width="229" height="80"/>
-        <image name="ic_download_arrow.png" width="44" height="44"/>
         <image name="ic_partiallywatched.png" width="12" height="12"/>
     </resources>
 </document>

--- a/Source/OEXRouter.m
+++ b/Source/OEXRouter.m
@@ -196,13 +196,14 @@ OEXRegistrationViewControllerDelegate
     OEXMyVideosSubSectionViewController* vc = [[UIStoryboard storyboardWithName:@"OEXMyVideosSubSectionViewController" bundle:nil] instantiateViewControllerWithIdentifier:@"MyVideosSubsection"];
     vc.course = course;
     vc.arr_CourseData = courseData;
+    vc.environment = self.environment;
     [controller.navigationController pushViewController:vc animated:YES];
 }
 
 - (void)showMyVideos {
     OEXMyVideosViewController* videoController = [[UIStoryboard storyboardWithName:@"OEXMyVideosViewController" bundle:nil]instantiateViewControllerWithIdentifier:@"MyVideos"];
     NSAssert( self.revealController != nil, @"oops! must have a revealViewController" );
-    videoController.environment = [[OEXMyVideosViewControllerEnvironment alloc] initWithInterface:self.environment.interface networkManager:self.environment.networkManager router:self];
+    videoController.environment = self.environment;
     [self showContentStackWithRootController:videoController animated:YES];
 }
 

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -25,7 +25,7 @@
 /* Acessibility label for the download progress button. {percent_complete} is an already localized numeric percentage like "44%" */
 "ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON##{other}" = "Downloads in progress: {percent_complete}";
 /* Acessibility hint for the download progress button. */
-"ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON_HINT" = "View current downloads";
+"ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON_HINT" = "Double tap to View current downloads";
 /* Accessibility hint for video download list row cells. {video_name} is the name of video being downloaded. {percent_complete} is an already localized numeric percentage like "44%". */
 "ACCESSIBILITY_DOWNLOAD_VIEW_CELL##{one}" = "Downloading {video_name}. {percent_complete} percent complete.";
 /* Accessibility hint for video download list row cells. {video_name} is the name of video being downloaded. {percent_complete} is an already localized numeric percentage like "44%". */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -25,7 +25,7 @@
 /* Acessibility label for the download progress button. {percent_complete} is an already localized numeric percentage like "44%" */
 "ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON##{other}" = "Downloads in progress: {percent_complete}";
 /* Acessibility hint for the download progress button. */
-"ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON_HINT" = "Double tap to View current downloads";
+"ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON_HINT" = "Double tap to view current downloads";
 /* Accessibility hint for video download list row cells. {video_name} is the name of video being downloaded. {percent_complete} is an already localized numeric percentage like "44%". */
 "ACCESSIBILITY_DOWNLOAD_VIEW_CELL##{one}" = "Downloading {video_name}. {percent_complete} percent complete.";
 /* Accessibility hint for video download list row cells. {video_name} is the name of video being downloaded. {percent_complete} is an already localized numeric percentage like "44%". */


### PR DESCRIPTION
### Description

[MA-2807](https://openedx.atlassian.net/browse/MA-2807)

Mock navigation has been removed from My Videos, and native navigation bar is not used instead. All navigation elements have also been assigned accessibility labels as needed.

### Notes

N/A

### How to test this PR

- Turn on VO
- Navigate to My Videos
- Items in navigation bar should be pronounced in consistency with other screens.

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @saeedbashir 
- [x] Code review: @BenjiLee 
