### PR TITLE
Filter enrollments/courses by organization code

### DIFF
--- a/Source/Core/Code/OEXConfig.h
+++ b/Source/Core/Code/OEXConfig.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString*)platformName;
 /// User facing platform web destination, like "edx.org"
 - (NSString*)platformDestinationName;
-- (NSString*)organizationCode;
+- (nullable NSString*)organizationCode;
 // Network
 - (nullable NSURL*)apiHostURL;
 - (nullable NSString*)feedbackEmailAddress;

--- a/Source/Core/Code/OEXConfig.h
+++ b/Source/Core/Code/OEXConfig.h
@@ -47,6 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString*)platformName;
 /// User facing platform web destination, like "edx.org"
 - (NSString*)platformDestinationName;
+- (NSString*)organizationCode;
 // Network
 - (nullable NSURL*)apiHostURL;
 - (nullable NSString*)feedbackEmailAddress;

--- a/Source/Core/Code/OEXConfig.m
+++ b/Source/Core/Code/OEXConfig.m
@@ -16,6 +16,7 @@ static NSString* const OEXEnvironmentDisplayName = @"ENVIRONMENT_DISPLAY_NAME";
 static NSString* const OEXPlatformName = @"PLATFORM_NAME";
 static NSString* const OEXPlatformDestinationName = @"PLATFORM_DESTINATION_NAME";
 static NSString* const OEXFeedbackEmailAddress = @"FEEDBACK_EMAIL_ADDRESS";
+static NSString* const OEXOrganizationCode = @"ORGANIZATION_CODE";
 
 static NSString* const OEXOAuthClientID = @"OAUTH_CLIENT_ID";
 
