### PR TITLE
Crash fix if course_dates_fragment or xBlock end points returns 500

### DIFF
--- a/Source/AuthenticatedWebViewController.swift
+++ b/Source/AuthenticatedWebViewController.swift
@@ -262,10 +262,12 @@ public class AuthenticatedWebViewController: UIViewController, WKNavigationDeleg
             
             switch errorGroup {
             case HttpErrorGroup.http4xx:
-                self.state = .NeedingSession
+                state = .NeedingSession
+                break
             case HttpErrorGroup.http5xx:
-                self.loadController.state = LoadState.failed()
+                loadController.state = LoadState.failed()
                 decisionHandler(.cancel)
+                return
             }
         }
         decisionHandler(.allow)


### PR DESCRIPTION
### Description

[LEARNER-4372](https://openedx.atlassian.net/browse/LEARNER-4372)

The issue was introduced because Apple had made some changes in WebKit in their latest iOS SDK (Xcode 9.x & iOS 11) and didn't inform developers about this change. A number of people have reported this issue. Version 2.13.2 was the first version which was built by latest Xcode and in our case App is crashing if mobile_dates_fragment or any xBlock returns an error code of 500 error codes family

### Notes

### How to test this PR
