### PR TITLE
Add invitation only button to course detail view

### DIFF
--- a/Source/CourseCatalogDetailView.swift
+++ b/Source/CourseCatalogDetailView.swift
@@ -18,7 +18,7 @@ class CourseCatalogDetailView : UIView, UIWebViewDelegate {
         let icon : Icon
     }
     
-    typealias Environment = NetworkManagerProvider
+    typealias Environment = NetworkManagerProvider & OEXStylesProvider
     
     fileprivate let environment : Environment
     
@@ -205,10 +205,10 @@ class CourseCatalogDetailView : UIView, UIWebViewDelegate {
     
     var invitationOnlyText: String? {
         get {
-            return self.actionButton.attributedTitle(for: .normal)?.string
+            return actionButton.attributedTitle(for: .normal)?.string
         }
         set {
-            actionButton.applyButtonStyle(style: OEXStyles.shared().filledButtonStyle(color: OEXStyles.shared().neutralBase()), withTitle: newValue)
+            actionButton.applyButtonStyle(style: environment.styles.filledButtonStyle(color: environment.styles.neutralBase()), withTitle: newValue)
             actionButton.isEnabled = false
         }
     }

--- a/Source/CourseCatalogDetailView.swift
+++ b/Source/CourseCatalogDetailView.swift
@@ -202,6 +202,16 @@ class CourseCatalogDetailView : UIView, UIWebViewDelegate {
             actionButton.applyButtonStyle(style: OEXStyles.shared().filledEmphasisButtonStyle, withTitle: newValue)
         }
     }
+    
+    var invitationOnlyText: String? {
+        get {
+            return self.actionButton.attributedTitle(for: .normal)?.string
+        }
+        set {
+            actionButton.applyButtonStyle(style: OEXStyles.shared().filledButtonStyle(color: OEXStyles.shared().neutralBase()), withTitle: newValue)
+            actionButton.isEnabled = false
+        }
+    }
 }
 
 extension CourseCatalogDetailView {

--- a/Source/CourseCatalogDetailViewController.swift
+++ b/Source/CourseCatalogDetailViewController.swift
@@ -67,6 +67,9 @@ class CourseCatalogDetailViewController: UIViewController {
                         completion()
                     }
                 }