@@ -106,6 +107,10 @@ static OEXConfig* sSharedConfig;
 
 - (NSString*)platformDestinationName {
     return [self stringForKey:OEXPlatformDestinationName] ?: @"example.com";
+}
+
+- (NSString*)organizationCode {
+    return [self stringForKey:OEXOrganizationCode];
 }
 
 - (NSString*)feedbackEmailAddress {

--- a/Source/CourseCatalogAPI.swift
+++ b/Source/CourseCatalogAPI.swift
@@ -33,11 +33,11 @@ public struct CourseCatalogAPI {
         case Org = "org"
     }
     
-    public static func getCourseCatalog(userID: String, page : Int, organizationCode: String) -> NetworkRequest<Paginated<[OEXCourse]>> {
+    public static func getCourseCatalog(userID: String, page : Int, organizationCode: String?) -> NetworkRequest<Paginated<[OEXCourse]>> {
         var query = [Params.Mobile.rawValue: JSON(true), Params.User.rawValue: JSON(userID)]
  
-        if (organizationCode != "") {
-            query[Params.Org.rawValue] = JSON(organizationCode)
+        if (!(organizationCode ?? "").isEmpty) {
+            query[Params.Org.rawValue] = JSON(organizationCode!)
         }
         
         return NetworkRequest(

--- a/Source/CourseCatalogAPI.swift
+++ b/Source/CourseCatalogAPI.swift
@@ -30,16 +30,20 @@ public struct CourseCatalogAPI {
         case CourseID = "course_id"
         case EmailOptIn = "email_opt_in"
         case Mobile = "mobile"
+        case Org = "org"
     }
     
-    public static func getCourseCatalog(userID: String, page : Int) -> NetworkRequest<Paginated<[OEXCourse]>> {
+    public static func getCourseCatalog(userID: String, page : Int, organizationCode: String) -> NetworkRequest<Paginated<[OEXCourse]>> {
+        var query = [Params.Mobile.rawValue: JSON(true), Params.User.rawValue: JSON(userID)]
+ 
+        if (organizationCode != "") {
+            query[Params.Org.rawValue] = JSON(organizationCode)
+        }
+        
         return NetworkRequest(
             method: .GET,
             path : "api/courses/v1/courses/",
-            query : [
-                Params.Mobile.rawValue: JSON(true),
-                Params.User.rawValue: JSON(userID),
-            ],
+            query : query,
             requiresAuth : true,
             deserializer: .JSONResponse(coursesDeserializer)
         ).paginated(page: page)

--- a/Source/CourseCatalogAPI.swift
+++ b/Source/CourseCatalogAPI.swift
@@ -35,9 +35,11 @@ public struct CourseCatalogAPI {
     
     public static func getCourseCatalog(userID: String, page : Int, organizationCode: String?) -> NetworkRequest<Paginated<[OEXCourse]>> {
         var query = [Params.Mobile.rawValue: JSON(true), Params.User.rawValue: JSON(userID)]
- 
-        if (!(organizationCode ?? "").isEmpty) {
-            query[Params.Org.rawValue] = JSON(organizationCode!)
+        
+        if let orgCode = organizationCode {
+            if (!(orgCode ?? "").isEmpty) {
+                query[Params.Org.rawValue] = JSON(organizationCode!)
+            }
         }
         
         return NetworkRequest(

--- a/Source/CourseCatalogViewController.swift
+++ b/Source/CourseCatalogViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class CourseCatalogViewController: UIViewController, CoursesTableViewControllerDelegate {
-    typealias Environment = protocol<NetworkManagerProvider, OEXRouterProvider, OEXSessionProvider>
+    typealias Environment = protocol<NetworkManagerProvider, OEXRouterProvider, OEXSessionProvider, OEXConfigProvider>
     
     private let environment : Environment
     private let tableController : CoursesTableViewController
@@ -31,7 +31,7 @@ class CourseCatalogViewController: UIViewController, CoursesTableViewControllerD
     private lazy var paginationController : PaginationController<OEXCourse> = {
         let username = self.environment.session.currentUser?.username ?? ""
         precondition(username != "", "Shouldn't be showing course catalog without a logged in user")
-        let organizationCode = OEXConfig.sharedConfig().organizationCode()
+        let organizationCode =  self.environment.config.organizationCode()
         
         let paginator = WrappedPaginator(networkManager: self.environment.networkManager) { page in
             return CourseCatalogAPI.getCourseCatalog(username, page: page, organizationCode: organizationCode)

--- a/Source/CourseCatalogViewController.swift
+++ b/Source/CourseCatalogViewController.swift
@@ -31,9 +31,10 @@ class CourseCatalogViewController: UIViewController, CoursesTableViewControllerD
     private lazy var paginationController : PaginationController<OEXCourse> = {
         let username = self.environment.session.currentUser?.username ?? ""
         precondition(username != "", "Shouldn't be showing course catalog without a logged in user")
+        let organizationCode = OEXConfig.sharedConfig().organizationCode()
         
         let paginator = WrappedPaginator(networkManager: self.environment.networkManager) { page in
-            return CourseCatalogAPI.getCourseCatalog(username, page: page)
+            return CourseCatalogAPI.getCourseCatalog(username, page: page, organizationCode: organizationCode)
         }
         return PaginationController(paginator: paginator, tableView: self.tableController.tableView)
     }()

--- a/Source/CoursesAPI.swift
+++ b/Source/CoursesAPI.swift
@@ -15,10 +15,14 @@ struct CoursesAPI {
         return (json.array?.flatMap { UserCourseEnrollment(json: $0) }).toResult()
     }
     
-    static func getUserEnrollments(username: String) -> NetworkRequest<[UserCourseEnrollment]> {
+    static func getUserEnrollments(username: String, organizationCode: String) -> NetworkRequest<[UserCourseEnrollment]> {
+        var path = "api/mobile/v0.5/users/{username}/course_enrollments/".oex_formatWithParameters(["username": username])
+        if (organizationCode != "") {
+            path = "api/mobile/v0.5/users/{username}/course_enrollments/?org={org}".oex_formatWithParameters(["username": username, "org": organizationCode])
+        }
         return NetworkRequest(
             method: .GET,
-            path: "api/mobile/v0.5/users/{username}/course_enrollments/".oex_formatWithParameters(["username": username]),
+            path: path,
             requiresAuth: true,
             deserializer: .JSONResponse(enrollmentsDeserializer)
         )

--- a/Source/CoursesAPI.swift
+++ b/Source/CoursesAPI.swift
@@ -17,8 +17,10 @@ struct CoursesAPI {
     
     static func getUserEnrollments(username: String, organizationCode: String?) -> NetworkRequest<[UserCourseEnrollment]> {
         var path = "api/mobile/v0.5/users/{username}/course_enrollments/".oex_formatWithParameters(["username": username])
-        if (!(organizationCode ?? "").isEmpty) {
-            path = "api/mobile/v0.5/users/{username}/course_enrollments/?org={org}".oex_formatWithParameters(["username": username, "org": organizationCode!])
+        if let orgCode = organizationCode {
+            if (!(orgCode ?? "").isEmpty) {
+                path = "api/mobile/v0.5/users/{username}/course_enrollments/?org={org}".oex_formatWithParameters(["username": username, "org": organizationCode!])
+            }
         }
         return NetworkRequest(
             method: .GET,

--- a/Source/CoursesAPI.swift
+++ b/Source/CoursesAPI.swift
@@ -15,10 +15,10 @@ struct CoursesAPI {
         return (json.array?.flatMap { UserCourseEnrollment(json: $0) }).toResult()
     }
     
-    static func getUserEnrollments(username: String, organizationCode: String) -> NetworkRequest<[UserCourseEnrollment]> {
+    static func getUserEnrollments(username: String, organizationCode: String?) -> NetworkRequest<[UserCourseEnrollment]> {
         var path = "api/mobile/v0.5/users/{username}/course_enrollments/".oex_formatWithParameters(["username": username])
-        if (organizationCode != "") {
-            path = "api/mobile/v0.5/users/{username}/course_enrollments/?org={org}".oex_formatWithParameters(["username": username, "org": organizationCode])
+        if (!(organizationCode ?? "").isEmpty) {
+            path = "api/mobile/v0.5/users/{username}/course_enrollments/?org={org}".oex_formatWithParameters(["username": username, "org": organizationCode!])
         }
         return NetworkRequest(
             method: .GET,

--- a/Source/EnrollmentManager.swift
+++ b/Source/EnrollmentManager.swift
@@ -83,13 +83,14 @@ public class EnrollmentManager : NSObject {
     
     private func setupFeedWithUserDetails(userDetails: OEXUserDetails) {
         guard let username = userDetails.username else { return }
-        let feed = freshFeedWithUsername(username)
+        let organizationCode = OEXConfig.sharedConfig().organizationCode()
+        let feed = freshFeedWithUsername(username, organizationCode: organizationCode)
         enrollmentFeed.backWithFeed(feed.map {x in x})
         enrollmentFeed.refresh()
     }
     
-    func freshFeedWithUsername(username: String) -> Feed<[UserCourseEnrollment]> {
-        let request = CoursesAPI.getUserEnrollments(username)
+    func freshFeedWithUsername(username: String, organizationCode: String) -> Feed<[UserCourseEnrollment]> {
+        let request = CoursesAPI.getUserEnrollments(username, organizationCode: organizationCode)
         return Feed(request: request, manager: networkManager, persistResponse: true)
     }
 }

--- a/Source/EnrollmentManager.swift
+++ b/Source/EnrollmentManager.swift
@@ -12,10 +12,12 @@ public class EnrollmentManager : NSObject {
     private let interface: OEXInterface?
     private let networkManager : NetworkManager
     private let enrollmentFeed = BackedFeed<[UserCourseEnrollment]?>()
+    private let config: OEXConfig
     
-    public init(interface: OEXInterface?, networkManager: NetworkManager) {
+    public init(interface: OEXInterface?, networkManager: NetworkManager, config: OEXConfig) {
         self.interface = interface
         self.networkManager = networkManager
+        self.config = config
         
         super.init()
         
@@ -83,7 +85,7 @@ public class EnrollmentManager : NSObject {
     
     private func setupFeedWithUserDetails(userDetails: OEXUserDetails) {
         guard let username = userDetails.username else { return }
-        let organizationCode = OEXConfig.sharedConfig().organizationCode()
+        let organizationCode = self.config.organizationCode()
         let feed = freshFeedWithUsername(username, organizationCode: organizationCode)
         enrollmentFeed.backWithFeed(feed.map {x in x})
         enrollmentFeed.refresh()

--- a/Source/EnrollmentManager.swift
+++ b/Source/EnrollmentManager.swift
@@ -89,7 +89,7 @@ public class EnrollmentManager : NSObject {
         enrollmentFeed.refresh()
     }
     
-    func freshFeedWithUsername(username: String, organizationCode: String) -> Feed<[UserCourseEnrollment]> {
+    func freshFeedWithUsername(username: String, organizationCode: String?) -> Feed<[UserCourseEnrollment]> {
         let request = CoursesAPI.getUserEnrollments(username, organizationCode: organizationCode)
         return Feed(request: request, manager: networkManager, persistResponse: true)
     }

--- a/Source/OEXEnvironment.m
+++ b/Source/OEXEnvironment.m
@@ -98,7 +98,7 @@
             OEXPushSettingsManager* pushSettingsManager = [[OEXPushSettingsManager alloc] init];
             EnrollmentManager* enrollmentManager =
             [[EnrollmentManager alloc] initWithInterface:[OEXInterface sharedInterface]
-                                          networkManager:env.networkManager];
+                                          networkManager:env.networkManager config:[OEXConfig sharedConfig]];
             UserProfileManager* userProfileManager =
             [[UserProfileManager alloc]
              initWithNetworkManager:env.networkManager

--- a/Test/EnrollmentManagerTests.swift
+++ b/Test/EnrollmentManagerTests.swift
@@ -21,7 +21,7 @@ class EnrollmentManagerTests : XCTestCase {
             return (nil, enrollments)
         }
         
-        let manager = EnrollmentManager(interface: nil, networkManager: environment.networkManager)
+        let manager = EnrollmentManager(interface: nil, networkManager: environment.networkManager, config: environment.config)
         let feed = manager.feed
         // starts empty
         XCTAssertNil(feed.output.value)

--- a/Test/MockEnrollmentManager.swift
+++ b/Test/MockEnrollmentManager.swift
@@ -36,7 +36,7 @@ class MockEnrollmentManager: EnrollmentManager {
         }
     }
     
-    override func freshFeedWithUsername(username: String, organizationCode: String) -> Feed<[UserCourseEnrollment]> {
+    override func freshFeedWithUsername(username: String, organizationCode: String?) -> Feed<[UserCourseEnrollment]> {
         return Feed {[unowned self] in
             $0.backWithStream(self.enrollmentSink)
             return

--- a/Test/MockEnrollmentManager.swift
+++ b/Test/MockEnrollmentManager.swift
@@ -36,7 +36,7 @@ class MockEnrollmentManager: EnrollmentManager {
         }
     }
     
-    override func freshFeedWithUsername(username: String) -> Feed<[UserCourseEnrollment]> {
+    override func freshFeedWithUsername(username: String, organizationCode: String) -> Feed<[UserCourseEnrollment]> {
         return Feed {[unowned self] in
             $0.backWithStream(self.enrollmentSink)
             return

--- a/Test/TestRouterEnvironment.swift
+++ b/Test/TestRouterEnvironment.swift
@@ -32,7 +32,7 @@ class TestRouterEnvironment : RouterEnvironment {
         let analytics = OEXAnalytics()
         
         
-        let mockEnrollmentManager = MockEnrollmentManager(interface: interface, networkManager: mockNetworkManager)
+        let mockEnrollmentManager = MockEnrollmentManager(interface: interface, networkManager: mockNetworkManager, config: config)
         self.mockEnrollmentManager = mockEnrollmentManager
         
         let mockCourseDataManager = MockCourseDataManager(


### PR DESCRIPTION
### Description

[MA-OSPR-1499](https://openedx.atlassian.net/browse/OSPR-1499)

Added ORGANIZATION_CODE flag in custom config files and logic to filter displayed courses and enrollments respectively.

[This is the pull request for the Android version](https://github.com/edx/edx-app-android/pull/829)

### Notes

- The app is not dependant on this flag.
- When trying to make rebase to make a single commit the pull request closed, making a new pull request with previous [comments](https://github.com/edx/edx-app-ios/pull/810) about nullable organizationCode, change queryDict to query and remove singleton from api calls and instead add organizationCode as param.

### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the 👍

- [ ] Code review: @saeedbashir
- [ ] Code review: @danialzahid94 
- [ ] Code review: @BenjiLee 

