### PR TITLE
Replacing OEXLogError with Logger.logError

### DIFF
--- a/Source/Dictionary+SafeAccess.swift
+++ b/Source/Dictionary+SafeAccess.swift
@@ -30,7 +30,7 @@ extension NSMutableDictionary {
             #if DEBUG
                 assert(false, "Expecting object for key: \(forKey)");
             #else
-                OEXLogError("FOUNDATION", "Expecting object for key: \(forKey)");
+                Logger.logError("FOUNDATION", "Expecting object for key: \(forKey)");
             #endif
         }
     }
@@ -53,7 +53,7 @@ extension Dictionary {
             #if DEBUG
                 assert(false, "Expecting object for key: \(forKey)");
             #else
-                OEXLogError("FOUNDATION", "Expecting object for key: \(forKey)");
+                Logger.logError("FOUNDATION", "Expecting object for key: \(forKey)");
             #endif
         }
     }


### PR DESCRIPTION
### Description
OEXLogError is a Objective-C variant of of Logger.logError that was being used in swift code.