### PR TITLE
Add flag USING_VIDEO_PIPELINE to support fallback video

### DIFF
--- a/Source/OEXConfig+AppFeatures.swift
+++ b/Source/OEXConfig+AppFeatures.swift
@@ -81,4 +81,8 @@ extension OEXConfig {
     var isCourseVideosEnabled: Bool {
         return bool(forKey: "COURSE_VIDEOS_ENABLED")
     }
+    
+    var isUsingVideoPipeline: Bool {
+        return bool(forKey: "USING_VIDEO_PIPELINE")
+    }
 }

--- a/Test/OEXVideoSummaryTests.m
+++ b/Test/OEXVideoSummaryTests.m
@@ -128,15 +128,22 @@
     XCTAssertFalse(summary.isSupportedVideo);
 }
 
-- (void)testSupportedFallbackEncoding {
+- (void)testSupportedEncoding {
     NSDictionary *fallback = [self encodingWithName:OEXVideoEncodingMobileLow andUrl:@"https://www.example.com/video.mp4"];
     OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncoding:fallback andOnlyOnWeb:false]];
     
     XCTAssertTrue(summary.isSupportedVideo);
 }
 
-- (void)testUnSupportedFallbackEncoding {
+- (void)testSupportedFallbackEncoding {
     NSDictionary *fallback = [self encodingWithName:OEXVideoEncodingFallback andUrl:@"https://www.example.com/video.mp4"];
+    OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncoding:fallback andOnlyOnWeb:false]];
+    
+    XCTAssertTrue(summary.isSupportedVideo);
+}
+
+- (void)testUnSupportedFallbackEncoding {
+    NSDictionary *fallback = [self encodingWithName:OEXVideoEncodingYoutube andUrl:@"https://www.example.com/video.mp4"];
     OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncoding:fallback andOnlyOnWeb:false]];
     
     XCTAssertFalse(summary.isSupportedVideo);


### PR DESCRIPTION
### Description

[OSPR-1850](https://openedx.atlassian.net/browse/OSPR-1850)

This PR uses the ```fallback_video``` when not using video pipeline by setting the variable ```USING_VIDEO_PIPELINE``` added in ```ios.yml```.

### How to test this PR

Add the flag to ```ios.yml``` and change the values of  ```USING_VIDEO_PIPELINE```

```
API_HOST_URL: ''
OAUTH_CLIENT_ID: ''
ENVIRONMENT_DISPLAY_NAME: ''
PLATFORM_NAME: ''
PLATFORM_DESTINATION_NAME: ''
FEEDBACK_EMAIL_ADDRESS: ''
DEBUG: false
ORGANIZATION_CODE: ''
PUSH_NOTIFICATIONS: false
MY_VIDEOS_ENABLED: true
COURSE_ENROLLMENT:
  ENABLED: true
  TYPE: 'native'
  COURSE_SHARING_ENABLED: false
DISCUSSIONS_ENABLED: true
CERTIFICATES_ENABLED: true
USER_PROFILES_ENABLED: true
BADGES_ENABLED: true
REGISTRATION_ENABLED: true
SEGMENT_IO:
  SEGMENT_IO_WRITE_KEY: ''
  ENABLED: false
USING_VIDEO_PIPELINE: false
```

### Reviewers
- [ ] Code review: @saeedbashir 
- [ ] Code review: @salman2013 

cc @marcotuts @gsong 

