### PR TITLE
Fix crash: user can open downloaded video

### DIFF
--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -61,12 +61,20 @@
             self.name = [Strings untitled];
         }
         
+        // The new course outline API sends the video info as encodings instead of as a single video_url.
+        // Once finish the transition to the new API we can remove setting the video url from the top level
+        NSString* videoURL = [summary objectForKey:@"video_url"];
+        NSNumber* videoSize = [summary objectForKey:@"size"];
+        
         NSDictionary* rawEncodings = OEXSafeCastAsClass(summary[@"encoded_videos"], NSDictionary);
         NSMutableDictionary* encodings = [[NSMutableDictionary alloc] init];
         [rawEncodings enumerateKeysAndObjectsUsingBlock:^(NSString* name, NSDictionary* encodingInfo, BOOL *stop) {
             OEXVideoEncoding* encoding = [[OEXVideoEncoding alloc] initWithDictionary:encodingInfo name:name];
             [encodings safeSetObject:encoding forKey:name];
         }];
+        if(!encodings[OEXVideoEncodingFallback] && videoURL.length > 0) {
+            [encodings safeSetObject:[[OEXVideoEncoding alloc] initWithName:OEXVideoEncodingFallback URL:videoURL size:videoSize] forKey:OEXVideoEncodingFallback];
+        }
         self.encodings = encodings;
 
         self.videoThumbnailURL = [summary objectForKey:@"video_thumbnail_url"];


### PR DESCRIPTION
### Description

[MA-](https://openedx.atlassian.net/browse/MA-)

When a video is downloaded and then opened, the application crashes. Unfortunately, this behavior was accidentally introduced in PR #803 while adding support for Youtube. 

I tested this on the latest version of master as of 10:30pm PST on 17 October, 2016 and manually confirmed on a private server that both downloaded and Youtube videos behave as expected.
### How to test this PR

Try downloading a video by navigating to a video unit in My Courses. Then, navigate to My Videos and try to watch that video. The application will crash.
### Reviewers

If you've been tagged for review, please "Start a review" with the Github GUI. 
- [ ] Code review: @saeedbashir
- [ ] Code review: @danialzahid94
- [ ] Code review: @BenjiLee
