### PR TITLE
Patch for UIPageViewController crash

### DIFF
--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -118,6 +118,7 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
                 {
                     owner.setPageControllers(with: [controller], direction: .forward, animated: false, competion: { [weak self] (finished) in
                         self?.view.isUserInteractionEnabled = true
+                        self?.navigationController?.toolbar.isUserInteractionEnabled = true
                     })
                 }
                 else {
@@ -273,6 +274,7 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
         {
             setPageControllers(with: [nextController], direction: direction, animated: true, competion: { [weak self] (finished) in
                 self?.view.isUserInteractionEnabled = true
+                self?.navigationController?.toolbar.isUserInteractionEnabled = true
             })
         }
     }
@@ -281,6 +283,7 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
         // setViewControllers is being called in async thread so user may intract with UIPageController in that duration so
         // disabling user interation while setting viewControllers of UIPageViewController
         view.isUserInteractionEnabled = false
+        navigationController?.toolbar.isUserInteractionEnabled = false
         DispatchQueue.main.async { [weak self] in
             self?.setViewControllers(controllers, direction: direction, animated: animated, completion: competion)
             self?.updateNavigationForEnteredController(controller: controllers.first)

--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -202,11 +202,11 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     }
     
     private func updateNavigationBars() {
-        DispatchQueue.main.async { [weak self] in
-            if let cursor = self?.contentLoader.value {
 
-                let item = cursor.current
+        if let cursor = contentLoader.value {
+            let item = cursor.current
 
+            DispatchQueue.main.async { [weak self] in
                 // only animate change if we haven't set a title yet, so the initial set happens without
                 // animation to make the push transition work right
                 let actions : () -> Void = {
@@ -214,6 +214,7 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
                 }
                 if let navigationBar = self?.navigationController?.navigationBar, let _ = self?.navigationItem.title {
                     let animated = self?.navigationItem.title != nil
+
                     UIView.transition(with: navigationBar,
                                       duration: 0.3 * (animated ? 1.0 : 0.0), options: UIViewAnimationOptions.transitionCrossDissolve,
                                       animations: actions, completion: nil)
@@ -221,21 +222,19 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
                 else {
                     actions()
                 }
+            }
 
-                let prevItem = self?.toolbarItemWithGroupItem(item: item, adjacentGroup: item.prevGroup, direction: .Prev, enabled: cursor.hasPrev)
-                let nextItem = self?.toolbarItemWithGroupItem(item: item, adjacentGroup: item.nextGroup, direction: .Next, enabled: cursor.hasNext)
-                if let prevItem = prevItem, let nextItem = nextItem {
-                    self?.setToolbarItems(
-                        [
-                            prevItem,
-                            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
-                            nextItem
-                        ], animated : true)
-                }
-            }
-            else {
-                self?.toolbarItems = []
-            }
+            let prevItem = toolbarItemWithGroupItem(item: item, adjacentGroup: item.prevGroup, direction: .Prev, enabled: cursor.hasPrev)
+            let nextItem = toolbarItemWithGroupItem(item: item, adjacentGroup: item.nextGroup, direction: .Next, enabled: cursor.hasNext)
+            setToolbarItems(
+                [
+                    prevItem,
+                    UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+                    nextItem
+                ], animated : true)
+        }
+        else {
+            toolbarItems = []
         }
     }
     
@@ -385,11 +384,11 @@ extension CourseContentPageViewController {
     }
     
     public var t_prevButtonEnabled : Bool {
-        return self.toolbarItems![0].isEnabled
+        return self.toolbarItems?[0].isEnabled ?? false
     }
     
     public var t_nextButtonEnabled : Bool {
-        return self.toolbarItems![2].isEnabled
+        return self.toolbarItems?[2].isEnabled ?? false
     }
     
     public func t_goForward() {


### PR DESCRIPTION
### Description

[LEARNER-3208](https://openedx.atlassian.net/browse/LEARNER-3208)

The crash is irreproducible so I'm not sure either this patch will fix it completely. I have applied the solutions which were mentioned by so other developers on StackOver flow. The first solution which I have applied can be found at [link](https://stackoverflow.com/questions/20004310/invalid-parameter-exception-thrown-by-uiqueuingscrollview) and the second solution which I have applied can be found at [link](https://stackoverflow.com/questions/24000712/pageviewcontroller-setviewcontrollers-crashes-with-invalid-parameter-not-satisf/24749239#24749239).  