### PR TITLE
Use correct tint color for UIToolbar

### DIFF
--- a/Source/OEXStyles+Swift.swift
+++ b/Source/OEXStyles+Swift.swift
@@ -48,7 +48,7 @@ extension OEXStyles {
         UINavigationBar.appearance().titleTextAttributes = navigationTitleTextStyle.attributes
         UIBarButtonItem.appearance().setTitleTextAttributes(navigationButtonTextStyle.attributes, for: .normal)
         
-        UIToolbar.appearance().tintColor = navigationBarColor()
+        UIToolbar.appearance().tintColor = navigationItemTintColor()
         
         let styleAttributes = OEXTextStyle(weight: .normal, size : .small, color : self.neutralBlack()).attributes
         UISegmentedControl.appearance().setTitleTextAttributes(styleAttributes, for: UIControlState.selected)


### PR DESCRIPTION
### Description

[OSPR-2318](https://openedx.atlassian.net/browse/OSPR-2318)

This PR sets the correct tint color for the `UIToolbar`. Currently, it is using `navigationBarColor()` and it should be using `navigationItemTintColor()`

Before

<img width="492" alt="screen shot 2018-03-26 at 12 49 51" src="https://user-images.githubusercontent.com/3858265/37903377-f3bc3562-30f7-11e8-8949-5e3de32708c1.png">

After

<img width="455" alt="screen shot 2018-03-26 at 12 50 53" src="https://user-images.githubusercontent.com/3858265/37903389-fcd36aa8-30f7-11e8-8ebe-9c7d1dbc8da0.png">

### Reviewers
- [ ] Code review: @saeedbashir 
- [ ] Code review: @salman2013 

cc @marcotuts 