### PR TITLE
Travis builds should automatically retry up to 3 times if they fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
 
 script:
     - instruments -s devices | grep "iPhone 5s (${IOS_VERSION}" | awk -F '[\[]' '{print $2}' | sed 's/.$//' | xargs open -a "simulator" --args -CurrentDeviceUDID
-    - set -o pipefail && ./gradlew -q $TEST_TASK | xcpretty -c
+    - set -o pipefail
+    - travis_retry ./gradlew -q $TEST_TASK | xcpretty -c
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
### Description

This PR fixes most intermittent build errors by asking Travis to run tests up to 3 times if they fail.
### Notes

The majority of failures contain this error:

`2016-10-21 00:38:44.199 xcodebuild[3012:7482] Error Domain=IDETestOperationsObserverErrorDomain Code=3 "The operation couldn’t be completed. (DTXProxyChannel error 1.) If you believe this error represents a bug, please attach the log file at /Users/travis/Library/Developer/Xcode/DerivedData/edX-exjjepupggxqgdchtzhsvbkvnvpy/Logs/Test/4180ADF2-994D-4B06-8D23-8AA979D8AD6C/Session-edXTests-2016-10-21_003215-f0eCyl.log" UserInfo={NSLocalizedDescription=The operation couldn’t be completed. (DTXProxyChannel error 1.) If you believe this error represents a bug, please attach the log file at /Users/travis/Library/Developer/Xcode/DerivedData/edX-exjjepupggxqgdchtzhsvbkvnvpy/Logs/Test/4180ADF2-994D-4B06-8D23-8AA979D8AD6C/Session-edXTests-2016-10-21_003215-f0eCyl.log}` 

I'm not sure what the root cause of this one is, but I've added `retry_travis` to ensure that failed builds are run again automatically up to 3 times if they fail. This should (almost) always fix this and other intermittent build failures.
### How to test this PR

Run a few builds and see a higher success rate.
### Reviewers

If you've been tagged for review, please "Start a review" with the Github GUI. 
- [x] Code review: @saeedbashir
- [ ] Code review: @danialzahid94
- [ ] Code review: @BenjiLee
