### PR TITLE
a11y optimizations for Responses & Comments

### DIFF
--- a/Source/DiscussionCommentsViewController.swift
+++ b/Source/DiscussionCommentsViewController.swift
@@ -61,6 +61,8 @@ class DiscussionCommentCell: UITableViewCell {
         divider.backgroundColor = OEXStyles.sharedStyles().discussionsBackgroundColor
         containerView.backgroundColor = OEXStyles.sharedStyles().neutralWhiteT()
         containerView.applyBorderStyle(BorderStyle())
+        accessibilityTraits = UIAccessibilityTraitHeader
+        bodyTextView.isAccessibilityElement = false
     }
     
     private func addSubViews() {
@@ -235,11 +237,7 @@ class DiscussionCommentCell: UITableViewCell {
             self.authorButton.accessibilityLabel = authorName
             self.authorButton.accessibilityHint = Strings.accessibilityShowUserProfileHint
         }
-        
-        self.bodyTextView.accessibilityTraits = UIAccessibilityTraitHeader
-        self.bodyTextView.isAccessibilityElement = true
     }
-    
 }
 
 protocol DiscussionCommentsViewControllerDelegate: class {

--- a/Source/DiscussionCommentsViewController.swift
+++ b/Source/DiscussionCommentsViewController.swift
@@ -150,7 +150,7 @@ class DiscussionCommentCell: UITableViewCell {
         
         DiscussionHelper.styleAuthorProfileImageView(authorProfileImage)
         
-        setAccessiblity(commentCountOrReportIconButton.attributedTitleForState(.Normal)?.string)
+        setAccessiblity(commentCountOrReportIconButton.currentAttributedTitle?.string)
     }
     
     func useComment(comment : DiscussionComment, inViewController viewController : DiscussionCommentsViewController, index: NSInteger) {
@@ -207,7 +207,7 @@ class DiscussionCommentCell: UITableViewCell {
             make.trailing.equalTo(contentView).offset(-2*StandardHorizontalMargin)
         }
         
-        button.accessibilityHint = report ? "Double tap to unreport." : "Double tap to report."
+        button.accessibilityHint = report ? Strings.Accessibility.discussionUnreportHint : Strings.Accessibility.discussionReportHint
     }
     
     func setAccessiblity(commentCount : String?) {

--- a/Source/DiscussionCommentsViewController.swift
+++ b/Source/DiscussionCommentsViewController.swift
@@ -227,8 +227,13 @@ class DiscussionCommentCell: UITableViewCell {
             accessibilityString.appendContentsOf(Strings.accessibilityBy + " " + author + sentenceSeparator)
         }
         
+        if let endorsed = endorsedLabel.text where !endorsedLabel.hidden {
+            accessibilityString.appendContentsOf(endorsed + sentenceSeparator)
+        }
+        
         if let comments = commentCount {
             accessibilityString.appendContentsOf(comments)
+            commentCountOrReportIconButton.isAccessibilityElement = false
         }
         
         accessibilityLabel = accessibilityString

--- a/Source/DiscussionCommentsViewController.swift
+++ b/Source/DiscussionCommentsViewController.swift
@@ -149,6 +149,8 @@ class DiscussionCommentCell: UITableViewCell {
         layoutIfNeeded()
         
         DiscussionHelper.styleAuthorProfileImageView(authorProfileImage)
+        
+        setAccessiblity(commentCountOrReportIconButton.attributedTitleForState(.Normal)?.string)
     }
     
     func useComment(comment : DiscussionComment, inViewController viewController : DiscussionCommentsViewController, index: NSInteger) {
@@ -182,6 +184,8 @@ class DiscussionCommentCell: UITableViewCell {
         setNeedsLayout()
         layoutIfNeeded()
         DiscussionHelper.styleAuthorProfileImageView(authorProfileImage)
+        
+        setAccessiblity(nil)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -202,6 +206,38 @@ class DiscussionCommentCell: UITableViewCell {
             make.width.equalTo(buttonTitle.singleLineWidth() + StandardHorizontalMargin)
             make.trailing.equalTo(contentView).offset(-2*StandardHorizontalMargin)
         }
+        
+        button.accessibilityHint = report ? "Double tap to unreport." : "Double tap to report."
+    }
+    
+    func setAccessiblity(commentCount : String?) {
+        var accessibilityString = ""
+        let sentenceSeparator = ", "
+        
+        let body = bodyTextView.attributedText.string
+        accessibilityString.appendContentsOf(body + sentenceSeparator)
+            
+        if let date = dateLabel.text {
+            accessibilityString.appendContentsOf(Strings.Accessibility.discussionPostedOn(date: date) + sentenceSeparator)
+        }
+        
+        if let author = authorNameLabel.text {
+            accessibilityString.appendContentsOf(Strings.accessibilityBy + " " + author + sentenceSeparator)
+        }
+        
+        if let comments = commentCount {
+            accessibilityString.appendContentsOf(comments)
+        }
+        
+        accessibilityLabel = accessibilityString
+        
+        if let authorName = authorNameLabel.text {
+            self.authorButton.accessibilityLabel = authorName
+            self.authorButton.accessibilityHint = Strings.accessibilityShowUserProfileHint
+        }
+        
+        self.bodyTextView.accessibilityTraits = UIAccessibilityTraitHeader
+        self.bodyTextView.isAccessibilityElement = true
     }
     
 }
@@ -390,6 +426,7 @@ class DiscussionCommentsViewController: UIViewController, UITableViewDataSource,
                 self?.loadController.state = .Loaded
                 self?.comments = comments
                 self?.tableView.reloadData()
+                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
             }, failure: { [weak self] (error) -> Void in
                 self?.loadController.state = LoadState.failed(error)
         })

