### PR TITLE
Travis should preload simulator faster & avoid simulator timeout failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ osx_image: xcode8
 
 env:
     matrix:
-        - TEST_TASK=testLTRCurrentOS IOS_VERSION=10.0
-        - TEST_TASK=testRTLCurrentOS IOS_VERSION=10.0
-        - TEST_TASK=testLTRPreviousOS IOS_VERSION=9.0
-        - TEST_TASK=testRTLPreviousOS IOS_VERSION=9.0
+        - TEST_TASK=testLTRCurrentOS IOS_VERSION=10.0 IOS_SIMULATOR_VERSION="FD151079-9530-43EE-99E4-39832503E251"
+        - TEST_TASK=testRTLCurrentOS IOS_VERSION=10.0 IOS_SIMULATOR_VERSION="FD151079-9530-43EE-99E4-39832503E251"
+        - TEST_TASK=testLTRPreviousOS IOS_VERSION=9.0 IOS_SIMULATOR_VERSION="EF410F98-CC94-4E06-B350-9C6B539DE6C5"
+        - TEST_TASK=testRTLPreviousOS IOS_VERSION=9.0 IOS_SIMULATOR_VERSION="EF410F98-CC94-4E06-B350-9C6B539DE6C5"
 
 script:
-    - instruments -s devices | grep "iPhone 5s (${IOS_VERSION}" | awk -F '[\[]' '{print $2}' | sed 's/].*//' | open -b 'com.apple.iphonesimulator' --args -CurrentDeviceUDID
+    - open -b 'com.apple.iphonesimulator' --args -CurrentDeviceUDID "${IOS_SIMULATOR_VERSION}"
     - set -o pipefail && ./gradlew -q $TEST_TASK | xcpretty -c
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
         - TEST_TASK=testRTLPreviousOS IOS_VERSION=9.0
 
 script:
-    - instruments -s devices | grep "iPhone 5s (${IOS_VERSION}" | awk -F '[\[]' '{print $2}' | sed 's/].*//' | xargs open -a "simulator" --args -CurrentDeviceUDID
+    - instruments -s devices | grep "iPhone 5s (${IOS_VERSION}" | awk -F '[\[]' '{print $2}' | sed 's/].*//' | open -b 'com.apple.iphonesimulator' --args -CurrentDeviceUDID
     - set -o pipefail && ./gradlew -q $TEST_TASK | xcpretty -c
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
         - TEST_TASK=testRTLPreviousOS IOS_VERSION=9.0
 
 script:
-    - instruments -s devices | grep "iPhone 5s (${IOS_VERSION}" | awk -F '[\[]' '{print $2}' | sed 's/.$//' | xargs open -a "simulator" --args -CurrentDeviceUDID
+    - instruments -s devices | grep "iPhone 5s (${IOS_VERSION}" | awk -F '[\[]' '{print $2}' | sed 's/].*//' | xargs open -a "simulator" --args -CurrentDeviceUDID
     - set -o pipefail && ./gradlew -q $TEST_TASK | xcpretty -c
 
 after_success:


### PR DESCRIPTION
### Description

This shortens travis run time and fixes simulator timeout errors.

### Notes

**simulator bugfix**
```iOSSimulator: Timed out waiting 120 seconds for simulator to boot```
I resolved this by shortening the simulator preload code to open -b 'com.apple.iphonesimulator' --args -CurrentDeviceUDID and by reordering the matrixes so that each simulator is only prelaunced once. This combination solved this issue. 

**faster build**
It speeds up the build a bit. This was confirmed by daniel in #832.

### How to test this PR

Here is an ([example build](https://travis-ci.org/appsembler/edx-app-ios/jobs/169127528)) showing the error. You can also test this by checking if this update speeds up Travis builds.

### Reviewers
If you've been tagged for review, please "Start a review" with the Github GUI. 
- [ ] Code review: @saeedbashir
- [ ] Code review: @danialzahid94
- [ ] Code review: @BenjiLee
