### PR TITLE
Rename profile localizable files to make it same for both platforms

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -13,19 +13,19 @@ file_filter = Source/<lang>.proj/InfoPlist.strings
 source_file = Source/en.lproj/InfoPlist.strings
 source_lang = en
 
-[edx-mobile-apps.ios-app-localizable-profiles]
+[edx-mobile-apps.app-localizable-profiles]
 type = KEYVALUEJSON
 file_filter = Source/<lang>.proj/profiles.json
 source_file = Source/en.lproj/profiles.json
 source_lang = en
 
-[edx-mobile-apps.ios-app-localizable-countries]
+[edx-mobile-apps.app-localizable-countries]
 type = KEYVALUEJSON
 file_filter = Source/<lang>.proj/countries.json
 source_file = Source/en.lproj/countries.json
 source_lang = en
 
-[edx-mobile-apps.ios-app-localizable-languages]
+[edx-mobile-apps.app-localizable-languages]
 type = KEYVALUEJSON
 file_filter = Source/<lang>.proj/languages.json
 source_file = Source/en.lproj/languages.json


### PR DESCRIPTION
### Description

[LEARNER-2509](https://openedx.atlassian.net/browse/LEARNER-2509)

Renaming json files of profile for transifex script. Now on, Android and iOS will be uploading profile json files under the same name so that only one copy of files will be on transifex for translations.