### PR TITLE
Allow online-only playback for HTTP Live Streaming videos with an .m3u8 extension

### DIFF
--- a/Source/CourseOutlineQuerier.swift
+++ b/Source/CourseOutlineQuerier.swift
@@ -343,7 +343,7 @@ public class CourseOutlineQuerier : NSObject {
         
         let blockVideos = videoStream.map({[weak self] videoIDs -> [OEXHelperVideoDownload] in
             let videos = self?.interface?.statesForVideos(withIDs: videoIDs, courseID: self?.courseID ?? "")
-            return videos?.filter { video in (video.summary?.isSupportedVideo ?? false)} ?? []
+            return videos?.filter { video in (video.summary?.isDownloadableVideo ?? false)} ?? []
         })
         
         return blockVideos

--- a/Source/CourseVideoTableViewCell.swift
+++ b/Source/CourseVideoTableViewCell.swift
@@ -31,7 +31,7 @@ class CourseVideoTableViewCell: SwipeableCell, CourseBlockContainerCell {
         didSet {
             content.setTitleText(title: block?.displayName)
             if let video = block?.type.asVideo {
-                video.isSupportedVideo ? (downloadView.isHidden = false) : (downloadView.isHidden = true)
+                video.isDownloadableVideo ? (downloadView.isHidden = false) : (downloadView.isHidden = true)
             }
         }
     }

--- a/Source/OEXInterface.m
+++ b/Source/OEXInterface.m
@@ -191,8 +191,13 @@ static OEXInterface* _sharedInterface = nil;
     if([URLString rangeOfString:URL_SUBSTRING_VIDEOS].location != NSNotFound) {
         return YES;
     }
-    else if([URLString rangeOfString:URL_EXTENSION_VIDEOS].location != NSNotFound) {
-        return YES;
+    else {
+        for (NSString *extension_option in VIDEO_URL_EXTENSION_OPTIONS) {
+        // Check each string in VIDEO_URL_EXTENSION_OPTIONS to see if the URL has a valid file extension for a video
+            if([URLString localizedCaseInsensitiveContainsString:extension_option]) {
+                return YES;
+            }
+        }
     }
     return NO;
 }

--- a/Source/OEXNetworkConstants.h
+++ b/Source/OEXNetworkConstants.h
@@ -21,7 +21,8 @@
 // edX Constants
 
 // TODO: move the remaining things that mention edx.org into config
-#define URL_EXTENSION_VIDEOS @".mp4"
+#define VIDEO_URL_EXTENSION_OPTIONS @[ @".mp4", @".m3u8" ]
+#define ONLINE_ONLY_VIDEO_URL_EXTENSIONS @[ @".m3u8" ]
 #define URL_EXCHANGE_TOKEN @"/oauth2/exchange_access_token/{backend}/"
 #define URL_USER_DETAILS @"/api/mobile/v0.5/users"
 #define URL_COURSE_ENROLLMENTS @"/course_enrollments/"

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic, assign) BOOL onlyOnWeb;
 @property (readonly, nonatomic, assign) BOOL isYoutubeVideo;
 @property (readonly, nonatomic, assign) BOOL isSupportedVideo;
+@property (readonly, nonatomic, assign) BOOL isDownloadableVideo;
 @property (readonly, nonatomic, assign) BOOL hasVideoDuration;
 @property (readonly, nonatomic, assign) BOOL hasVideoSize;
 @property (nonatomic, strong) NSDictionary* encodings;

--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -8,6 +8,7 @@
 
 #import "OEXVideoSummary.h"
 #import "OEXConfig.h"
+#import "OEXNetworkConstants.h"
 
 #import "edX-Swift.h"
 #import "OEXVideoEncoding.h"
@@ -172,6 +173,19 @@
     }
     
     return !self.onlyOnWeb && isSupportedEncoding;
+}
+
+- (BOOL) isDownloadableVideo {
+    BOOL canDownload = self.isSupportedVideo;
+    if(canDownload) {
+        for (NSString *extension in ONLINE_ONLY_VIDEO_URL_EXTENSIONS) {
+            if([self.videoURL localizedCaseInsensitiveContainsString:extension]){
+                canDownload = NO;
+                break;
+            }
+        }
+    }
+    return canDownload;
 }
 
 - (NSString*)videoURL {


### PR DESCRIPTION
### Description

This pull request adds one feature; the ability to configure HTTP Live Streaming m3u8 playlists as videos that can be played in the iOS application. HTTP live streams are not currently downloadable, and so features are added to ensure that interface elements related to file downloads are not rendered for these streams. Playback is handled by the native iOS video player.

### How to test this PR

In edx-platform, add a video with a single variant with an m3u8 file extension (for example: https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8). Verify that the master branch of the app cannot play this video.

Check out this branch. Verify that you are able to play the video, and that user interface elements related to downloading that video aren't shown.

Verify the above with m3u8 playlists with URLs with and without query parameters after the m3u8 file extension.

### Screenshots

<img width="616" alt="screen shot 2017-10-10 at 2 22 43 pm" src="https://user-images.githubusercontent.com/7773758/31403625-a702d4d2-adc7-11e7-81c5-182f0eb76b61.png">
<img width="614" alt="screen shot 2017-10-10 at 2 24 36 pm" src="https://user-images.githubusercontent.com/7773758/31403626-a70c8bda-adc7-11e7-9e1f-3564b5ff3334.png">
