### PR TITLE
Adding fallback as default encoding to view a video in my videos.

### DIFF
--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -32,7 +32,8 @@
 @property (nonatomic, copy) NSString* unitURL;
 @property (nonatomic, assign) BOOL onlyOnWeb;
 @property (nonatomic, strong) NSDictionary* transcripts;
-
+@property (nonatomic, strong) OEXVideoEncoding *defaultEncoding;
+    
 @end
 
 @implementation OEXVideoSummary
@@ -77,6 +78,9 @@
         self.onlyOnWeb = [[summary objectForKey:@"only_on_web"] boolValue];
 
         self.transcripts = [summary objectForKey:@"transcripts"];
+        
+        if (_encodings.count <=0)
+            _defaultEncoding = [[OEXVideoEncoding alloc] initWithName:OEXVideoEncodingFallback URL:[summary objectForKey:@"video_url"] size:[summary objectForKey:@"size"]];
     }
 
     return self;
@@ -118,9 +122,9 @@
             return encoding;
         }
     }
-    // Don't have a known encoding, so just pick one. These are in a dict, but we need to do
-    // something stable, so just do it alphabetically
-    return self.encodings[[self.encodings.allKeys sortedArrayUsingSelector:@selector(compare:)].firstObject];
+    
+    // Don't have a known encoding, so return default encoding
+    return self.defaultEncoding;
 }
 
 - (BOOL) isYoutubeVideo {


### PR DESCRIPTION
### Description

[MA-2965](https://openedx.atlassian.net/browse/MA-2965)

Adding fallback as default encoding to view videos in My Videos, if server didn't return any encoding for a video. In courseware it will be considered as unsupported video but if user has any downloaded video in db without encoding then user can view it.
### Notes

### How to test this PR

### Reviewers
If you've been tagged for review, please "Start a review" with the Github GUI. 
- Code review: @BenjiLee , @danialzahid94 

