### PR TITLE
Accessibility identifier for message label on Startup Screen

### DIFF
--- a/Source/StartupViewController.swift
+++ b/Source/StartupViewController.swift
@@ -86,6 +86,7 @@ class StartupViewController: UIViewController, InterfaceOrientationOverriding {
         let labelStyle = OEXTextStyle(weight: .semiBold, size: .xxLarge, color: environment.styles.primaryBaseColor())
         messageLabel.numberOfLines = 0
         messageLabel.attributedText = labelStyle.attributedString(withText: Strings.Startup.infoMessageText)
+        messageLabel.accessibilityIdentifier = "StartUpViewController:message-label"
         view.addSubview(messageLabel)
         
         messageLabel.snp_makeConstraints { (make) in


### PR DESCRIPTION
Accessibility identifier got missed during the implementation of new landing screen. It is required for the implementation of [LEARNER-4692](https://openedx.atlassian.net/browse/LEARNER-4692) by *Automation Team*.
