### PR TITLE
Removed hardcoded edx string swap

### DIFF
--- a/Source/OEXRegistrationFormField.m
+++ b/Source/OEXRegistrationFormField.m
@@ -42,10 +42,6 @@
         self.defaultValue = dictionary[@"defaultValue"];
         self.instructions = dictionary[@"instructions"];
         self.label = dictionary[@"label"];
-        NSString *platformName = [[OEXConfig sharedConfig] platformName];
-        if (platformName) {
-            self.label = [self.label stringByReplacingOccurrencesOfString:@"edX" withString:platformName];
-        }
         if (self.instructions.length > 0) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 NSAttributedString *attributedLabel = [[NSAttributedString alloc] initWithData:[self.instructions dataUsingEncoding:NSUTF8StringEncoding]


### PR DESCRIPTION
Follow up from https://github.com/edx/edx-app-ios/pull/812


- [ ] Code review: @saeedbashir 


Oddly, this was never used. I don't think any of the labels we used ever had edX hardcoded in it.

I also checked for `stringByReplacingOccurrencesOfString:@"edX"` but didn't find anymore so I hope this is the last one.