--- a/Source/DiscussionHelper.swift
+++ b/Source/DiscussionHelper.swift
@@ -94,6 +94,7 @@ class DiscussionHelper: NSObject {
             // if post is by anonymous user then disable author button (navigating to user profile)
             authorButton.enabled = false
         }
+        authorButton.isAccessibilityElement = authorButton.enabled
         
         imageView.remoteImage = profileImage(hasProfileImage, imageURL: imageURL)
         

--- a/Source/DiscussionNewCommentViewController.swift
+++ b/Source/DiscussionNewCommentViewController.swift
@@ -210,9 +210,9 @@ public class DiscussionNewCommentViewController: UIViewController, UITextViewDel
     
     private func authorDetails() {
         switch context {
-        case let .Comment(commnet):
-            DiscussionHelper.styleAuthorDetails(commnet.author, authorLabel: commnet.authorLabel, createdAt: commnet.createdAt, hasProfileImage: commnet.hasProfileImage, imageURL: commnet.imageURL, authoNameLabel: authorNamelabel, dateLabel: dateLabel, authorButton: authorButton, imageView: authorProfileImage, viewController: self, router: environment.router)
-            setAuthorAccessibility(commnet.author, date: commnet.createdAt)
+        case let .Comment(comment):
+            DiscussionHelper.styleAuthorDetails(comment.author, authorLabel: comment.authorLabel, createdAt: comment.createdAt, hasProfileImage: comment.hasProfileImage, imageURL: comment.imageURL, authoNameLabel: authorNamelabel, dateLabel: dateLabel, authorButton: authorButton, imageView: authorProfileImage, viewController: self, router: environment.router)
+            setAuthorAccessibility(comment.author, date: comment.createdAt)
         case let .Thread(thread):
             DiscussionHelper.styleAuthorDetails(thread.author, authorLabel: thread.authorLabel, createdAt: thread.createdAt, hasProfileImage: thread.hasProfileImage, imageURL: thread.imageURL, authoNameLabel: authorNamelabel, dateLabel: dateLabel, authorButton: authorButton, imageView: authorProfileImage, viewController: self, router: environment.router)
             setAuthorAccessibility(thread.author, date: thread.createdAt)

--- a/Source/DiscussionResponses.storyboard
+++ b/Source/DiscussionResponses.storyboard
@@ -1,8 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="j3M-ve-6uV">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="j3M-ve-6uV">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,48 +23,55 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d5Z-08-ZhJ">
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="144" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="jXd-ka-683">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <prototypes>
                                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="DiscussionPostCell" rowHeight="170" id="XL2-Y8-F3C" customClass="DiscussionPostCell" customModule="edX" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="22" width="375" height="170"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="XL2-Y8-F3C" id="dbX-Af-div">
-                                                    <frame key="frameInset" width="375" height="170"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="170"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Post Title" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6dv-fn-8x8" userLabel="Title Label">
-                                                            <accessibility key="accessibilityConfiguration" label="Title Label"/>
+                                                            <rect key="frame" x="15" y="56" width="87.5" height="25.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="21"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="240" verticalCompressionResistancePriority="250" text="Body Text" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j0K-vv-JYH" userLabel="Body Text Label">
-                                                            <accessibility key="accessibilityConfiguration" label="Body Text Label"/>
+                                                            <rect key="frame" x="15" y="85.5" width="352" height="25.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LAA-Rz-HUh" userLabel="Separator Line">
+                                                            <rect key="frame" x="0.0" y="139" width="375" height="1"/>
                                                             <color key="backgroundColor" red="0.90196079015731812" green="0.90196079015731812" blue="0.90196079015731812" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="1" id="GJe-G3-FR3"/>
                                                             </constraints>
                                                         </view>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eSV-LK-3aD">
+                                                            <rect key="frame" x="0.0" y="140" width="375" height="30"/>
                                                             <subviews>
                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L30-kl-kgU" userLabel="Plus Icon Button" customClass="DiscussionCellButton" customModule="edX" customModuleProvider="target">
+                                                                    <rect key="frame" x="8" y="-2" width="113" height="34"/>
                                                                     <state key="normal" title="+">
                                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     </state>
                                                                 </button>
                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vl3-EK-JID" userLabel="Star Icon Button" customClass="DiscussionCellButton" customModule="edX" customModuleProvider="target">
+                                                                    <rect key="frame" x="131" y="-2" width="113" height="34"/>
                                                                     <state key="normal" title="*">
                                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     </state>
                                                                 </button>
                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9xP-Ud-enT" userLabel="Flag Icon Button" customClass="DiscussionCellButton" customModule="edX" customModuleProvider="target">
+                                                                    <rect key="frame" x="254" y="0.0" width="113" height="30"/>
                                                                     <state key="normal" title="Flag">
                                                                         <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     </state>
@@ -83,33 +93,40 @@
                                                             </constraints>
                                                         </view>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This post is visible to cohort." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5nU-48-Ubc" userLabel="Visibility Label">
+                                                            <rect key="frame" x="15" y="119" width="186" height="17"/>
                                                             <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
                                                             <color key="textColor" red="0.25" green="0.25" blue="0.25" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1Cc-N7-tvJ" userLabel="authorDetailsView">
+                                                            <rect key="frame" x="0.0" y="8" width="375" height="40"/>
                                                             <subviews>
                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="74D-eX-A73">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="135.5" height="40"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="40" id="abG-B0-M1D"/>
                                                                     </constraints>
                                                                 </button>
                                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="t5n-Jc-AJT">
+                                                                    <rect key="frame" x="15" y="0.0" width="40" height="40"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="40" id="Jgg-Sq-4gh"/>
                                                                         <constraint firstAttribute="height" constant="40" id="fhY-p6-GPr"/>
                                                                     </constraints>
                                                                 </imageView>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Staff (Staff)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CWK-zu-5QZ" userLabel="authorNameLabel">
+                                                                    <rect key="frame" x="70" y="0.0" width="65.5" height="13.5"/>
                                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="11"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EFZ-pU-2wk" userLabel="dateLabel">
+                                                                    <rect key="frame" x="70" y="13.5" width="65.5" height="13.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8 responses" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Obq-Kp-AOa" userLabel="Response Count Label">
+                                                                    <rect key="frame" x="287.5" y="0.0" width="79.5" height="17"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                     <color key="textColor" red="0.25" green="0.25" blue="0.25" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
@@ -161,12 +178,12 @@
                                                     </constraints>
                                                     <variation key="default">
                                                         <mask key="constraints">
-                                                            <exclude reference="25y-gz-32g"/>
-                                                            <exclude reference="gvt-r2-Nvf"/>
-                                                            <exclude reference="kAw-6K-aiW"/>
                                                             <exclude reference="GDX-b6-HQf"/>
                                                             <exclude reference="S8d-2a-dSE"/>
                                                             <exclude reference="TPO-tp-PWk"/>
+                                                            <exclude reference="25y-gz-32g"/>
+                                                            <exclude reference="gvt-r2-Nvf"/>
+                                                            <exclude reference="kAw-6K-aiW"/>
                                                         </mask>
                                                     </variation>
                                                 </tableViewCellContentView>
@@ -190,34 +207,41 @@
                                                 <rect key="frame" x="0.0" y="192" width="375" height="195"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="VDM-At-vOL" id="3GX-RL-azA">
-                                                    <frame key="frameInset" width="375" height="195"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="195"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="43m-cs-FaV" userLabel="Container View">
+                                                            <rect key="frame" x="8" y="8" width="359" height="187"/>
                                                             <subviews>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1ma-TW-pTW" userLabel="authorDetailsView">
+                                                                    <rect key="frame" x="0.0" y="8" width="375" height="40"/>
                                                                     <subviews>
                                                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jPy-aI-v6F">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="194.5" height="40"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="height" constant="40" id="weL-oz-nzD"/>
                                                                             </constraints>
                                                                         </button>
                                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="gEr-Iq-8Ht">
+                                                                            <rect key="frame" x="15" y="0.0" width="40" height="40"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="width" constant="40" id="1hG-jF-lIc"/>
                                                                                 <constraint firstAttribute="height" constant="40" id="72X-c7-QUZ"/>
                                                                             </constraints>
                                                                         </imageView>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Answer with checkmark" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Weq-s5-z42">
+                                                                            <rect key="frame" x="70" y="27" width="124.5" height="13.5"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                                             <color key="textColor" red="0.0" green="0.50196081400000003" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Staff (Staff)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lJa-1S-OmS" userLabel="authorNameLabel">
+                                                                            <rect key="frame" x="70" y="0.0" width="124.5" height="13.5"/>
                                                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="11"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FLD-L6-s7e" userLabel="dateLabel">
+                                                                            <rect key="frame" x="70" y="13.5" width="124.5" height="13.5"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                             <nil key="highlightedColor"/>
@@ -243,19 +267,23 @@
                                                                     </constraints>
                                                                 </view>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="agX-Ey-GLs" userLabel="SeparatorLine">
+                                                                    <rect key="frame" x="0.0" y="131" width="359" height="1"/>
                                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="1" id="sur-Ge-JE0"/>
                                                                     </constraints>
                                                                 </view>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4iN-zd-2mp">
+                                                                    <rect key="frame" x="0.0" y="132" width="359" height="30"/>
                                                                     <subviews>
                                                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zjb-dd-or3" userLabel="Plus Icon Button" customClass="DiscussionCellButton" customModule="edX" customModuleProvider="target">
+                                                                            <rect key="frame" x="8" y="-2" width="166.5" height="34"/>
                                                                             <state key="normal" title="+">
                                                                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                             </state>
                                                                         </button>
                                                                         <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5IN-Uy-i9D" userLabel="Flag Icon Button" customClass="DiscussionCellButton" customModule="edX" customModuleProvider="target">
+                                                                            <rect key="frame" x="184.5" y="-2" width="166.5" height="34"/>
                                                                             <state key="normal" title="Flag">
                                                                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                             </state>
@@ -273,8 +301,10 @@
                                                                     </constraints>
                                                                 </view>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iE0-nz-e9c" userLabel="Comment Box">
+                                                                    <rect key="frame" x="0.0" y="162" width="359" height="25"/>
                                                                     <subviews>
                                                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xYB-gy-XN1" userLabel="Comment Button" customClass="DiscussionCellButton" customModule="edX">
+                                                                            <rect key="frame" x="8" y="4" width="343" height="17"/>
                                                                             <state key="normal" title="comments"/>
                                                                             <connections>
                                                                                 <action selector="commentTapped:" destination="j3M-ve-6uV" eventType="touchUpInside" id="s0i-nv-7dD"/>
@@ -293,9 +323,11 @@
                                                                     </constraints>
                                                                 </view>
                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="etT-Cs-95I">
+                                                                    <rect key="frame" x="15" y="96" width="124" height="30"/>
                                                                     <state key="normal" title="Endorsed By Ataff"/>
                                                                 </button>
                                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="240" verticalCompressionResistancePriority="250" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" editable="NO" text="Two lines of text Two lines of text Two lines of text Two lines" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ySm-5w-1UB">
+                                                                    <rect key="frame" x="10" y="55" width="341" height="41"/>
                                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>

--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -696,10 +696,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
             cell.setAccessibility(response)
         }
         
-        
-        
         return cell
-
     }
     
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
@@ -724,7 +721,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
             Icon.UpVote.attributedTextWithStyle(iconStyle, inline : true),
             cellButtonStyle.attributedStringWithText(Strings.vote(count: voteCount))])
         button.setAttributedTitle(buttonText, forState:.Normal)
