### PR TITLE
Allow HLS video streaming, and use fallback video sources as download URL

### DIFF
--- a/Source/CourseOutlineQuerier.swift
+++ b/Source/CourseOutlineQuerier.swift
@@ -351,7 +351,7 @@ public class CourseOutlineQuerier : NSObject {
         
         let blockVideos = videoStream.map({[weak self] videoIDs -> [OEXHelperVideoDownload] in
             let videos = self?.interface?.statesForVideos(withIDs: videoIDs, courseID: self?.courseID ?? "")
-            return videos?.filter { video in (video.summary?.isSupportedVideo ?? false)} ?? []
+            return videos?.filter { video in (video.summary?.isDownloadableVideo ?? false)} ?? []
         })
         
         return blockVideos

--- a/Source/CourseVideoTableViewCell.swift
+++ b/Source/CourseVideoTableViewCell.swift
@@ -31,7 +31,7 @@ class CourseVideoTableViewCell: SwipeableCell, CourseBlockContainerCell {
         didSet {
             content.setTitleText(title: block?.displayName)
             if let video = block?.type.asVideo {
-                video.isSupportedVideo ? (downloadView.isHidden = false) : (downloadView.isHidden = true)
+                video.isDownloadableVideo ? (downloadView.isHidden = false) : (downloadView.isHidden = true)
             }
         }
     }

--- a/Source/OEXDownloadViewController.m
+++ b/Source/OEXDownloadViewController.m
@@ -106,7 +106,7 @@
             if(video.downloadProgress < OEXMaxDownloadProgress) {
                 [self.arr_downloadingVideo addObject:video];
                 if (video != nil && video.summary != nil) {
-                    NSString* key = video.summary.videoURL;
+                    NSString* key = video.summary.downloadURL;
                     if (key) {
                         duplicationAvoidingDict[key] = @"object";
                     }
@@ -195,7 +195,7 @@
             NSString* url = [task.originalRequest.URL absoluteString];
             
             for(OEXHelperVideoDownload* video in _arr_downloadingVideo) {
-                if([video.summary.videoURL isEqualToString:url]) {
+                if([video.summary.downloadURL isEqualToString:url]) {
                     [weakSelf updateProgressForVisibleRows];
                     break;
                 }

--- a/Source/OEXNetworkConstants.h
+++ b/Source/OEXNetworkConstants.h
@@ -20,8 +20,10 @@
 
 // edX Constants
 
-// TODO: move the remaining things that mention edx.org into config
-#define URL_EXTENSION_VIDEOS @".mp4"
+// Extensions must be lowercase
+#define VIDEO_URL_EXTENSION_OPTIONS @[ @".mp4", @".m3u8" ]
+#define ONLINE_ONLY_VIDEO_URL_EXTENSIONS @[ @".m3u8" ]
+
 #define URL_EXCHANGE_TOKEN @"/oauth2/exchange_access_token/{backend}/"
 #define URL_USER_DETAILS @"/api/mobile/v0.5/users"
 #define URL_COURSE_ENROLLMENTS @"/course_enrollments/"

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 // This property is deprecated. We should be reading it from the CourseBlock itself
 @property (readonly, nonatomic, copy, nullable) NSString* name;
 @property (readonly, nonatomic, copy, nullable) NSString* videoURL;
-@property (nonatomic, copy, nullable) NSString* downloadURL;
+@property (readonly, nonatomic, copy, nullable) NSString* downloadURL;
 @property (readonly, nonatomic, copy, nullable) NSString* videoThumbnailURL;
 // TODO: Make this readonly again, once we completely migrate to the new API
 @property (nonatomic, assign) double duration;

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -39,7 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 // This property is deprecated. We should be reading it from the CourseBlock itself
 @property (readonly, nonatomic, copy, nullable) NSString* name;
 @property (readonly, nonatomic, copy, nullable) NSString* videoURL;
-@property (readonly, nonatomic, copy, nullable) NSString* downloadURL;
 @property (readonly, nonatomic, copy, nullable) NSString* videoThumbnailURL;
 // TODO: Make this readonly again, once we completely migrate to the new API
 @property (nonatomic, assign) double duration;
@@ -53,6 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic, assign) BOOL hasVideoDuration;
 @property (readonly, nonatomic, assign) BOOL hasVideoSize;
 @property (nonatomic, strong) NSDictionary* encodings;
+@property (nonatomic, copy, nullable) NSString* downloadURL;
 
 // For CC
 // de - German

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 // This property is deprecated. We should be reading it from the CourseBlock itself
 @property (readonly, nonatomic, copy, nullable) NSString* name;
 @property (readonly, nonatomic, copy, nullable) NSString* videoURL;
+@property (nonatomic, copy, nullable) NSString* downloadURL;
 @property (readonly, nonatomic, copy, nullable) NSString* videoThumbnailURL;
 // TODO: Make this readonly again, once we completely migrate to the new API
 @property (nonatomic, assign) double duration;
@@ -48,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic, assign) BOOL onlyOnWeb;
 @property (readonly, nonatomic, assign) BOOL isYoutubeVideo;
 @property (readonly, nonatomic, assign) BOOL isSupportedVideo;
+@property (readonly, nonatomic, assign) BOOL isDownloadableVideo;
 @property (readonly, nonatomic, assign) BOOL hasVideoDuration;
 @property (readonly, nonatomic, assign) BOOL hasVideoSize;
 @property (nonatomic, strong) NSDictionary* encodings;

--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -34,7 +34,6 @@
 @property (nonatomic, strong) NSDictionary* transcripts;
 @property (nonatomic, strong) OEXVideoEncoding *defaultEncoding;
 @property (nonatomic, strong) NSMutableArray *supportedEncodings;
-@property (nonatomic, copy) NSArray *allSources;
 
 - (BOOL)isSupportedEncoding:(NSString *) encodingName;
 
@@ -85,13 +84,13 @@
         
         if (_encodings.count <=0)
             _defaultEncoding = [[OEXVideoEncoding alloc] initWithName:OEXVideoEncodingFallback URL:[summary objectForKey:@"video_url"] size:[summary objectForKey:@"size"]];
-
         self.supportedEncodings = [[NSMutableArray alloc] initWithArray:@[OEXVideoEncodingMobileHigh, OEXVideoEncodingMobileLow]];
-        self.allSources = [summary objectForKey:@"all_sources"];
         if (![[OEXConfig sharedConfig] isUsingVideoPipeline] ||
             [self.preferredEncoding.name isEqualToString:OEXVideoEncodingFallback]) {
             [self.supportedEncodings addObject:OEXVideoEncodingFallback];
         }
+
+        self.downloadURL = [self getDownloadURL:[summary objectForKey:@"all_sources"]];
     }
     
     return self;
@@ -195,7 +194,7 @@
     return (BOOL)self.downloadURL;
 }
 
-- (NSString*)downloadURL {
+- (NSString*)getDownloadURL:(NSArray*) allSources {
     NSString *downloadURL = nil;
 
     if ([[OEXConfig sharedConfig] isUsingVideoPipeline]) {
@@ -216,7 +215,7 @@
             downloadURL = self.videoURL;
         } else {
             // Loop through the video sources to find a downloadable video URL
-            for (NSString *url in self.allSources) {
+            for (NSString *url in allSources) {
                 if ([OEXVideoSummary isDownloadableVideoURL:url]) {
                     downloadURL = url;
                     break;

--- a/Test/OEXVideoSummaryTests.m
+++ b/Test/OEXVideoSummaryTests.m
@@ -9,11 +9,13 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
+#import "OEXConfig.h"
 #import "OEXVideoEncoding.h"
 #import "OEXVideoPathEntry.h"
 #import "OEXVideoSummary.h"
 
 @interface OEXVideoSummaryTests : XCTestCase
+
 
 @end
 
@@ -35,7 +37,31 @@
     if (encoding) {
         [summary setObject:encoding forKey:@"encoded_videos"];
     }
-    
+     
+    return @{@"summary": summary};
+}
+
+- (NSDictionary*) summaryWithEncodings:(NSArray*) encodings andOnlyOnWeb:(BOOL) onlyOnWeb {
+    return [self summaryWithEncodings:encodings andOnlyOnWeb: onlyOnWeb andAllSources:nil];
+}
+
+- (NSDictionary*) summaryWithEncodings:(NSArray*) encodings andOnlyOnWeb:(BOOL) onlyOnWeb andAllSources:(NSArray *)allSources {
+    NSMutableDictionary *summary = [NSMutableDictionary new];
+    NSMutableDictionary *allEncodings = [NSMutableDictionary new];
+    [summary setObject:[NSNumber numberWithBool:onlyOnWeb] forKey:@"only_on_web"];
+
+    for (NSDictionary *encoding in encodings) {
+        for (NSString *name in encoding) {
+            allEncodings[name] = encoding[name];
+        }
+    }
+    if (allEncodings) {
+        [summary setObject:allEncodings forKey:@"encoded_videos"];
+    }
+    if (allSources) {
+        [summary setObject:allSources forKey:@"all_sources"];
+    }
+
     return @{@"summary": summary};
 }
 
@@ -126,6 +152,7 @@
     OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncoding:nil andOnlyOnWeb:true]];
     XCTAssertTrue(summary.onlyOnWeb);
     XCTAssertFalse(summary.isSupportedVideo);
+    XCTAssertFalse(summary.isDownloadableVideo);
 }
 
 - (void)testSupportedEncoding {
@@ -133,6 +160,7 @@
     OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncoding:fallback andOnlyOnWeb:false]];
     
     XCTAssertTrue(summary.isSupportedVideo);
+    XCTAssertTrue(summary.isDownloadableVideo);
 }
 
 - (void)testSupportedFallbackEncoding {
@@ -140,6 +168,7 @@
     OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncoding:fallback andOnlyOnWeb:false]];
     
     XCTAssertTrue(summary.isSupportedVideo);
