### PR TITLE
Travis builds should not fail due to 'peer refused channel request' error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)
+    - sleep 5 # https://github.com/travis-ci/travis-ci/issues/4725
 
 branches:
     only:


### PR DESCRIPTION
### Description

This PR fixes an intermittent build error.

### Notes

([example build](https://travis-ci.org/appsembler/edx-app-ios/jobs/169224426)):
```
xcodebuild[1626:6385] Connection peer refused channel request for "dtxproxy:XCTestManager_IDEInterface:XCTestManager_DaemonConnectionInterface"; channel canceled <DTXChannel: 0x7fcb44bb8320>
```
This is resolved by adding more time between tests. We add a `sleep 5` to after_success in .travis.yml on the recommendation of this [discussion](https://github.com/travis-ci/travis-ci/issues/4725). This seems to resolve the issue.

### How to test this PR

Here's an ([example build](https://travis-ci.org/appsembler/edx-app-ios/jobs/169224426)) where this error was triggered.

### Reviewers
If you've been tagged for review, please "Start a review" with the Github GUI. 
- [ ] Code review: @saeedbashir
- [ ] Code review: @danialzahid94
- [x] Code review: @BenjiLee