### PR TITLE
On announcements, display heading & content as non-optional strings

### DIFF
--- a/Source/CourseAnnouncementsViewController.swift
+++ b/Source/CourseAnnouncementsViewController.swift
@@ -179,9 +179,9 @@ class CourseAnnouncementsViewController: OfflineSupportViewController, UIWebView
         var html:String = String()
         
         for (index,announcement) in announcements.enumerate() {
-                html += "<div class=\"announcement-header\">\(announcement.heading == nil ? "" : announcement.heading!)</div>"
+                html += "<div class=\"announcement-header\">\(announcement.heading ?? "")</div>"
                 html += "<hr class=\"announcement\"/>"
-                html += announcement.content == nil ? "" : announcement.content!
+                html += announcement.content ?? ""
                 if(index + 1 < announcements.count)
                 {
                     html += "<div class=\"announcement-separator\"/></div>"

--- a/Source/CourseAnnouncementsViewController.swift
+++ b/Source/CourseAnnouncementsViewController.swift
@@ -179,9 +179,9 @@ class CourseAnnouncementsViewController: OfflineSupportViewController, UIWebView
         var html:String = String()
         
         for (index,announcement) in announcements.enumerate() {
-                html += "<div class=\"announcement-header\">\(announcement.heading)</div>"
+                html += "<div class=\"announcement-header\">\(announcement.heading == nil ? "" : announcement.heading!)</div>"
                 html += "<hr class=\"announcement\"/>"
-                html += announcement.content ?? ""
+                html += announcement.content == nil ? "" : announcement.content!
                 if(index + 1 < announcements.count)
                 {
                     html += "<div class=\"announcement-separator\"/></div>"


### PR DESCRIPTION
### Description

[MA-](https://openedx.atlassian.net/browse/MA-)

When the heading or content is non-empty, we don't want it to display as, for example: Optional("name")

### Notes

### How to test this PR

All announcement headings have Optional in them. Merge this and that goes away. 