+    XCTAssertTrue(summary.isDownloadableVideo);
 }
 
 - (void)testUnSupportedFallbackEncoding {
@@ -147,6 +176,7 @@
     OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncoding:fallback andOnlyOnWeb:false]];
     
     XCTAssertFalse(summary.isSupportedVideo);
+    XCTAssertTrue(summary.isDownloadableVideo);
 }
 
 - (void)testYoutubeEncoding {
@@ -154,7 +184,56 @@
     OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncoding:youtube andOnlyOnWeb:false]];
     
     XCTAssertFalse(summary.isSupportedVideo);
+    XCTAssertFalse(summary.isDownloadableVideo);
     XCTAssertTrue(summary.isYoutubeVideo);
 }
 
+- (void)testSupportedYoutubeFallbackEncodingDownload {
+    NSDictionary *youtube = [self encodingWithName:OEXVideoEncodingYoutube andUrl:@"https://www.youtube.com/watch?v=abc123"];
+    NSDictionary *fallback = [self encodingWithName:OEXVideoEncodingFallback andUrl:@"https://www.example.com/video.mp4"];
+    OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncodings:@[youtube, fallback] andOnlyOnWeb:false]];
+    
+    XCTAssertTrue(summary.isSupportedVideo);
+    XCTAssertTrue(summary.isDownloadableVideo);
+    XCTAssertFalse(summary.isYoutubeVideo);
+}
+
+- (void)testSupportedYoutubeHLSEncodingDownload {
+    NSDictionary *youtube = [self encodingWithName:OEXVideoEncodingYoutube andUrl:@"https://www.youtube.com/watch?v=abc123"];
+    NSDictionary *hls = [self encodingWithName:OEXVideoEncodingFallback andUrl:@"https://www.example.com/video.m3u8"];
+    OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncodings:@[youtube, hls] andOnlyOnWeb:false]];
+    
+    XCTAssertTrue(summary.isSupportedVideo);
+    XCTAssertFalse(summary.isDownloadableVideo);
+    XCTAssertFalse(summary.isYoutubeVideo);
+}
+
+- (void)testSupportedYoutubeHLSEncodingAllSourcesDownload {
+    NSDictionary *youtube = [self encodingWithName:OEXVideoEncodingYoutube andUrl:@"https://www.youtube.com/watch?v=abc123"];
+    NSDictionary *hls = [self encodingWithName:OEXVideoEncodingFallback andUrl:@"https://www.example.com/video.m3u8"];
+    NSArray *all_sources = @[@"https://www.example.com/video.mp4"];
+    OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncodings:@[youtube, hls] andOnlyOnWeb:false andAllSources:all_sources]];
+    
+    XCTAssertTrue(summary.isSupportedVideo);
+    XCTAssertTrue(summary.isDownloadableVideo);
+    XCTAssertFalse(summary.isYoutubeVideo);
+}
+
+- (void)testSupportedFallbackEncodingDownloadPipelineEnabled {
+    NSDictionary *youtube = [self encodingWithName:OEXVideoEncodingYoutube andUrl:@"https://www.youtube.com/watch?v=abc123"];
+    NSDictionary *hls = [self encodingWithName:OEXVideoEncodingFallback andUrl:@"https://www.example.com/video.m3u8"];
+    NSArray *all_sources = @[@"https://www.example.com/video.mp4"];
+    OEXVideoSummary *summary = nil;
+
+    OEXConfig *origConfig = [OEXConfig sharedConfig];
+    OEXConfig *overrideConfig = [[OEXConfig alloc] initWithDictionary:@{@"USING_VIDEO_PIPELINE": @YES}];
+
+    [OEXConfig setSharedConfig:overrideConfig];
+    summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncodings:@[youtube, hls] andOnlyOnWeb:false andAllSources:all_sources]];
+    
+    XCTAssertTrue(summary.isSupportedVideo);
+    XCTAssertFalse(summary.isDownloadableVideo);
+    XCTAssertFalse(summary.isYoutubeVideo);
+    [OEXConfig setSharedConfig:origConfig];
+}
 @end

