### PR TITLE
Add flag ANNOUNCEMENTS_ENABLED

### DIFF
--- a/Source/CourseDashboardViewController.swift
+++ b/Source/CourseDashboardViewController.swift
@@ -264,10 +264,12 @@ public class CourseDashboardViewController: UIViewController, UITableViewDataSou
             cellItems.append(item)
         }
         
-        item = StandardCourseDashboardItem(title: Strings.Dashboard.courseAnnouncements, detail: Strings.Dashboard.courseAnnouncementsDetail, icon: .Announcements) {[weak self] () -> Void in
-            self?.showAnnouncements()
+        if environment.config.isAnnouncementsEnabled {
+            item = StandardCourseDashboardItem(title: Strings.Dashboard.courseAnnouncements, detail: Strings.Dashboard.courseAnnouncementsDetail, icon: .Announcements) {[weak self] () -> Void in
+                self?.showAnnouncements()
+            }
+            cellItems.append(item)
         }
-        cellItems.append(item)
         
         if environment.config.courseDatesEnabled {
             item = StandardCourseDashboardItem(title: Strings.Dashboard.courseImportantDates, detail:Strings.Dashboard.courseImportantDatesDetail, icon:.Calendar, action: {[weak self] () -> Void in
@@ -365,6 +367,10 @@ extension CourseDashboardViewController {
     
     func t_canVisitHandouts() -> Bool {
         return self.cellItems.firstIndexMatching({ (item: CourseDashboardItem) in return (item is StandardCourseDashboardItem) && (item as! StandardCourseDashboardItem).icon == .Handouts }) != nil
+    }
+    
+    func t_canVisitAnnouncements() -> Bool {
+        return self.cellItems.firstIndexMatching({ (item: CourseDashboardItem) in return (item is StandardCourseDashboardItem) && (item as! StandardCourseDashboardItem).icon == .Announcements }) != nil
     }
 
     func t_canVisitCertificate() -> Bool {

--- a/Source/OEXConfig+AppFeatures.swift
+++ b/Source/OEXConfig+AppFeatures.swift
@@ -81,4 +81,8 @@ extension OEXConfig {
     var isCourseVideosEnabled: Bool {
         return bool(forKey: "COURSE_VIDEOS_ENABLED")
     }
+    
+    var isAnnouncementsEnabled: Bool {
+        return bool(forKey: "ANNOUNCEMENTS_ENABLED")
+    }
 }

--- a/Test/CourseDashboardViewControllerTests.swift
+++ b/Test/CourseDashboardViewControllerTests.swift
@@ -13,11 +13,12 @@ import edXCore
 
 private extension OEXConfig {
 
-    convenience init(discussionsEnabled : Bool, courseSharingEnabled: Bool = false, courseVideosEnabled: Bool = false) {
+    convenience init(discussionsEnabled : Bool, courseSharingEnabled: Bool = false, courseVideosEnabled: Bool = false, isAnnouncementsEnabled: Bool = true) {
         self.init(dictionary: [
             "DISCUSSIONS_ENABLED": discussionsEnabled,
             "COURSE_SHARING_ENABLED": courseSharingEnabled,
-            "COURSE_VIDEOS_ENABLED": courseVideosEnabled
+            "COURSE_VIDEOS_ENABLED": courseVideosEnabled,
+            "ANNOUNCEMENTS_ENABLED": isAnnouncementsEnabled
             ]
         )
     }
@@ -66,6 +67,27 @@ class CourseDashboardViewControllerTests: SnapshotTestCase {
                 
                 let expected = hasHandoutsUrl
                 XCTAssertEqual(enabled, expected, "Expected handouts visiblity \(expected) when course_handouts_empty: \(hasHandoutsUrl)")
+            }
+        }
+    }
+    
+    func testAnnouncementsEnabled() {
+        for isAnnouncementsEnabled in [true, false] {
+            let config = OEXConfig(discussionsEnabled: true, isAnnouncementsEnabled:isAnnouncementsEnabled)
+            let course = OEXCourse.freshCourse(discussionsEnabled: true)
+            let environment = TestRouterEnvironment(config: config)
+            environment.mockEnrollmentManager.courses = [course]
+            environment.logInTestUser()
+            let controller = CourseDashboardViewController(environment: environment,
+                                                           courseID: course.course_id!)
+            
+            inScreenDisplayContext(controller) {
+                waitForStream(controller.t_loaded)
+                
+                let enabled = controller.t_canVisitAnnouncements()
+                
+                let expected = isAnnouncementsEnabled
+                XCTAssertEqual(enabled, expected, "Expected announcements visiblity \(expected) when is_announcements_enabled: \(isAnnouncementsEnabled)")
             }
         }
     }


### PR DESCRIPTION
### Description

[OSPR-1827](https://openedx.atlassian.net/browse/OSPR-1827)

This PR shows or hide the announcements tab in ```CourseDashboardViewController.swift``` depending on the flag ```ANNOUNCEMENTS_ENABLED``` added in ```ios.yml```.

### Notes
This flag is for the whole app and not course specific.

### How to test this PR

Add the flag to ```ios.yml``` and change the values of  ```ANNOUNCEMENTS_ENABLED```

```
API_HOST_URL: ''
OAUTH_CLIENT_ID: ''
ENVIRONMENT_DISPLAY_NAME: ''
PLATFORM_NAME: ''
PLATFORM_DESTINATION_NAME: ''
FEEDBACK_EMAIL_ADDRESS: ''
DEBUG: false
ORGANIZATION_CODE: ''
PUSH_NOTIFICATIONS: false
MY_VIDEOS_ENABLED: true
ANNOUNCEMENTS_ENABLED: false
COURSE_ENROLLMENT:
  ENABLED: true
  TYPE: 'native'
  COURSE_SHARING_ENABLED: false
DISCUSSIONS_ENABLED: true
CERTIFICATES_ENABLED: true
USER_PROFILES_ENABLED: true
BADGES_ENABLED: true
REGISTRATION_ENABLED: true
SEGMENT_IO:
  SEGMENT_IO_WRITE_KEY: ''
  ENABLED: false
```

### Reviewers
- [ ] Code review: @saeedbashir 
- [ ] Code review: @salman2013 

cc @marcotuts @gsong 