-        button.accessibilityHint = voted ? "Double tap to un-vote." : "Double tap to vote."
+        button.accessibilityHint = voted ? Strings.Accessibility.discussionUnvoteHint : Strings.Accessibility.discussionVoteHint
     }
     
     private func updateFollowText(button: DiscussionCellButton, following: Bool) {
@@ -732,7 +729,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         let buttonText = NSAttributedString.joinInNaturalLayout([Icon.FollowStar.attributedTextWithStyle(iconStyle, inline : true),
             cellButtonStyle.attributedStringWithText(following ? Strings.discussionUnfollow : Strings.discussionFollow )])
         button.setAttributedTitle(buttonText, forState:.Normal)
-        button.accessibilityHint = following ? "Double tap to unfollow." : "Double tap to follow."
+        button.accessibilityHint = following ? Strings.Accessibility.discussionUnfollowHint : Strings.Accessibility.discussionFollowHint
     }
     
     private func updateReportText(button: DiscussionCellButton, report: Bool) {
@@ -740,7 +737,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         let buttonText = NSAttributedString.joinInNaturalLayout([Icon.ReportFlag.attributedTextWithStyle(iconStyle, inline : true),
             cellButtonStyle.attributedStringWithText(report ? Strings.discussionUnreport : Strings.discussionReport )])
         button.setAttributedTitle(buttonText, forState:.Normal)
-        button.accessibilityHint = report ? "Double tap to unreport." : "Double tap to report."
+        button.accessibilityHint = report ? Strings.Accessibility.discussionUnreportHint : Strings.Accessibility.discussionReportHint
     }
     
     func increaseResponseCount() {

--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -145,6 +145,9 @@ class DiscussionResponseCell: UITableViewCell {
         endorsedByButton.localizedHorizontalContentAlignment = .Leading
 
         containerView.applyBorderStyle(BorderStyle())
+        
+        accessibilityTraits = UIAccessibilityTraitHeader
+        bodyTextView.isAccessibilityElement = false
     }
     
     var endorsed : Bool = false {
@@ -201,11 +204,6 @@ class DiscussionResponseCell: UITableViewCell {
             self.authorButton.accessibilityLabel = authorName
             self.authorButton.accessibilityHint = Strings.accessibilityShowUserProfileHint
         }
-        
-        self.bodyTextView.accessibilityTraits = UIAccessibilityTraitHeader
-        self.bodyTextView.isAccessibilityElement = true
-        
-        
     }
 }
 

