### PR TITLE
Stop audio from playing after switching screens

### DIFF
--- a/Source/CutomePlayer/CLVideoPlayerControls.h
+++ b/Source/CutomePlayer/CLVideoPlayerControls.h
@@ -99,6 +99,10 @@ typedef enum
  */
 @property (nonatomic, readonly, getter = isShowing) BOOL showing;
 
+/**
+ Is the parent viewController at the top of the stack?
+ */
+@property (nonatomic) BOOL isVisibile;
 
 /// Are the next/previous buttons hidden
 @property (assign, nonatomic) BOOL hidesNextPrev;

--- a/Source/CutomePlayer/CLVideoPlayerControls.h
+++ b/Source/CutomePlayer/CLVideoPlayerControls.h
@@ -100,7 +100,7 @@ typedef enum
 @property (nonatomic, readonly, getter = isShowing) BOOL showing;
 
 /**
- Is the parent viewController at the top of the stack?
+ Checks if the parent viewController is at the top of the stack
  */
 @property (nonatomic) BOOL isVisibile;
 

--- a/Source/CutomePlayer/CLVideoPlayerControls.m
+++ b/Source/CutomePlayer/CLVideoPlayerControls.m
@@ -1486,6 +1486,10 @@ static const CGFloat iPhoneScreenPortraitWidth = 320.f;
                 [self.moviePlayer setCurrentPlaybackTime:self.moviePlayer.lastPlayedTime];
                 self.moviePlayer.lastPlayedTime = 0;
             }
+            
+            if(!self.isVisibile) {
+                break;
+            }
 
             if(self.video.summary.videoID) {
                 [_dataInterface sendAnalyticsEvents:OEXVideoStateLoading withCurrentTime:0 forVideo:self.video];

--- a/Source/OEXVideoPlayerInterface.m
+++ b/Source/OEXVideoPlayerInterface.m
@@ -250,6 +250,7 @@
     else {
         [_moviePlayerController stop];
     }
+    [self resetPlayer];
     _shouldRotate = NO;
 }
 

--- a/Source/OEXVideoPlayerInterface.m
+++ b/Source/OEXVideoPlayerInterface.m
@@ -240,16 +240,6 @@
     [NSObject cancelPreviousPerformRequestsWithTarget:self];
     [_moviePlayerController setShouldAutoplay:NO];
     
-    // There appears to be an OS bug on iOS 8
-    // where if you don't call "stop" before a movie player view disappears
-    // it can cause a crash
-    // See http://stackoverflow.com/questions/31188035/overreleased-mpmovieplayercontroller-under-arc-in-ios-sdk-8-4-on-ipad
-    if([UIDevice isOSVersionAtLeast9]) {
-        [_moviePlayerController pause];
-    }
-    else {
-        [_moviePlayerController stop];
-    }
     [self resetPlayer];
     _shouldRotate = NO;
 }

--- a/Source/OEXVideoPlayerInterface.m
+++ b/Source/OEXVideoPlayerInterface.m
@@ -240,14 +240,25 @@
     [NSObject cancelPreviousPerformRequestsWithTarget:self];
     [_moviePlayerController setShouldAutoplay:NO];
     
-    [self resetPlayer];
+    // There appears to be an OS bug on iOS 8
+    // where if you don't call "stop" before a movie player view disappears
+    // it can cause a crash
+    // See http://stackoverflow.com/questions/31188035/overreleased-mpmovieplayercontroller-under-arc-in-ios-sdk-8-4-on-ipad
+    if([UIDevice isOSVersionAtLeast9]) {
+        [_moviePlayerController pause];
+    }
+    else {
+        [_moviePlayerController stop];
+    }
     _shouldRotate = NO;
+    _moviePlayerController.controls.isVisibile = NO;
 }
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     [_moviePlayerController setShouldAutoplay:YES];
     _shouldRotate = YES;
+    _moviePlayerController.controls.isVisibile = YES;
 }
 
 - (void)videoPlayerShouldRotate {


### PR DESCRIPTION
### Description

[MA-2405](https://openedx.atlassian.net/browse/MA-2405)

This PR aims to fix an issue with the video player for courseware, where the audio starts playing even if the user moves to the next non-video unit.

### How to test this PR

1) Open a video block in courseware
2) Navigate to next block a little before the video starts playing
3) The audio should not start to play after navigation (Earlier the audio kept playing after navigation to the next block)

### Reviewers
If you've been tagged for review, please "Start a review" with the Github GUI. 
- Code review: @BenjiLee, @saeedbashir 

