### PR TITLE
Adds configurable URLs for EULA, TOS etc.

### DIFF
--- a/Source/AgreementTextView.swift
+++ b/Source/AgreementTextView.swift
@@ -21,11 +21,11 @@ class AgreementTextView: UITextView {
     
     weak var agreementDelegate: AgreementTextViewDelegate?
     
-    @objc func setup(for type: AgreementType) {
+    @objc func setup(for type: AgreementType, config: OEXConfig?) {
         let style = OEXMutableTextStyle(weight: .normal, size: .xSmall, color: OEXStyles.shared().neutralDark())
         style.lineBreakMode = .byWordWrapping
         style.alignment = .center
-        let platformName = OEXConfig.shared().platformName()
+        let platformName = config?.platformName() ?? ""
         let prefix: String
         switch type {
         case .signIn:
@@ -40,9 +40,9 @@ class AgreementTextView: UITextView {
         let privacyPolicyText = Strings.Agreement.linkTextPrivacyPolicy
         let agreementText = "\(prefix)\(Strings.Agreement.text(eula: eulaText, tos: tosText, privacyPolicy: privacyPolicyText))"
         var attributedString = style.attributedString(withText: agreementText)
-        if let eulaUrl = OEXConfig.shared().agreementURLsConfig.eulaURL,
-            let tosUrl = OEXConfig.shared().agreementURLsConfig.tosURL,
-            let privacyPolicyUrl = OEXConfig.shared().agreementURLsConfig.privacyPolicyURL {
+        if let eulaUrl = config?.agreementURLsConfig.eulaURL,
+            let tosUrl = config?.agreementURLsConfig.tosURL,
+            let privacyPolicyUrl = config?.agreementURLsConfig.privacyPolicyURL {
             attributedString = attributedString.addLink(on: eulaText, value: eulaUrl)
             attributedString = attributedString.addLink(on: tosText, value: tosUrl)
             attributedString = attributedString.addLink(on: privacyPolicyText, value: privacyPolicyUrl)

--- a/Source/AgreementTextView.swift
+++ b/Source/AgreementTextView.swift
@@ -40,9 +40,9 @@ class AgreementTextView: UITextView {
         let privacyPolicyText = Strings.Agreement.linkTextPrivacyPolicy
         let agreementText = "\(prefix)\(Strings.Agreement.text(eula: eulaText, tos: tosText, privacyPolicy: privacyPolicyText))"
         var attributedString = style.attributedString(withText: agreementText)
-        if let eulaUrl = Bundle.main.url(forResource: "MobileAppEula", withExtension: "htm"),
-            let tosUrl = Bundle.main.url(forResource: "TermsOfServices", withExtension: "htm"),
-            let privacyPolicyUrl = Bundle.main.url(forResource: "PrivacyPolicy", withExtension: "htm") {
+        if let eulaUrl = OEXConfig.shared().agreementURLsConfig.eulaURL,
+            let tosUrl = OEXConfig.shared().agreementURLsConfig.tosURL,
+            let privacyPolicyUrl = OEXConfig.shared().agreementURLsConfig.privacyPolicyURL {
             attributedString = attributedString.addLink(on: eulaText, value: eulaUrl)
             attributedString = attributedString.addLink(on: tosText, value: tosUrl)
             attributedString = attributedString.addLink(on: privacyPolicyText, value: privacyPolicyUrl)

--- a/Source/AgreementURLsConfig.swift
+++ b/Source/AgreementURLsConfig.swift
@@ -1,0 +1,50 @@
+//
+//  AgreementURLsConfig.swift
+//
+//  Created by Afzal Wali on 20/May/2018
+//  OpenSource Contribution
+//
+
+import Foundation
+
+private enum AgreementURLsKeys: String, RawStringExtractable {
+    case eulaURL = "EULA_URL"
+    case tosURL = "TOS_URL"
+    case privacyPolicyURL = "PRIVACY_POLICY_URL"
+}
+
+class AgreementURLsConfig : NSObject {
+    let eulaURL: URL?
+    let tosURL: URL?
+    let privacyPolicyURL: URL?
+    
+    init(dictionary: [String: AnyObject]) {
+        if let eulaURL = dictionary[AgreementURLsKeys.eulaURL] as? String {
+            self.eulaURL = URL(string: eulaURL)
+        }
+        else {
+            self.eulaURL = Bundle.main.url(forResource: "MobileAppEula", withExtension: "htm")
+        }
+        
+        if let tosURL = dictionary[AgreementURLsKeys.tosURL] as? String {
+            self.tosURL = URL(string: tosURL)
+        }
+        else {
+            self.tosURL = Bundle.main.url(forResource: "TermsOfServices", withExtension: "htm")
+        }
+        
+        if let privacyPolicyURL = dictionary[AgreementURLsKeys.privacyPolicyURL] as? String {
+            self.privacyPolicyURL = URL(string: privacyPolicyURL)
+        }
+        else {
+            self.privacyPolicyURL = Bundle.main.url(forResource: "PrivacyPolicy", withExtension: "htm")
+        }
+    }
+}
+
+private let key = "AGREEMENT_URLS"
+extension OEXConfig {
+    var agreementURLsConfig : AgreementURLsConfig {
+        return AgreementURLsConfig(dictionary: self[key] as? [String:AnyObject] ?? [:])
+    }
+}

--- a/Source/AgreementURLsConfig.swift
+++ b/Source/AgreementURLsConfig.swift
@@ -23,21 +23,21 @@ class AgreementURLsConfig : NSObject {
             self.eulaURL = URL(string: eulaURL)
         }
         else {
-            self.eulaURL = Bundle.main.url(forResource: "MobileAppEula", withExtension: "htm")
+            eulaURL = Bundle.main.url(forResource: "MobileAppEula", withExtension: "htm")
         }
         
         if let tosURL = dictionary[AgreementURLsKeys.tosURL] as? String {
             self.tosURL = URL(string: tosURL)
         }
         else {
-            self.tosURL = Bundle.main.url(forResource: "TermsOfServices", withExtension: "htm")
+            tosURL = Bundle.main.url(forResource: "TermsOfServices", withExtension: "htm")
         }
         
         if let privacyPolicyURL = dictionary[AgreementURLsKeys.privacyPolicyURL] as? String {
             self.privacyPolicyURL = URL(string: privacyPolicyURL)
         }
         else {
-            self.privacyPolicyURL = Bundle.main.url(forResource: "PrivacyPolicy", withExtension: "htm")
+            privacyPolicyURL = Bundle.main.url(forResource: "PrivacyPolicy", withExtension: "htm")
         }
     }
 }

--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -180,7 +180,7 @@
 }
 
 -(void) setUpAgreementTextView {
-    [self.agreementTextView setupFor:AgreementTypeSignIn];
+    [self.agreementTextView setupFor:AgreementTypeSignIn config:self.environment.config];
     self.agreementTextView.agreementDelegate = self;
     // To adjust textView according to its content size.
     self.agreementTextViewHeight.constant = self.agreementTextView.contentSize.height + [self.environment.styles standardHorizontalMargin];

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -173,7 +173,7 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
 }
 
 -(void) setUpAgreementTextView {
-    [self.agreementTextView setupFor:AgreementTypeSignUp];
+    [self.agreementTextView setupFor:AgreementTypeSignUp config:self.environment.config];
     self.agreementTextView.agreementDelegate = self;
     CGSize size = [self.agreementTextView sizeThatFits:CGSizeMake(self.scrollView.frame.size.width - 2 * self.styles.formMargin, CGFLOAT_MAX)];
     self.agreementTextView.frame = CGRectMake(0, 0, size.width, size.height + [[OEXStyles sharedStyles] standardHorizontalMargin]);

--- a/Source/OEXUserLicenseAgreementViewController.m
+++ b/Source/OEXUserLicenseAgreementViewController.m
@@ -64,6 +64,7 @@
 - (void)webView:(UIWebView*)webView didFailLoadWithError:(NSError*)error {
     [activityIndicator stopAnimating];
     OEXLogInfo(@"EULA", @"Error is %@", error.localizedDescription);
+    [[UIAlertController alloc] showAlertWithTitle:nil message:error.localizedDescription onViewController:self];
 }
 
 - (void)webViewDidFinishLoad:(UIWebView*)webView {

--- a/Test/AgreementURLsConfigTests.swift
+++ b/Test/AgreementURLsConfigTests.swift
@@ -14,9 +14,9 @@ class AgreementURLsConfigTests : XCTestCase {
     func testAgreementURLsConfig() {
         // In case the configuration values are provided, they should be used instead of the
         // fallback values.
-        let eulaUrl = "https://www.google.com/chrome/privacy/eula_text.html"
-        let tosUrl = "https://policies.google.com/terms"
-        let privacyPolicyUrl = "https://www.google.com/chrome/privacy/privacy_text.html"
+        let eulaUrl = "https://example-eula.com"
+        let tosUrl = "https://example-tos.com"
+        let privacyPolicyUrl = "https://example-policy.com"
         let configDictionary = [
             "AGREEMENT_URLS" : [
                 "EULA_URL": eulaUrl,
@@ -55,7 +55,7 @@ class AgreementURLsConfigTests : XCTestCase {
         // In the case where some of the config values are overridden, the AgreementURLsConfig
         // should be populated with fallback values for the remaining values.
         
-        let eulaUrlOverride = "https://www.google.com/chrome/privacy/eula_text.html"
+        let eulaUrlOverride = "https://example-eula.com"
         let configDictionary = [
             "AGREEMENT_URLS" : [
                 "EULA_URL": eulaUrlOverride

--- a/Test/AgreementURLsConfigTests.swift
+++ b/Test/AgreementURLsConfigTests.swift
@@ -1,0 +1,75 @@
+//
+//  AgreementURLsConfigTests.swift
+//
+//  Created by Afzal Wali on 20/May/2018
+//  OpenSource Contribution
+//
+
+import Foundation
+import XCTest
+@testable import edX
+
+class AgreementURLsConfigTests : XCTestCase {
+
+    func testAgreementURLsConfig() {
+        // In case the configuration values are provided, they should be used instead of the
+        // fallback values.
+        let eulaUrl = "https://www.google.com/chrome/privacy/eula_text.html"
+        let tosUrl = "https://policies.google.com/terms"
+        let privacyPolicyUrl = "https://www.google.com/chrome/privacy/privacy_text.html"
+        let configDictionary = [
+            "AGREEMENT_URLS" : [
+                "EULA_URL": eulaUrl,
+                "TOS_URL": tosUrl,
+                "PRIVACY_POLICY_URL": privacyPolicyUrl
+            ]
+        ]
+        let config = OEXConfig(dictionary: configDictionary)
+
+        XCTAssertNotNil(config.agreementURLsConfig)
+        XCTAssertNotNil(config.agreementURLsConfig.eulaURL)
+        XCTAssertNotNil(config.agreementURLsConfig.tosURL)
+        XCTAssertNotNil(config.agreementURLsConfig.privacyPolicyURL)
+        
+        XCTAssertEqual(config.agreementURLsConfig.eulaURL?.absoluteString, eulaUrl)
+        XCTAssertEqual(config.agreementURLsConfig.tosURL?.absoluteString, tosUrl)
+        XCTAssertEqual(config.agreementURLsConfig.privacyPolicyURL?.absoluteString, privacyPolicyUrl)
+    }
+
+    func testAgreementURLsNoConfig() {
+        // In the case where no config values are overridden, the AgreementURLsConfig should be
+        // populated with fallback values
+        let config = OEXConfig(dictionary:[:])
+        XCTAssertNotNil(config.agreementURLsConfig)
+
+        let eulaUrl = Bundle.main.url(forResource: "MobileAppEula", withExtension: "htm")
+        let tosUrl = Bundle.main.url(forResource: "TermsOfServices", withExtension: "htm")
+        let privacyPolicyUrl = Bundle.main.url(forResource: "PrivacyPolicy", withExtension: "htm")
+        
+        XCTAssertEqual(config.agreementURLsConfig.eulaURL, eulaUrl)
+        XCTAssertEqual(config.agreementURLsConfig.tosURL, tosUrl)
+        XCTAssertEqual(config.agreementURLsConfig.privacyPolicyURL, privacyPolicyUrl)
+    }
+    
+    func testAgreementURLsPartialConfig() {
+        // In the case where some of the config values are overridden, the AgreementURLsConfig
+        // should be populated with fallback values for the remaining values.
+        
+        let eulaUrlOverride = "https://www.google.com/chrome/privacy/eula_text.html"
+        let configDictionary = [
+            "AGREEMENT_URLS" : [
+                "EULA_URL": eulaUrlOverride
+            ]
+        ]
+        let config = OEXConfig(dictionary: configDictionary)
+        
+        XCTAssertNotNil(config.agreementURLsConfig)
+
+        let tosUrlBundle = Bundle.main.url(forResource: "TermsOfServices", withExtension: "htm")
+        let privacyPolicyUrlBundle = Bundle.main.url(forResource: "PrivacyPolicy", withExtension: "htm")
+        
+        XCTAssertEqual(config.agreementURLsConfig.eulaURL?.absoluteString, eulaUrlOverride)
+        XCTAssertEqual(config.agreementURLsConfig.tosURL, tosUrlBundle)
+        XCTAssertEqual(config.agreementURLsConfig.privacyPolicyURL, privacyPolicyUrlBundle)
+    }
+}

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -126,6 +126,8 @@
 		22F6A15F20BD2D06009C3F4A /* String+DecodeHTMLEntitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F6A15E20BD2D05009C3F4A /* String+DecodeHTMLEntitiesTests.swift */; };
 		22F8A9101F45EFAF0025E18A /* AccountViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F8A90F1F45EFAF0025E18A /* AccountViewControllerTest.swift */; };
 		22F8A9141F4708A50025E18A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22F8A9131F4708A50025E18A /* Main.storyboard */; };
+		3F92D6E420B1996800A69806 /* AgreementURLsConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F92D6E320B1996800A69806 /* AgreementURLsConfigTests.swift */; };
+		3F92D6E620B19C9B00A69806 /* AgreementURLsConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F92D6E520B19C9B00A69806 /* AgreementURLsConfig.swift */; };
 		46CECC3A1B041CDC0073C63A /* CourseCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CECC391B041CDC0073C63A /* CourseCardView.swift */; };
 		46CECC3C1B041D270073C63A /* AdditionalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CECC3B1B041D270073C63A /* AdditionalTableViewCell.swift */; };
 		46CECC401B041FCA0073C63A /* DiscussionTopicsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CECC3F1B041FCA0073C63A /* DiscussionTopicsViewController.swift */; };
@@ -959,6 +961,8 @@
 		22F6A15E20BD2D05009C3F4A /* String+DecodeHTMLEntitiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+DecodeHTMLEntitiesTests.swift"; sourceTree = "<group>"; };
 		22F8A90F1F45EFAF0025E18A /* AccountViewControllerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AccountViewControllerTest.swift; path = ../Source/AccountViewControllerTest.swift; sourceTree = "<group>"; };
 		22F8A9131F4708A50025E18A /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		3F92D6E320B1996800A69806 /* AgreementURLsConfigTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AgreementURLsConfigTests.swift; path = Test/AgreementURLsConfigTests.swift; sourceTree = SOURCE_ROOT; };
+		3F92D6E520B19C9B00A69806 /* AgreementURLsConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgreementURLsConfig.swift; sourceTree = "<group>"; };
 		46CECC391B041CDC0073C63A /* CourseCardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseCardView.swift; sourceTree = "<group>"; };
 		46CECC3B1B041D270073C63A /* AdditionalTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdditionalTableViewCell.swift; sourceTree = "<group>"; };
 		46CECC3D1B041FAF0073C63A /* DiscussionTopicCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscussionTopicCell.swift; sourceTree = "<group>"; };
@@ -2947,6 +2951,7 @@
 		B44A52791A63E57A00943542 /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
+				3F92D6E520B19C9B00A69806 /* AgreementURLsConfig.swift */,
 				7742F8DC1C3C979D009E555A /* EnrollmentConfig.swift */,
 				775434841AD73D1900635A40 /* OEXParseConfig.h */,
 				775434851AD73D1900635A40 /* OEXParseConfig.m */,
@@ -3321,6 +3326,7 @@
 		BECB7B331924C0C3009C77F1 /* Unit Tests */ = {
 			isa = PBXGroup;
 			children = (
+				3F92D6E320B1996800A69806 /* AgreementURLsConfigTests.swift */,
 				22F8A90F1F45EFAF0025E18A /* AccountViewControllerTest.swift */,
 				E0CB646E1F20B6DD00CEF378 /* DateFormattingTests.swift */,
 				7768745A1CDCCB1E001DFB77 /* RemoteImageTests.swift */,
@@ -4406,6 +4412,7 @@
 				77C182AC1CD2E60E00AE1474 /* StackPaginationManipulator.swift in Sources */,
 				5D7EACC81B3E202C000A6C36 /* DiscussionAPI.swift in Sources */,
 				77EA92261BB4590A00EC625A /* DownloadsAccessoryView.swift in Sources */,
+				3F92D6E620B19C9B00A69806 /* AgreementURLsConfig.swift in Sources */,
 				77ADF4A61AC1B35000AC8955 /* OEXExternalAuthProviderButton.m in Sources */,
 				77C182AA1CD2E46900AE1474 /* TablePaginationManipulator.swift in Sources */,
 				0B1212221B4F089A002EE96C /* OEXCoursewareAccess.m in Sources */,
@@ -4688,6 +4695,7 @@
 				773181401B6C23F9000CC050 /* DiscussionTopic+DataFactory.swift in Sources */,
 				E00523451CFD768700B7F5C3 /* DiscussionBlockViewControllerTests.swift in Sources */,
 				77C6BBC81CB43A6D0026C37B /* TabContainerViewTests.swift in Sources */,
+				3F92D6E420B1996800A69806 /* AgreementURLsConfigTests.swift in Sources */,
 				223A5F201FA9AA8F008C9963 /* CourseDashboardViewControllerTests.swift in Sources */,
 				021AD6281F166F78009AF653 /* CourseCatalogDetailViewControllerTests.swift in Sources */,
 				770A27A11A6F172300DFC6FF /* OEXVideoSummaryTests.m in Sources */,


### PR DESCRIPTION
### Description

This PR adds the ability for the application to read the URLs for EULA, TOS and the Privacy Policy from the configuration. This is useful for WhiteLabel apps which need to override these texts for their app.


### Notes

Files locations:
    AgreementURLsConfig.swift in App/Source/Configuration
    AgreementTextView.swift in App/Source/Helper Views
    AgreementURLsConfigTests in App/Tests/Unit Tests


### How to test this PR

In the default_config.yaml file, add this dictionary:

AGREEMENT_URLS: {
  EULA_URL: 'https://www.cloudera.com/legal/commercial-terms-and-conditions/cloudera-training-terms/cloudera-ta-v6-2017-05-25.html'
}

The EULA on the registration page will link to the URL above. Default values will be used for the other two URLs.

Screenshots:
![simulator screen shot - iphone x - 2018-05-20 at 22 56 57](https://user-images.githubusercontent.com/9654006/40281970-28737450-5c81-11e8-983a-f108e08e84a3.png)




Other URLs can be overridden by using:

AGREEMENT_URLS: {
  EULA_URL: 'https://example-eula.com',
  TOS_URL: 'https://example-tos.com,
  PRIVACY_POLICY_URL: 'https://example-privacy-policy.com'
}

### Author Concerns
The page takes longer to show the contents since it is loading from the web. The EULA page should be made as lightweight as possible. This seems to be a good example:
https://www.google.com/chrome/privacy/eula_text.html