--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -61,6 +61,43 @@ class DiscussionPostCell: UITableViewCell {
         authorButton.localizedHorizontalContentAlignment = .Leading
         DiscussionHelper.styleAuthorProfileImageView(authorProfileImage)
     }
+    
+    func setAccessibility(thread: DiscussionThread) {
+        
+        var accessibilityString = ""
+        let sentenceSeparator = ", "
+        
+        if let title = thread.title {
+            accessibilityString.appendContentsOf(title + sentenceSeparator)
+        }
+        
+        if let body = thread.rawBody {
+            accessibilityString.appendContentsOf(body + sentenceSeparator)
+        }
+        
+        if let date = dateLabel.text {
+            accessibilityString.appendContentsOf(Strings.Accessibility.discussionPostedOn(date: date) + sentenceSeparator)
+        }
+        
+        if let author = authorNameLabel.text {
+            accessibilityString.appendContentsOf(Strings.accessibilityBy + " " + author + sentenceSeparator)
+        }
+        
+        if let visibility = visibilityLabel.text {
+            accessibilityString.appendContentsOf(visibility)
+        }
+        
+        if let responseCount = responseCountLabel.text {
+            accessibilityString.appendContentsOf(responseCount)
+        }
+        
+        self.accessibilityLabel = accessibilityString
+        
+        if let authorName = authorNameLabel.text {
+            self.authorButton.accessibilityLabel = authorName
+            self.authorButton.accessibilityHint = Strings.accessibilityShowUserProfileHint
+        }
+    }
 }
 
 class DiscussionResponseCell: UITableViewCell {
@@ -129,6 +166,45 @@ class DiscussionResponseCell: UITableViewCell {
         }
         
         super.updateConstraints()
+        
+    }
+    
+    func setAccessibility(response: DiscussionComment) {
+        
+        var accessibilityString = ""
+        let sentenceSeparator = ". "
+        
+        let body = bodyTextView.attributedText.string
+        accessibilityString.appendContentsOf(body + sentenceSeparator)
+        
+        if let date = dateLabel.text {
+            accessibilityString.appendContentsOf(Strings.Accessibility.discussionPostedOn(date: date) + sentenceSeparator)
+        }
+        
+        if let author = authorNameLabel.text {
+            accessibilityString.appendContentsOf(Strings.accessibilityBy + " " + author + sentenceSeparator)
+        }
+        
+        if endorsedByButton.hidden == false {
+            if let endorsed = endorsedByButton.attributedTitleForState(.Normal)?.string  {
+                accessibilityString.appendContentsOf(endorsed + sentenceSeparator)
+            }
+        }
+        
+        if response.childCount > 0 {
+            accessibilityString.appendContentsOf(Strings.commentsToResponse(count: response.childCount))
+        }
+        
+        self.accessibilityLabel = accessibilityString
+        
+        if let authorName = authorNameLabel.text {
+            self.authorButton.accessibilityLabel = authorName
+            self.authorButton.accessibilityHint = Strings.accessibilityShowUserProfileHint
+        }
+        
+        self.bodyTextView.accessibilityTraits = UIAccessibilityTraitHeader
+        self.bodyTextView.isAccessibilityElement = true
+        
         
     }
 }
