### PR TITLE
Travis should not show shell update warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: objective-c
 
 osx_image: xcode8
 before_script:
-        - rvm get head # https://github.com/travis-ci/travis-ci/issues/6307
+        - rvm get head || true # https://github.com/travis-ci/travis-ci/issues/6307
 
 env:
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: objective-c  
 
 osx_image: xcode8
+before_script:
+        - rvm get head # https://github.com/travis-ci/travis-ci/issues/6307
 
 env:
     matrix:


### PR DESCRIPTION
### Description

At the end of all travis builds, we will no longer see "shell_session_update warning".
### Notes

This fix is discussed in detail here: https://github.com/travis-ci/travis-ci/issues/6307

`/Users/travis/build.sh: line 109: shell_session_update: command not found`
This is resolved by loading rvm if we don't have it on the server. We add a get rvm head || true to before_script in .travis.yml on the recommendation of this discussion. This seems to resolve the issue.
### How to test this PR

Open any travis build of edx-app-ios and you will see "shell_session_update warning" at the end of the build printout. With this fix, you no longer see this warning.
### Reviewers

If you've been tagged for review, please "Start a review" with the Github GUI. 
- [ ] Code review: @saeedbashir
- [ ] Code review: @danialzahid94
- [x] Code review: @BenjiLee
