### PR TITLE
WIP: EDUCATOR-341 Add edx.forum.thread.viewed research event

### DIFF
--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -320,6 +320,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         logScreenEvent()
+        logTrackingEvent()
     }
     
     override var shouldAutorotate: Bool {
@@ -337,6 +338,20 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
         }
     }
     
+    private func logTrackingEvent() {
+        if let thread = thread {
+
+            self.environment.analytics.trackDiscussionThreadViewed(
+                thread.threadID,
+                courseId: thread.courseId,
+                title: thread.title,
+                topicId: thread.topicId,
+                author: thread.author,
+                teamId: nil
+            )
+        }
+    }
+
     func navigationItemTitleForThread(thread : DiscussionThread) -> String {
         switch thread.type {
         case .Discussion:

--- a/Source/DiscussionResponsesViewController.swift
+++ b/Source/DiscussionResponsesViewController.swift
@@ -346,8 +346,7 @@ class DiscussionResponsesViewController: UIViewController, UITableViewDataSource
                 courseId: thread.courseId,
                 title: thread.title,
                 topicId: thread.topicId,
-                author: thread.author,
-                teamId: nil
+                author: thread.author
             )
         }
     }

--- a/Source/OEXAnalytics.h
+++ b/Source/OEXAnalytics.h
@@ -146,6 +146,8 @@ NS_ASSUME_NONNULL_BEGIN
 //Discussion search screen event
 - (void) trackDiscussionSearchScreenWithName:(NSString *) screenName courseId:(NSString *) courseID value:(nullable NSString *) value searchQuery:(NSString *) query;
 
+- (void) trackDiscussionThreadViewed:(NSString *)threadId courseId:(nullable NSString *)courseId title:(nullable NSString *)title topicId:(NSString *)topicId author:(nullable NSString *)author teamId:(nullable NSString *)teamId;
+
 @end
 
 @protocol OEXAnalyticsProvider <NSObject>

--- a/Source/OEXAnalytics.h
+++ b/Source/OEXAnalytics.h
@@ -146,7 +146,7 @@ NS_ASSUME_NONNULL_BEGIN
 //Discussion search screen event
 - (void) trackDiscussionSearchScreenWithName:(NSString *) screenName courseId:(NSString *) courseID value:(nullable NSString *) value searchQuery:(NSString *) query;
 
-- (void) trackDiscussionThreadViewed:(NSString *)threadId courseId:(nullable NSString *)courseId title:(nullable NSString *)title topicId:(NSString *)topicId author:(nullable NSString *)author teamId:(nullable NSString *)teamId;
+- (void) trackDiscussionThreadViewed:(NSString *)threadId courseId:(nullable NSString *)courseId title:(nullable NSString *)title topicId:(NSString *)topicId author:(nullable NSString *)author;
 
 @end
 

--- a/Source/OEXAnalytics.m
+++ b/Source/OEXAnalytics.m
@@ -518,18 +518,17 @@ static OEXAnalytics* sAnalytics;
     [self trackScreenWithName:screenName courseID:courseID value:value additionalInfo:@{OEXAnalyticsKeyQueryString:query}];
 }
 
