### PR TITLE
Use 10.1 instead of 10.0 for Xcode 8.1 in travis and gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_script:
 
 env:
     matrix:
-        - TEST_TASK=testLTRCurrentOS IOS_VERSION=10.0
-        - TEST_TASK=testRTLCurrentOS IOS_VERSION=10.0
+        - TEST_TASK=testLTRCurrentOS IOS_VERSION=10.1
+        - TEST_TASK=testRTLCurrentOS IOS_VERSION=10.1
         - TEST_TASK=testLTRPreviousOS IOS_VERSION=9.0
         - TEST_TASK=testRTLPreviousOS IOS_VERSION=9.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -218,7 +218,7 @@ def RTLSchemeForScheme(scheme) {
     return scheme + '-RTL'
 }
 
-def operatingSystems = ["currentOS": "10.0", "previousOS": "9.0"]
+def operatingSystems = ["currentOS": "10.1", "previousOS": "9.0"]
 def directions = ["LTR": scheme, "RTL": RTLSchemeForScheme(scheme)]
 def commands = ["test" : ["record" : false], "recordSnapshots": ["record" : true]] 
 


### PR DESCRIPTION
### Description

Update tests for Xcode 8.1

### Notes

Xcode 8.1 comes with iOS 10.1 installed instead of 10.0.

### How to test this PR

Use Xcode 8.1 and run gradle or push a branch to run travis.

### Reviewers
If you've been tagged for review, please "Start a review" with the Github GUI. 
- [ ] Code review: @danialzahid94

