### PR TITLE
Fix tab layout navigation

### DIFF
--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -114,7 +114,7 @@ extension OEXRouter {
     }
     
     @objc(showMyCoursesAnimated:pushingCourseWithID:) func showMyCourses(animated: Bool = true, pushingCourseWithID courseID: String? = nil) {
-        let controller = EnrolledCoursesViewController(environment: self.environment)
+        let controller = self.environment.config.isTabLayoutEnabled ? EnrolledTabBarViewController(environment: self.environment) : EnrolledCoursesViewController(environment: self.environment)
         showContentStack(withRootController: controller, animated: animated)
         if let courseID = courseID {
             self.showCourseWithID(courseID: courseID, fromController: controller, animated: false)
@@ -269,7 +269,8 @@ extension OEXRouter {
             else {
                 showContentStack(withRootController: controller, animated: true)
             }
-            
+        } else if self.environment.config.isTabLayoutEnabled {
+            fromController?.tabBarController?.selectedIndex = 1
         } else {
             showControllerFromStartupScreen(controller: controller)
         }


### PR DESCRIPTION
### Description

[OSPR-2163](https://openedx.atlassian.net/browse/OSPR-2163)

If the flag ```TAB_LAYOUTS_ENABLED``` is set to ```True``` the navigation stack gets messed up when trying to view a course through the ```Find Courses``` tab. When you access a course and go back it doesn't display the ```EnrolledTabBarViewController``` but instead ```EnrolledCoursesViewController```. The tabs ```Courses``` and ```Find Courses``` disappear. The ```Account``` and ```Profile``` buttons also disappear so it is impossible to logout from the app. The only way to make appear again the correct layout is to close the app completely and open it again.

### How to test this PR

Set the flag ```TAB_LAYOUTS_ENABLED``` to ```True```. Run the and check that when going to a course through the ```Find Courses``` tab when you go back it actually shows the correct layout.

### Example

**Current**
1. 
<img width="379" alt="screen shot 2018-01-23 at 11 51 53 am" src="https://user-images.githubusercontent.com/3858265/35269719-85854ac2-0035-11e8-8f8c-d94f8b254cc0.png">

2.
 <img width="372" alt="screen shot 2018-01-23 at 11 52 00 am" src="https://user-images.githubusercontent.com/3858265/35269723-877740ec-0035-11e8-857f-7b6c12cb643b.png">

3.
 <img width="370" alt="screen shot 2018-01-23 at 11 52 10 am" src="https://user-images.githubusercontent.com/3858265/35269725-892b19e0-0035-11e8-95d5-7f7e8ba2dfe1.png">

4.
 <img width="385" alt="screen shot 2018-01-23 at 11 52 16 am" src="https://user-images.githubusercontent.com/3858265/35269729-8aaa446c-0035-11e8-95b2-3aa55e480438.png">

**Fix**
1. 
<img width="379" alt="screen shot 2018-01-23 at 11 51 53 am" src="https://user-images.githubusercontent.com/3858265/35269733-8e686624-0035-11e8-9b4d-0c54587b0228.png">

2. 
<img width="372" alt="screen shot 2018-01-23 at 11 52 00 am" src="https://user-images.githubusercontent.com/3858265/35269746-90a5e9d4-0035-11e8-91dd-107ad8592bed.png">

3. 
<img width="370" alt="screen shot 2018-01-23 at 11 52 10 am" src="https://user-images.githubusercontent.com/3858265/35269750-94018a8e-0035-11e8-858c-3235acf87e08.png">

4.
<img width="383" alt="screen shot 2018-01-23 at 11 53 18 am" src="https://user-images.githubusercontent.com/3858265/35317441-85ea0cdc-00df-11e8-813f-35600c734386.png">


### Reviewers

- [x] Code review: @saeedbashir 
- [ ] Code review: @salman2013 

cc @nedbat 

![](https://media.giphy.com/media/EYtHITkBdAvNm/giphy.gif)
