### PR TITLE
Fixes so the app will build with XCode 9

### DIFF
--- a/Source/OEXAppDelegate.m
+++ b/Source/OEXAppDelegate.m
@@ -152,7 +152,7 @@
 
 #pragma mark Background Downloading
 
-- (void)application:(UIApplication*)application handleEventsForBackgroundURLSession:(NSString*)identifier completionHandler:(void (^)())completionHandler {
+- (void)application:(UIApplication*)application handleEventsForBackgroundURLSession:(NSString*)identifier completionHandler:(void (^)(void))completionHandler {
     [OEXDownloadManager sharedManager];
     [self addCompletionHandler:completionHandler forSession:identifier];
 }

--- a/script/Localizations.swift
+++ b/script/Localizations.swift
@@ -185,7 +185,7 @@ func getArguments(_ string : String) throws -> [String] {
                 
                 let argument = string[string.index(after: start.lowerBound)..<string.index(before: end.upperBound)]
                 
-                arguments.append(argument)
+                arguments.append(String(argument))
                 current = end.upperBound
             }
             else {


### PR DESCRIPTION
### Description

This fixes some Swift syntax issues so the app will build with XCode 9.

### Notes

I have not yet confirmed that these changes work in older versions of XCode.

### How to test this PR

Build the app in XCode 9.