+                else if course.invitation_only {
+                    self?.aboutView.invitationOnlyText = Strings.CourseDetail.invitationOnly
+                }
                 else {
                     self?.aboutView.actionText = Strings.CourseDetail.enrollNow
                     self?.aboutView.action = {[weak self] completion in

--- a/Source/CourseCatalogDetailViewController.swift
+++ b/Source/CourseCatalogDetailViewController.swift
@@ -14,7 +14,7 @@ import edXCore
 class CourseCatalogDetailViewController: UIViewController {
     private let courseID: String
     
-    typealias Environment = OEXAnalyticsProvider & DataManagerProvider & NetworkManagerProvider & OEXRouterProvider
+    typealias Environment = OEXAnalyticsProvider & DataManagerProvider & NetworkManagerProvider & OEXRouterProvider & OEXStylesProvider
     
     private let environment: Environment
     private lazy var loadController = LoadStateViewController()
@@ -67,7 +67,7 @@ class CourseCatalogDetailViewController: UIViewController {
                         completion()
                     }
                 }
-                else if course.invitation_only {
+                else if course.invitationOnly {
                     self?.aboutView.invitationOnlyText = Strings.CourseDetail.invitationOnly
                 }
                 else {

--- a/Source/OEXCourse.h
+++ b/Source/OEXCourse.h
@@ -57,7 +57,7 @@ OEXStartType OEXStartTypeForString(NSString* type);
 @property (readonly, nonatomic, copy, nullable) NSString* course_updates;         //  ANNOUNCEMENTS URL
 @property (readonly, nonatomic, copy, nullable) NSString* course_handouts;        //  HANDOUTS URL
 @property (readonly, nonatomic, copy, nullable) NSString* course_about;           // COURSE INFO URL
-@property (readonly, nonatomic) Boolean invitation_only;
+@property (readonly, nonatomic) Boolean invitationOnly;
 @property (readonly, nonatomic, strong, nullable) OEXCoursewareAccess* courseware_access;
 @property (readonly, nonatomic, copy, nullable) NSString* discussionUrl;
 @property (readonly, nonatomic, copy, nullable) NSDictionary<NSString*, CourseMediaInfo*>* mediaInfo;

--- a/Source/OEXCourse.h
+++ b/Source/OEXCourse.h
@@ -57,6 +57,7 @@ OEXStartType OEXStartTypeForString(NSString* type);
 @property (readonly, nonatomic, copy, nullable) NSString* course_updates;         //  ANNOUNCEMENTS URL
 @property (readonly, nonatomic, copy, nullable) NSString* course_handouts;        //  HANDOUTS URL
 @property (readonly, nonatomic, copy, nullable) NSString* course_about;           // COURSE INFO URL
+@property (readonly, nonatomic) Boolean invitation_only;
 @property (readonly, nonatomic, strong, nullable) OEXCoursewareAccess* courseware_access;
 @property (readonly, nonatomic, copy, nullable) NSString* discussionUrl;
 @property (readonly, nonatomic, copy, nullable) NSDictionary<NSString*, CourseMediaInfo*>* mediaInfo;

--- a/Source/OEXCourse.m
+++ b/Source/OEXCourse.m
@@ -84,7 +84,7 @@ NSString* NSStringForOEXStartType(OEXStartType type) {
 @property (nonatomic, copy) NSString* course_updates;         //  ANNOUNCEMENTS
 @property (nonatomic, copy) NSString* course_handouts;        //  HANDOUTS
 @property (nonatomic, copy) NSString* course_about;           // COURSE INFO
-@property (nonatomic) Boolean invitation_only;
+@property (nonatomic) Boolean invitationOnly;
 @property (nonatomic, strong) OEXCoursewareAccess* courseware_access;
 @property (nonatomic, copy) NSString* discussionUrl;
 @property (nonatomic, copy) NSDictionary<NSString*, CourseMediaInfo*>* mediaInfo;
@@ -119,7 +119,7 @@ NSString* NSStringForOEXStartType(OEXStartType type) {
         self.course_handouts = [info objectForKey:@"course_handouts"];
         self.course_about = [info objectForKey:@"course_about"];
         self.subscription_id = [info objectForKey:@"subscription_id"];
-        self.invitation_only = [[info objectForKey:@"invitation_only"] boolValue];
+        self.invitationOnly = [[info objectForKey:@"invitation_only"] boolValue];
         NSDictionary* accessInfo = [info objectForKey:@"courseware_access"];
         self.courseware_access = [[OEXCoursewareAccess alloc] initWithDictionary: accessInfo];
         NSDictionary* updatesInfo = [info objectForKey:@"latest_updates"];

--- a/Source/OEXCourse.m
+++ b/Source/OEXCourse.m
@@ -84,6 +84,7 @@ NSString* NSStringForOEXStartType(OEXStartType type) {
 @property (nonatomic, copy) NSString* course_updates;         //  ANNOUNCEMENTS
 @property (nonatomic, copy) NSString* course_handouts;        //  HANDOUTS
 @property (nonatomic, copy) NSString* course_about;           // COURSE INFO
+@property (nonatomic) Boolean invitation_only;
 @property (nonatomic, strong) OEXCoursewareAccess* courseware_access;
 @property (nonatomic, copy) NSString* discussionUrl;
 @property (nonatomic, copy) NSDictionary<NSString*, CourseMediaInfo*>* mediaInfo;
@@ -118,6 +119,7 @@ NSString* NSStringForOEXStartType(OEXStartType type) {
         self.course_handouts = [info objectForKey:@"course_handouts"];
         self.course_about = [info objectForKey:@"course_about"];
         self.subscription_id = [info objectForKey:@"subscription_id"];
+        self.invitation_only = [[info objectForKey:@"invitation_only"] boolValue];
         NSDictionary* accessInfo = [info objectForKey:@"courseware_access"];
         self.courseware_access = [[OEXCoursewareAccess alloc] initWithDictionary: accessInfo];
         NSDictionary* updatesInfo = [info objectForKey:@"latest_updates"];

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -244,6 +244,8 @@
 "COURSE_DETAIL.ENROLL_NOW" = "Enroll now";
 /* Button title allowing user to view a course from the course's catalog detail page */
 "COURSE_DETAIL.VIEW_COURSE" = "View course";
+/* Button title describing that the course is invitation only */
+"COURSE_DETAIL.INVITATION_ONLY" = "Invitation only";
 /* Message shown when there is no course content */
 "COURSEWARE_UNAVAILABLE"="No course content is currently available.";
 /* Message shown when attempting to display content not available on the app */


### PR DESCRIPTION
### Description

[OSPR-1781](https://openedx.atlassian.net/browse/OSPR-1781)

This PR disables the enroll button in a course if it is invite only and changes the text.

### Notes
For this PR to work it depends on this other [PR](https://github.com/edx/edx-platform/pull/15223)

### How to test this PR
- Have a course invite only.
- Find the course in the app.
- Click on it, should see button disabled.

### Reviewers
- [ ] Code review: @saeedbashir 
- [ ] Code review: @salman2013 

cc @marcotuts @gsong 