@@ -305,7 +381,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
                 self?.loadController?.state = .Loaded
                 self?.responsesDataController.endorsedResponses = responses
                 self?.tableView.reloadData()
-                
+                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
                 if self?.paginationController?.hasNext ?? false { }
                 else {
                     // load unanswered responses
@@ -335,6 +411,8 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
                 self?.loadController?.state = .Loaded
                 self?.responsesDataController.responses = responses
                 self?.tableView.reloadData()
+                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
+                
             }, failure: { [weak self] (error) -> Void in
                 // endorsed responses are loaded in separate request and also populated in different section
                 if self?.responsesDataController.endorsedResponses.count <= 0 {
@@ -455,6 +533,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
                     
                     if let thread: DiscussionThread = result.data {
                         self?.loadedThread(thread)
+                        owner.updateVoteText(cell.voteButton, voteCount: thread.voteCount, voted: thread.voted)
                     }
                     else {
                         self?.showOverlayMessage(DiscussionHelper.messageForError(result.error))
@@ -504,6 +583,11 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
                 }
             }
             }, forEvents: UIControlEvents.TouchUpInside)
+        
+        if let thread = self.thread {
+            cell.setAccessibility(thread)
+        }
+        
         
         return cell
 
@@ -609,7 +693,10 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         
         if let thread = thread {
             DiscussionHelper.updateEndorsedTitle(thread, label: cell.endorsedLabel, textStyle: cell.endorsedTextStyle)
+            cell.setAccessibility(response)
         }
