### PR TITLE
Accessibility labels for Add Response Screen

### DIFF
--- a/Source/DiscussionNewCommentViewController.swift
+++ b/Source/DiscussionNewCommentViewController.swift
@@ -212,12 +212,25 @@ public class DiscussionNewCommentViewController: UIViewController, UITextViewDel
         switch context {
         case let .Comment(commnet):
             DiscussionHelper.styleAuthorDetails(commnet.author, authorLabel: commnet.authorLabel, createdAt: commnet.createdAt, hasProfileImage: commnet.hasProfileImage, imageURL: commnet.imageURL, authoNameLabel: authorNamelabel, dateLabel: dateLabel, authorButton: authorButton, imageView: authorProfileImage, viewController: self, router: environment.router)
+            setAuthorAccessibility(commnet.author, date: commnet.createdAt)
         case let .Thread(thread):
             DiscussionHelper.styleAuthorDetails(thread.author, authorLabel: thread.authorLabel, createdAt: thread.createdAt, hasProfileImage: thread.hasProfileImage, imageURL: thread.imageURL, authoNameLabel: authorNamelabel, dateLabel: dateLabel, authorButton: authorButton, imageView: authorProfileImage, viewController: self, router: environment.router)
+            setAuthorAccessibility(thread.author, date: thread.createdAt)
         }
     }
     
+    private func setAuthorAccessibility(author: String?, date: NSDate?) {
+        if let author = author, date = date {
+            authorButton.accessibilityLabel = "\(Strings.byAuthor(authorName: author)), \(date.displayDate)"
+            authorButton.accessibilityHint = Strings.accessibilityShowUserProfileHint
+        }
+        
+        dateLabel.isAccessibilityElement = false
+        authorNamelabel.isAccessibilityElement = false
+    }
+    
     public func textViewDidChange(textView: UITextView) {
+        
         self.validateAddButton()
         self.growingTextController.handleTextChange()
     }

--- a/Source/DiscussionNewCommentViewController.swift
+++ b/Source/DiscussionNewCommentViewController.swift
@@ -262,6 +262,7 @@ public class DiscussionNewCommentViewController: UIViewController, UITextViewDel
         
         addCommentButton.applyButtonStyle(OEXStyles.sharedStyles().filledPrimaryButtonStyle, withTitle: buttonTitle)
         self.contentTitleLabel.attributedText = NSAttributedString.joinInNaturalLayout([responseTextViewStyle.attributedStringWithText(titleText), responseTextViewStyle.attributedStringWithText(Strings.asteric)])
+        self.contentTitleLabel.isAccessibilityElement = false
         self.navigationItem.title = navigationItemTitle
             
         if case .Comment(_) = self.context, let thread = thread{

--- a/Source/DiscussionNewCommentViewController.swift
+++ b/Source/DiscussionNewCommentViewController.swift
@@ -244,11 +244,13 @@ public class DiscussionNewCommentViewController: UIViewController, UITextViewDel
             titleText = Strings.addAResponse
             navigationItemTitle = Strings.addResponse
             responseTitle.attributedText = responseTitleStyle.attributedStringWithText(thread.title)
+            contentTextView.accessibilityLabel = Strings.addAResponse
             self.isEndorsed = false
         case let .Comment(comment):
             buttonTitle = Strings.addComment
             titleText = Strings.addAComment
             navigationItemTitle = Strings.addComment
+            contentTextView.accessibilityLabel = Strings.addAComment
             responseTitle.snp_makeConstraints{ (make) -> Void in
                 make.height.equalTo(0)
             }

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -74,6 +74,8 @@
 "ACCESSIBILITY_CLOSE_MENU" = "Close Navigation Menu";
 /* Accessibility label for hiding keyboard*/
 "ACCESSIBILITY_HIDE_KEYBOARD" = "Hide Keyboard";
+/* Accessibility Hint to view user profile*/
+"ACCESSIBILITY_SHOW_USER_PROFILE_HINT" = "Double tap to view user profile";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Accomplishments";
 /* Default text template when user shares an accomplishment */


### PR DESCRIPTION
### Description

[MA-2964](https://openedx.atlassian.net/browse/MA-2964)

Add Response screen has been made a11y compliant by adding VO descriptions to all components.

### Reviewers
If you've been tagged for review, please "Start a review" with the Github GUI. 
- Code review: @saeedbashir, @BenjiLee 