-- (void) trackDiscussionThreadViewed:(nonnull NSString *)threadId courseId:(nullable NSString *)courseId title:(nullable NSString *)title topicId:(nonnull NSString *)topicId author:(nullable NSString *)author teamId:(nullable NSString *)teamId {
+- (void) trackDiscussionThreadViewed:(nonnull NSString *)threadId courseId:(nullable NSString *)courseId title:(nullable NSString *)title topicId:(nonnull NSString *)topicId author:(nullable NSString *)author {
     OEXAnalyticsEvent* event = [[OEXAnalyticsEvent alloc] init];
     event.name = OEXResearchAnalyticsEventThreadViewed;
     event.displayName = @"Forum: View Thread (Research Event)";
 
     NSMutableDictionary* info = [[NSMutableDictionary alloc] init];
-    [info setObject:threadId forKey:OEXResearchAnalyticsKeyThreadID];
+    [info safeSetObject:threadId forKey:OEXResearchAnalyticsKeyThreadID];
     [info setObjectOrNil:courseId forKey:OEXResearchAnalyticsKeyCourseID];
     [info setObjectOrNil:title forKey:OEXResearchAnalyticsKeyTitle];
-    [info setObjectOrNil:topicId forKey:OEXResearchAnalyticsKeyTopicID];
+    [info safeSetObject:topicId forKey:OEXResearchAnalyticsKeyTopicID];
     [info setObjectOrNil:author forKey:OEXResearchAnalyticsKeyAuthor];
-    [info setObjectOrNil:teamId forKey:OEXResearchAnalyticsKeyTeamID];
 
     [self trackEvent:event forComponent:nil withInfo:info];
 }

--- a/Source/OEXAnalytics.m
+++ b/Source/OEXAnalytics.m
@@ -517,4 +517,21 @@ static OEXAnalytics* sAnalytics;
 - (void) trackDiscussionSearchScreenWithName:(NSString *) screenName courseId:(NSString *) courseID value:(nullable NSString *) value searchQuery:(NSString *) query {
     [self trackScreenWithName:screenName courseID:courseID value:value additionalInfo:@{OEXAnalyticsKeyQueryString:query}];
 }
+
+- (void) trackDiscussionThreadViewed:(nonnull NSString *)threadId courseId:(nullable NSString *)courseId title:(nullable NSString *)title topicId:(nonnull NSString *)topicId author:(nullable NSString *)author teamId:(nullable NSString *)teamId {
+    OEXAnalyticsEvent* event = [[OEXAnalyticsEvent alloc] init];
+    event.name = OEXResearchAnalyticsEventThreadViewed;
+    event.displayName = @"Forum: View Thread (Research Event)";
+
+    NSMutableDictionary* info = [[NSMutableDictionary alloc] init];
+    [info setObject:threadId forKey:OEXResearchAnalyticsKeyThreadID];
+    [info setObjectOrNil:courseId forKey:OEXResearchAnalyticsKeyCourseID];
+    [info setObjectOrNil:title forKey:OEXResearchAnalyticsKeyTitle];
+    [info setObjectOrNil:topicId forKey:OEXResearchAnalyticsKeyTopicID];
+    [info setObjectOrNil:author forKey:OEXResearchAnalyticsKeyAuthor];
+    [info setObjectOrNil:teamId forKey:OEXResearchAnalyticsKeyTeamID];
+
+    [self trackEvent:event forComponent:nil withInfo:info];
+}
+
 @end

--- a/Source/OEXAnalytics.m
+++ b/Source/OEXAnalytics.m
@@ -522,10 +522,10 @@ static OEXAnalytics* sAnalytics;
     OEXAnalyticsEvent* event = [[OEXAnalyticsEvent alloc] init];
     event.name = OEXResearchAnalyticsEventThreadViewed;
     event.displayName = @"Forum: View Thread (Research Event)";
+    event.courseID = courseId;
 
     NSMutableDictionary* info = [[NSMutableDictionary alloc] init];
     [info safeSetObject:threadId forKey:OEXResearchAnalyticsKeyThreadID];
-    [info setObjectOrNil:courseId forKey:OEXResearchAnalyticsKeyCourseID];
     [info setObjectOrNil:title forKey:OEXResearchAnalyticsKeyTitle];
     [info safeSetObject:topicId forKey:OEXResearchAnalyticsKeyTopicID];
     [info setObjectOrNil:author forKey:OEXResearchAnalyticsKeyAuthor];

--- a/Source/OEXAnalyticsData.h
+++ b/Source/OEXAnalyticsData.h
@@ -18,6 +18,13 @@ extern NSString* const OEXAnalyticsKeyTopicID;
 extern NSString* const OEXAnalyticsKeyResponseID;
 extern NSString* const OEXAnalyticsKeyQueryString;
 
+extern NSString* const OEXResearchAnalyticsKeyCourseID;
+extern NSString* const OEXResearchAnalyticsKeyTopicID;
+extern NSString* const OEXResearchAnalyticsKeyThreadID;
+extern NSString* const OEXResearchAnalyticsKeyAuthor;
+extern NSString* const OEXResearchAnalyticsKeyTitle;
+extern NSString* const OEXResearchAnalyticsKeyTeamID;
+
 // TODO rename these to be more like the above
 #define key_app_name @"app_name"
 #define key_app_version @"app_version"
@@ -67,6 +74,8 @@ extern NSString* const OEXAnalyticsEventProfileViewed;
 extern NSString* const OEXAnalyticsEventScreen;
 extern NSString* const OEXAnalyticsEventCertificateShared;
 extern NSString* const OEXAnalyticsEventCourseShared;
+
+extern NSString* const OEXResearchAnalyticsEventThreadViewed;
 
 // TODO rename these to be more like the above
 #define value_video_loaded @"edx.video.loaded"

--- a/Source/OEXAnalyticsData.m
+++ b/Source/OEXAnalyticsData.m
@@ -18,6 +18,13 @@ NSString* const OEXAnalyticsKeyTopicID = @"topic_id";
 NSString* const OEXAnalyticsKeyResponseID = @"response_id";
 NSString* const OEXAnalyticsKeyQueryString = @"query_string";
 
+NSString* const OEXResearchAnalyticsKeyCourseID = @"course_id";
+NSString* const OEXResearchAnalyticsKeyTopicID = @"commentable_id";
+NSString* const OEXResearchAnalyticsKeyThreadID = @"id";
+NSString* const OEXResearchAnalyticsKeyAuthor = @"target_username";
+NSString* const OEXResearchAnalyticsKeyTitle = @"title";
+NSString* const OEXResearchAnalyticsKeyTeamID = @"team_id";
+
 NSString* const OEXAnalyticsEventAnnouncementNotificationReceived = @"edx.bi.app.notification.course.update.received";
 NSString* const OEXAnalyticsEventAnnouncementNotificationTapped = @"edx.bi.app.notification.course.update.tapped";
 NSString* const OEXAnalyticsEventPictureSet = @"edx.bi.app.profile.setphoto";
@@ -27,6 +34,8 @@ NSString* const OEXAnalyticsEventComponentViewed = @"edx.bi.app.navigation.compo
 NSString* const OEXAnalyticsEventScreen = @"edx.bi.app.navigation.screen";
 NSString* const OEXAnalyticsEventCertificateShared = @"edx.bi.app.certificate.shared";
 NSString* const OEXAnalyticsEventCourseShared = @"edx.bi.app.course.shared";
+
+NSString* const OEXResearchAnalyticsEventThreadViewed = @"edx.forum.thread.viewed";
 
 NSString* const OEXAnalyticsCategoryNavigation = @"navigation";
 NSString* const OEXAnalyticsCategoryNotifications = @"notifications";


### PR DESCRIPTION
### Update

I am closing this PR, because it was decided that instead of creating a new event, we will use the existing business intelligence forum thread view event, and transform it in the LMS.

-------------------

### Description

[EDUCATOR-341](https://openedx.atlassian.net/browse/EDUCATOR-341)

Adds the Segment event `edx.forum.thread.viewed`, which will be processed in the LMS by the changes made in [this PR](https://github.com/edx/edx-platform/pull/15237). The corresponding Android PR is [here](https://github.com/edx/edx-app-android/pull/966).

### Notes

The goal of this ticket is to introduce an event analogous to `edx.forum.thread.created` for forum thread views. The existing `edx.forum.*` events are fired by calling the function `eventtracking.tracker.emit` directly within the LMS, as will be `edx.forum.thread.viewed` for thread views within the browser.  However, it is not possible to use this approach for app-based thread views, because both the iOS and Android apps fetch all threads for a single topic at once through the Mobile API, so it is impossible to discern within the LMS exactly when a thread is clicked on to be viewed.

The solution to this is by creating a new Segment event that is fired when a thread is clicked for viewing, and collecting and processing it in the LMS. Because not all the fields desired for the event are available and easily accessible within the app (for example, `user_course_roles` is not available, and `category_name` would require either an extra API call or a modification of the app to cache topic names), a transformation is done in the LMS to add extra fields.

(more description incoming)
<!-- 
It should be noted that within this app, a forum thread being viewed already fires two existing events: a 'screen' event and the tracking event `edx.bi.app.navigation.screen`. So, instead of introducing a new event, an alternative approach would have been modifying the LMS tracking log filter to accept `edx.bi.*`, and then within the event transformer.

However, it was decided to create a new, redundant event instead of using the existing tracking event because:
1. The LMS currently rejects all `edx.bi.*` events from its tracking logs, so to use `edx.bi.app.navigation.screen` would involve introducing all `edx.bi.*` into the logs
2. To stay consistent with the existing `edx.forum.*` event naming scheme, the desired name of the event is `edx.forum.thread.viewed`. To conform to this with the `edx.bi.app.navigation.screen` event would involve transforming the event name in the LMS, which)-->

### How to test this PR

TODO