### PR TITLE
Dropping Fallback video encoding

### DIFF
--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -133,7 +133,7 @@
         OEXVideoEncoding* encoding = self.encodings[name];
         
         NSString *name = [encoding name];
-        if ([name isEqualToString:OEXVideoEncodingMobileHigh] || [name isEqualToString:OEXVideoEncodingMobileLow] || [name isEqualToString:OEXVideoEncodingFallback]) {
+        if ([name isEqualToString:OEXVideoEncodingMobileHigh] || [name isEqualToString:OEXVideoEncodingMobileLow]) {
             return false;
         }
         else if ([[encoding name] isEqualToString:OEXVideoEncodingYoutube]) {
@@ -150,7 +150,7 @@
         OEXVideoEncoding* encoding = self.encodings[name];
         NSString *name = [encoding name];
         // fallback encoding can be with unsupported type like webm
-        if (([encoding URL] && [OEXInterface isURLForVideo:[encoding URL]]) && ([name isEqualToString:OEXVideoEncodingMobileHigh] || [name isEqualToString:OEXVideoEncodingMobileLow] || [name isEqualToString:OEXVideoEncodingFallback])) {
+        if (([encoding URL] && [OEXInterface isURLForVideo:[encoding URL]]) && ([name isEqualToString:OEXVideoEncodingMobileHigh] || [name isEqualToString:OEXVideoEncodingMobileLow])) {
             isSupportedEncoding = true;
             break;
         }

--- a/Test/OEXVideoSummaryTests.m
+++ b/Test/OEXVideoSummaryTests.m
@@ -129,14 +129,14 @@
 }
 
 - (void)testSupportedFallbackEncoding {
-    NSDictionary *fallback = [self encodingWithName:OEXVideoEncodingFallback andUrl:@"https://www.example.com/video.mp4"];
+    NSDictionary *fallback = [self encodingWithName:OEXVideoEncodingMobileLow andUrl:@"https://www.example.com/video.mp4"];
     OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncoding:fallback andOnlyOnWeb:false]];
     
     XCTAssertTrue(summary.isSupportedVideo);
 }
 
 - (void)testUnSupportedFallbackEncoding {
-    NSDictionary *fallback = [self encodingWithName:OEXVideoEncodingFallback andUrl:@"https://www.example.com/video.webm"];
+    NSDictionary *fallback = [self encodingWithName:OEXVideoEncodingFallback andUrl:@"https://www.example.com/video.mp4"];
     OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncoding:fallback andOnlyOnWeb:false]];
     
     XCTAssertFalse(summary.isSupportedVideo);


### PR DESCRIPTION
### Description

[MA-3157](https://openedx.atlassian.net/browse/MA-3157)

We are encouraging to upload all videos by edX video pipeline so that's why we are dropping support fallback encoding. Users can still view their downloaded fallback videos in my videos section.