### PR TITLE
VO fix for modalViewControllers

### DIFF
--- a/Source/RevealViewController.swift
+++ b/Source/RevealViewController.swift
@@ -13,8 +13,6 @@ class RevealViewController: SWRevealViewController, SWRevealViewControllerDelega
 
     // Dims the front content when the side drawer is visible
     private var dimmingOverlay : UIButton!
-    // To prevent overridding of default accessibilityElements on initial load
-    private var isInitialLoad: Bool = true
     
     override init!(rearViewController: UIViewController!, frontViewController: UIViewController!) {
         super.init(rearViewController: rearViewController, frontViewController: frontViewController)
@@ -45,15 +43,6 @@ class RevealViewController: SWRevealViewController, SWRevealViewControllerDelega
             }, forEvents: .TouchUpInside)
         
         super.loadView()
-    }
-    
-    override func viewDidAppear(animated: Bool) {
-        super.viewDidAppear(animated)
-        if isInitialLoad {
-           isInitialLoad = false
-            return
-        }
-        performSelector(#selector(RevealViewController.defaultMenuVOFocus), withObject: nil, afterDelay: 0.4)
     }
     
     private func postNavigationStateChanged(state : OEXSideNavigationState) {


### PR DESCRIPTION
### Description

[MA-2972](https://openedx.atlassian.net/browse/MA-2972)

This PR aims to fix a bug that was causing VO to read elements from the side menu whenever a modalViewController was dismissed.

### How to test this PR

1. Login to edX app. 
2. Tap on user profile section. 
3. Tap on edit button. 
4. Switch on 'VoiceOver'. 
5. Tap on 'Change' button to change photo. 
6. Tap on 'Take photo/Choose a photo'.
7. Dismissing the VC should shift the focus to the on screen elements.

### Reviewers
If you've been tagged for review, please "Start a review" with the Github GUI. 
- Code review: @saeedbashir @BenjiLee 

