### PR TITLE
Change edx-app-gradle-plugin repo url from https to ssh

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -58,4 +58,4 @@ def edXAppPluginSetup(url, ref) {
     grgit.checkout(branch : ref)
 }
 
-edXAppPluginSetup('https://github.com/edx/edx-app-gradle-plugin', '2e0516c8b3c4e0d60bff01491bc66c9f0f2eedf4')
+edXAppPluginSetup('git@github.com:edx/edx-app-gradle-plugin.git', '2e0516c8b3c4e0d60bff01491bc66c9f0f2eedf4')


### PR DESCRIPTION
### Description

[OSPR-1682](https://openedx.atlassian.net/browse/OSPR-1682)

This PR changes the url from the repo edx-app-gradle-plugin. Using https the app builds correctly locally but while trying to build with Circle CI the build process fails. When I change it to ssh it works on both. I don't know if this would break in Travis but nothing to lose here and try it.

### Reviewers
- [ ] Code review: @danialzahid94 
- [ ] Code review: @saeedbashir