### PR TITLE
Adding NSContactsUsageDescription privacy value

### DIFF
--- a/Source/edX-Info.plist
+++ b/Source/edX-Info.plist
@@ -82,6 +82,8 @@
 	<string>for bluetooth</string>
 	<key>NSCameraUsageDescription</key>
 	<string>so you can take a picture for a profile image</string>
+	<key>NSContactsUsageDescription</key>
+	<string>so you can save a contact</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>so you can select a profile image</string>
 	<key>UIAppFonts</key>


### PR DESCRIPTION
### Description

[LEARNER-4407](https://openedx.atlassian.net/browse/LEARNER-4407)

Although edX is not interacting with *Contacts* directly, but a user can save or create a new contact from comments screen by using force touch functionality because `dataDetectorTypes` is enabled for `UITextView`. From the force touch menu, a new contact can be created with the phone number, or the phone number can be added to an existing contact. Once the user taps on *Add To Contact*, the application will try to request access to the address book. If `info.plist` don't have NSContactsUsageDescription, the app will crash.
