### PR TITLE
Proposal to add filledSecondaryButtonStyle

### DIFF
--- a/Source/OEXStyles+Swift.swift
+++ b/Source/OEXStyles+Swift.swift
@@ -106,6 +106,10 @@ extension OEXStyles {
     var filledPrimaryButtonStyle : ButtonStyle {
         return filledButtonStyle(OEXStyles.sharedStyles().primaryBaseColor())
     }
+    
+    var filledSecondaryButtonStyle : ButtonStyle {
+        return filledButtonStyle(OEXStyles.sharedStyles().secondaryBaseColor())
+    }
 
     func filledButtonStyle(color: UIColor) -> ButtonStyle {
         let buttonMargins : CGFloat = 8


### PR DESCRIPTION
### Description

[OSPR-1552](https://openedx.atlassian.net/browse/OSPR-1552)

This has already been close in this [PR](https://github.com/edx/edx-app-ios/pull/833). But maybe think about it after seeing the attach images.

![screenshot 2016-11-02 10 04 59](https://cloud.githubusercontent.com/assets/3858265/19922122/db43203a-a0e9-11e6-943d-6b099495777d.png)

![screenshot 2016-11-02 09 41 39](https://cloud.githubusercontent.com/assets/3858265/19922123/dcd706aa-a0e9-11e6-8dc5-219ac560bc98.png)

I don't know about you guys but for me it looks better in the second image using filledSecondaryButtonStyle. This is only a convenience method but it can help make some UI changes quicker.

Hope you guys give it some thought (and don't close it because ¯(ツ)/¯).

### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the 👍
- [ ] Code review: @danialzahid94 
- [ ] Code review: @BenjiLee 

