### PR TITLE
Check if RTL to use correct view controller when using the drawer

### DIFF
--- a/Source/RevealViewController.swift
+++ b/Source/RevealViewController.swift
@@ -77,7 +77,7 @@ class RevealViewController: SWRevealViewController, SWRevealViewControllerDelega
     }
     
     @objc private func defaultMenuVOFocus() {
-        view.accessibilityElements = [dimmingOverlay, rearViewController.view.subviews]
+        view.accessibilityElements = [dimmingOverlay, drawerViewController.view.subviews]
         UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification,  dimmingOverlay)
     }
     


### PR DESCRIPTION
### Description

[OSPR-1967](https://openedx.atlassian.net/browse/OSPR-1967)

Currently, if you use ```rearViewController.view.subviews``` on Arabic lang it returns nil and the app bombs.

By changing it to ```drawerViewController.view.subviews``` the app will work again in Arabic.

### How to test this PR

Run the app in Arabic and see that it doesn't bomb.

### Reviewers
- [ ] Code review: @saeedbashir 
- [ ] Code review: @salman2013 

cc @marcotuts
