### PR TITLE
add flag INVERT_COLOR_LOGIN_SPLASH_VIEW_SIGN_IN_BTN

### DIFF
--- a/Source/OEXConfig+AppFeatures.swift
+++ b/Source/OEXConfig+AppFeatures.swift
@@ -87,4 +87,8 @@ extension OEXConfig {
     var isTabsDashboardEnabled: Bool {
         return bool(forKey: "TABS_DASHBOARD_ENABLED")
     }
+    
+    var invertColorLoginSlpashViewSignInBtn: Bool {
+        return bool(forKey: "INVERT_COLOR_LOGIN_SPLASH_VIEW_SIGN_IN_BTN")
+    }
 }

--- a/Source/OEXLoginSplashViewController.m
+++ b/Source/OEXLoginSplashViewController.m
@@ -39,6 +39,10 @@
     [self.signInButton setTitle:[Strings loginSplashSignIn] forState:UIControlStateNormal];
     [self.signUpButton applyButtonStyleWithStyle:[self.environment.styles filledPrimaryButtonStyle] withTitle:[Strings loginSplashSignUp]];
     [self.signInButton.titleLabel setFont:[self.environment.styles boldSansSerifOfSize:14.0f]];
+    if (self.environment.config.invertColorLoginSlpashViewSignInBtn) {
+        [self.signInButton setTitleColor:[self.environment.styles neutralBlack] forState:UIControlStateNormal];
+        [self.signInButton setTitleColor:[self.environment.styles neutralBlack] forState:UIControlStateSelected];
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated {


### PR DESCRIPTION
### Description

[OSPR-2025](https://openedx.atlassian.net/browse/OSPR-2025)

The text color of the button ```Already have an account? Sign in``` in ```OEXLoginSplashViewController.xib``` is by default white.
Sometimes the background image used in that view doesn´t work with the white color and manually the text color needs to be updated to use another color, generally black.
With the flag ```INVERT_COLOR_LOGIN_SPLASH_VIEW_SIGN_IN_BTN```we can invert the color so instead of everytime changing the color manually it can all be done by configuration.

### How to test this PR

Add the flag ```INVERT_COLOR_LOGIN_SPLASH_VIEW_SIGN_IN_BTN``` and set it to ```True```. The text color of the button should be black.

### Reviewers
- [ ] Code review: @saeedbashir 
- [ ] Code review: @salman2013 