+        
+        
         
         return cell
 
@@ -636,8 +723,8 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         let buttonText = NSAttributedString.joinInNaturalLayout([
             Icon.UpVote.attributedTextWithStyle(iconStyle, inline : true),
             cellButtonStyle.attributedStringWithText(Strings.vote(count: voteCount))])
-        
         button.setAttributedTitle(buttonText, forState:.Normal)
+        button.accessibilityHint = voted ? "Double tap to un-vote." : "Double tap to vote."
     }
     
     private func updateFollowText(button: DiscussionCellButton, following: Bool) {
@@ -645,6 +732,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         let buttonText = NSAttributedString.joinInNaturalLayout([Icon.FollowStar.attributedTextWithStyle(iconStyle, inline : true),
             cellButtonStyle.attributedStringWithText(following ? Strings.discussionUnfollow : Strings.discussionFollow )])
         button.setAttributedTitle(buttonText, forState:.Normal)
+        button.accessibilityHint = following ? "Double tap to unfollow." : "Double tap to follow."
     }
     
     private func updateReportText(button: DiscussionCellButton, report: Bool) {
@@ -652,6 +740,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         let buttonText = NSAttributedString.joinInNaturalLayout([Icon.ReportFlag.attributedTextWithStyle(iconStyle, inline : true),
             cellButtonStyle.attributedStringWithText(report ? Strings.discussionUnreport : Strings.discussionReport )])
         button.setAttributedTitle(buttonText, forState:.Normal)
+        button.accessibilityHint = report ? "Double tap to unreport." : "Double tap to report."
     }
     
     func increaseResponseCount() {

--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -172,7 +172,7 @@ class DiscussionResponseCell: UITableViewCell {
     func setAccessibility(response: DiscussionComment) {
         
         var accessibilityString = ""
-        let sentenceSeparator = ". "
+        let sentenceSeparator = ", "
         
         let body = bodyTextView.attributedText.string
         accessibilityString.appendContentsOf(body + sentenceSeparator)

--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -148,6 +148,7 @@ class DiscussionResponseCell: UITableViewCell {
         
         accessibilityTraits = UIAccessibilityTraitHeader
         bodyTextView.isAccessibilityElement = false
+        endorsedByButton.isAccessibilityElement = false
     }
     
     var endorsed : Bool = false {

--- a/Source/PostsViewController.swift
+++ b/Source/PostsViewController.swift
@@ -482,6 +482,7 @@ class PostsViewController: UIViewController, UITableViewDataSource, UITableViewD
         self.loadController.state = self.posts.isEmpty ? emptyState : .Loaded
         // set visibility of header view
         updateHeaderViewVisibility()
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
     }
 
     func titleForFilter(filter : DiscussionPostsFilter) -> String {

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -20,6 +20,8 @@
 "ACCESSIBILITY_CHECKBOX_HINT_UNCHECKED" = "Tap to select";
 /* Appending By before course organization and number on My Find Courses*/
 "ACCESSIBILITY_BY" = "By";
+/* Accessibility label for posted data of discussion responses*/
+"ACCESSIBILITY.DISCUSSION_POSTED_ON" = "Posted on {date}";
 /* Acessibility label for the download progress button. {percent_complete} is an already localized numeric percentage like "44%" */
 "ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON##{one}" = "Downloads in progress: {percent_complete}";
 /* Acessibility label for the download progress button. {percent_complete} is an already localized numeric percentage like "44%" */
@@ -220,10 +222,14 @@
 "DELETE"="Delete";
 /* Discussion used in the segmented control Creating a new post */
 "DISCUSSION"="Discussion";
+/* Discussion comment overlay message when new comment added */
+"DISCUSSION_COMMENT_POSTED" = "Your comment has been added.";
 /* Title of button to allow user to follow a discussion post */
 "DISCUSSION_FOLLOW"="Follow";
 /* Title of action to report a discussion post/response/comment to the course staff */
 "DISCUSSION_REPORT"="Report";
+/* Discussion response overlay message when new response added */
+"DISCUSSION_THREAD_POSTED" = "Your response has been added.";
 /* Title of the navigation bar when entering the course discussion */
 "DISCUSSION_TOPICS"="Discussion topics";
 /* Title of button to allow user to unfollow a discussion post */
@@ -254,10 +260,6 @@
 "DOWNLOADS"="Downloads";
 /* Overlay message after user chooses to download a video */
 "DOWNLOADING_1_VIDEO"="Downloading 1 video.";
-/* Discussion comment overlay message when new comment added */
-"DISCUSSION_COMMENT_POSTED" = "Your comment has been added.";
-/* Discussion response overlay message when new response added */
-"DISCUSSION_THREAD_POSTED" = "Your response has been added.";
 /* Title for Edit button on My Videos Screen */
 "EDIT" = "Edit";
 /* Alert message shown when user tries to send an email, but email isn't setup */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -22,6 +22,18 @@
 "ACCESSIBILITY_BY" = "By";
 /* Accessibility label for posted data of discussion responses*/
 "ACCESSIBILITY.DISCUSSION_POSTED_ON" = "Posted on {date}";
+/* Accessibility hint for Vote button for discussion responses*/
+"ACCESSIBILITY.DISCUSSION_VOTE_HINT" = "Double tap to vote.";
+/* Accessibility hint for Unvote button for discussion responses*/
+"ACCESSIBILITY.DISCUSSION_UNVOTE_HINT" = "Double tap to unvote.";
+/* Accessibility hint for Report button for discussion responses*/
+"ACCESSIBILITY.DISCUSSION_REPORT_HINT" = "Double tap to report.";
+/* Accessibility hint for Unreport button for discussion responses*/
+"ACCESSIBILITY.DISCUSSION_UNREPORT_HINT" = "Double tap to unreport.";
+/* Accessibility hint for Follow button for discussion responses*/
+"ACCESSIBILITY.DISCUSSION_FOLLOW_HINT" = "Double tap to follow.";
+/* Accessibility hint for Unfollow button for discussion responses*/
+"ACCESSIBILITY.DISCUSSION_UNFOLLOW_HINT" = "Double tap to unfollow.";
 /* Acessibility label for the download progress button. {percent_complete} is an already localized numeric percentage like "44%" */
 "ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON##{one}" = "Downloads in progress: {percent_complete}";
 /* Acessibility label for the download progress button. {percent_complete} is an already localized numeric percentage like "44%" */


### PR DESCRIPTION
### Description

[MA-2963](https://openedx.atlassian.net/browse/MA-2963)

This PR aims to make Responses and Comments screens a11y friendly by integrating VO descriptions and hints to all respective elements of the screens.

### Reviewers
If you've been tagged for review, please "Start a review" with the Github GUI. 
- Code review: @BenjiLee, @saeedbashir 