--- a/Test/OEXVideoSummaryTests.m
+++ b/Test/OEXVideoSummaryTests.m
@@ -211,11 +211,18 @@
 - (void)testSupportedYoutubeHLSEncodingAllSourcesDownload {
     NSDictionary *youtube = [self encodingWithName:OEXVideoEncodingYoutube andUrl:@"https://www.youtube.com/watch?v=abc123"];
     NSDictionary *hls = [self encodingWithName:OEXVideoEncodingFallback andUrl:@"https://www.example.com/video.m3u8"];
-    NSArray *all_sources = @[@"https://www.example.com/video.mp4"];
-    OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncodings:@[youtube, hls] andOnlyOnWeb:false andAllSources:all_sources]];
-    
+    NSArray *all_sources = @[
+        @"https://www.example.com/video.m3u8",
+        @"https://player.vimeo.com/external/225003478.m3u8?s=6438b130458bd0eb38f7625ffa26623caee8ff7c",
+        @"https://player.vimeo.com/external/225003478.hd.mp4?s=bb4df4d286c4326e7b53074f30b05c845ebd3912&profile_id=174",
+    ];
+    NSDictionary *summaryDict = [self summaryWithEncodings:@[youtube, hls] andOnlyOnWeb:false andAllSources:all_sources];
+    OEXVideoSummary *summary = [[OEXVideoSummary alloc] initWithDictionary:summaryDict];
+
     XCTAssertTrue(summary.isSupportedVideo);
