### PR TITLE
Remove screen event for Firebase

### DIFF
--- a/Source/SegmentAnalyticsTracker.swift
+++ b/Source/SegmentAnalyticsTracker.swift
@@ -79,10 +79,6 @@ class SegmentAnalyticsTracker : NSObject, OEXAnalyticsTracker {
         
         SEGAnalytics.sharedAnalytics().screen(screenName, properties: properties)
         
-        if OEXConfig.sharedConfig().isFirebaseEnabled {
-            firebaseTracker.trackEventWithName(screenName, parameters: properties)
-        }
-        
         // adding additional info to event
         if let info = info where info.count > 0 {
             properties = properties.concat(info)


### PR DESCRIPTION
It looks like we are double sending events when we don't want to be.

https://github.com/edx/edx-app-ios/blob/master/Source/SegmentAnalyticsTracker.swift#L83
https://github.com/edx/edx-app-ios/blob/master/Source/SegmentAnalyticsTracker.swift#L65