+    XCTAssertTrue([summary.videoURL isEqualToString:all_sources[0]]);
     XCTAssertTrue(summary.isDownloadableVideo);
+    XCTAssertTrue([summary.downloadURL isEqualToString:all_sources[2]]);
     XCTAssertFalse(summary.isYoutubeVideo);
 }
 
@@ -230,10 +237,10 @@
 
     [OEXConfig setSharedConfig:overrideConfig];
     summary = [[OEXVideoSummary alloc] initWithDictionary:[self summaryWithEncodings:@[youtube, hls] andOnlyOnWeb:false andAllSources:all_sources]];
+    [OEXConfig setSharedConfig:origConfig];
     
     XCTAssertTrue(summary.isSupportedVideo);
     XCTAssertFalse(summary.isDownloadableVideo);
     XCTAssertFalse(summary.isYoutubeVideo);
-    [OEXConfig setSharedConfig:origConfig];
 }
 @end


### PR DESCRIPTION
### Description

Allows HLS videos to be streamed.

And because HLS videos cannot be downloaded using our current video download library, then fallback video URLs are used for downloading.  

The following sources are used to locate a valid download URL:

* available encodings, when the Video Pipeline is enabled.
* HTML5 sources, when the Video Pipeline is disabled.

**JIRA**

[OSPR-2019](https://openedx.atlassian.net/browse/OSPR-2019)

### Notes

Functionality depends on API changes in https://github.com/edx/edx-platform/pull/16590, but the app continues to work even if this change is not deployed yet.

Builds on https://github.com/edx/edx-app-ios/pull/1014, which differentiates between streamable and downloadable video URLs.

We'd like to get this merged before the next edx-app-ios release.

### How to test this PR

Ensure that the changes from https://github.com/edx/edx-platform/pull/16590 are running in your LMS, and import this [video_test_course.tar.gz](https://github.com/edx/edx-app-ios/files/1493756/video_test_course.Dl2Kjh.tar.gz), which contains permutations of all the various video streaming/download scenarios.

Alternately, run against this sandbox server, using:
```yaml
API_HOST_URL: 'https://pr16590.sandbox.opencraft.hosting'
OAUTH_CLIENT_ID: '14cdc120d61349b7eeba'
```

1. Run the iOS app.
1. Login as a student to the test course.
1. Visit each of the course subsections in turn, noting the expected Streaming and Download behaviours for each unit below.
    *note* Once you've downloaded a video, that video will be used in the player, regardless of what the original streaming video URL is.  So to test the permutations below, try streaming first, then download.

* YouTube:
    * Standard: YouTube 
        * Streaming: YouTube only; will not play on iOS app, but will play in browser.
        * Download: none
    * Standard w Fallback:  
        * Streaming: 0.05 mp4 (same as MP4 - 1), different from YouTube video
        * Download: yes, same as stream
    * HLS live stream:
        * Streaming: YouTube only; will not play on iOS app, but will play in browser.
        * Download: none
    * HLS w fallback:
        * Streaming: 0.05 mp4 (same as MP4 - 1)
            *Note* The main video is configured to use the same YouTube HLS used in the previous unit, but `USING_VIDEO_PIPELINE: false` causes the fallback URL to be streamed instead.
        * Download: Same as stream.
* MP4 
    * MP4 - 1
        * Streaming: 0.05 mp4 
        * Download: yes, same as stream
    * MP4 - 1 w fallback
        * Streaming: 0.05 mp4 
        * Download: yes, same as stream
            *Note* Fallback video is configured to be the 0:27 mp4 used by MP4 - 2, but because the main video 
            can be downloaded, the fallback video is ignored.
    * MP4 - 2
        * Streaming: 0:27 mp4 
        * Download: yes, same as stream
    * MP4 - 2 w fallback
        * Streaming: 0:27 mp4 
        * Download: yes, same as stream
            *note* Fallback video is configured to be the 0:05 mp4 used by MP4 - 1, but because the main video 
            can be downloaded, the fallback video is ignored.
* HLS .m3u8
    * HLS (10 min):
        * Streaming: 10:35 video
        * Download: none
    * HLS (10 min) w fallback:
        * Streaming: 10:35 video
        * Download: 0:27 mp4, same as MP4 - 2
    * Vimeo
        * Streaming: 8:22 Cloudera m3mu
        * Download: none
    * Vimeo w fallback
        * Streaming: 8:22 Cloudera m3mu
        * Download: 8:22 Cloudera mp4

### Screenshots

`USING_VIDEO_PIPELINE: false`
* Course page
 ![using_video_pipeline false course](https://user-images.githubusercontent.com/7556571/34403760-2b854134-ebfa-11e7-9324-a73992440929.png)
* YouTube section
  ![using_video_pipeline false youtube](https://user-images.githubusercontent.com/7556571/34403766-36f68cee-ebfa-11e7-99e4-e367c751925b.png)
* MP4 section
 ![using_video_pipeline false mp4](https://user-images.githubusercontent.com/7556571/34403769-3c3932ba-ebfa-11e7-9435-5278300f3838.png)
* HLS section
   ![using_video_pipeline false hls](https://user-images.githubusercontent.com/7556571/34403774-4256a6dc-ebfa-11e7-85f4-63206a75a581.png)

`USING_VIDEO_PIPELINE: true`
* Course page
  ![using_video_pipeline true course](https://user-images.githubusercontent.com/7556571/34403793-5a471b32-ebfa-11e7-9439-b61f955e0338.png)
* YouTube section
  ![using_video_pipeline true youtube](https://user-images.githubusercontent.com/7556571/34403797-5edcb454-ebfa-11e7-86a1-9d64e13c957f.png)
* MP4 section
  ![using_video_pipeline true mp4](https://user-images.githubusercontent.com/7556571/34403800-63d4d25c-ebfa-11e7-89d7-9e0301e92e0a.png)
* HLS section
   ![using_video_pipeline true hls](https://user-images.githubusercontent.com/7556571/34403805-692a1384-ebfa-11e7-87b8-be31a68c1ab0.png)

### Reviewers

- [x] @bradenmacdonald 
- [ ] edX TBD