### PR TITLE
iOS - Stop using legacy course API for video data

### DIFF
--- a/Source/OEXInterface.m
+++ b/Source/OEXInterface.m
@@ -309,9 +309,6 @@ static OEXInterface* _sharedInterface = nil;
     else if([URLString isEqualToString:URL_COURSE_ENROLLMENTS]) {
         URLString = [_network URLStringForType:URL_COURSE_ENROLLMENTS];
     }
-    else if([URLString rangeOfString:URL_VIDEO_SRT_FILE].location != NSNotFound) {      // For Closed Captioning
-        [_network downloadWithURLString:URLString];
-    }
     else if([OEXInterface isURLForImage:URLString]) {
         return NO;
     }

--- a/Source/OEXNetworkConstants.h
+++ b/Source/OEXNetworkConstants.h
@@ -34,8 +34,6 @@
 #define URL_SUBSTRING_ASSETS @"asset/"
 #define AUTHORIZATION_URL @"/oauth2/access_token"
 #define URL_GET_USER_INFO @"/api/mobile/v0.5/my_user_info"
-// For Closed Captioning
-#define URL_VIDEO_SRT_FILE @"/api/mobile/v0.5/video_outlines/transcript/"
 #define URL_COURSE_ENROLLMENT @"/api/enrollment/v1/enrollment"
 #define URL_COURSE_ENROLLMENT_EMAIL_OPT_IN @"/api/user_api/v1/preferences/email_opt_in"
 #define SIGN_UP_URL @"/user_api/v1/account/registration/"

--- a/Test/CourseContentPageViewControllerTests.swift
+++ b/Test/CourseContentPageViewControllerTests.swift
@@ -48,19 +48,6 @@ class CourseContentPageViewControllerTests: SnapshotTestCase {
                     }
                 }
             }
-            
-            
-//            DispatchQueue.main.async() {
-//                let blockLoadedStream = controller.t_blockIDForCurrentViewController()
-//                blockLoadedStream.listen(controller) {blockID in
-//                    if let next = verifier?(blockID.value, controller) {
-//                        next(expectation)
-//                    }
-//                    else {
-//                        expectation.fulfill()
-//                    }
-//                }
-//            }
             self.waitForExpectations()
         }
         return controller

--- a/Test/CourseContentPageViewControllerTests.swift
+++ b/Test/CourseContentPageViewControllerTests.swift
@@ -36,7 +36,8 @@ class CourseContentPageViewControllerTests: SnapshotTestCase {
         
         inScreenNavigationContext(controller) {
             let expectation = self.expectation(description: "course loaded")
-            DispatchQueue.main.async() {
+            let after = DispatchTime.now() + Double(Int64(0.5 * TimeInterval(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
+            DispatchQueue.main.asyncAfter(deadline: after) {
                 let blockLoadedStream = controller.t_blockIDForCurrentViewController()
                 blockLoadedStream.listen(controller) {blockID in
                     if let next = verifier?(blockID.value, controller) {
@@ -47,6 +48,19 @@ class CourseContentPageViewControllerTests: SnapshotTestCase {
                     }
                 }
             }
+            
+            
+//            DispatchQueue.main.async() {
+//                let blockLoadedStream = controller.t_blockIDForCurrentViewController()
+//                blockLoadedStream.listen(controller) {blockID in
+//                    if let next = verifier?(blockID.value, controller) {
+//                        next(expectation)
+//                    }
+//                    else {
+//                        expectation.fulfill()
+//                    }
+//                }
+//            }
             self.waitForExpectations()
         }
         return controller

--- a/Test/CourseOutlineViewControllerTests.swift
+++ b/Test/CourseOutlineViewControllerTests.swift
@@ -40,6 +40,7 @@ class CourseOutlineViewControllerTests: SnapshotTestCase {
         let updateStream = BackedStream<Void>()
         
         inScreenNavigationContext(controller) {
+            DispatchQueue.main.async {
                 let blockLoadedStream = controller.t_setup()
                 updateStream.backWithStream(blockLoadedStream)
                 updateStream.listen(controller) {[weak controller] _ in
@@ -51,6 +52,7 @@ class CourseOutlineViewControllerTests: SnapshotTestCase {
                         expectations.fulfill()
                     }
                 }
+            }
             self.waitForExpectations()
         }
     }

--- a/Test/CourseOutlineViewControllerTests.swift
+++ b/Test/CourseOutlineViewControllerTests.swift
@@ -40,7 +40,6 @@ class CourseOutlineViewControllerTests: SnapshotTestCase {
         let updateStream = BackedStream<Void>()
         
         inScreenNavigationContext(controller) {
-            DispatchQueue.main.async {
                 let blockLoadedStream = controller.t_setup()
                 updateStream.backWithStream(blockLoadedStream)
                 updateStream.listen(controller) {[weak controller] _ in
@@ -52,7 +51,6 @@ class CourseOutlineViewControllerTests: SnapshotTestCase {
                         expectations.fulfill()
                     }
                 }
-            }
             self.waitForExpectations()
         }
     }

--- a/Test/OEXDBTests.m
+++ b/Test/OEXDBTests.m
@@ -8,8 +8,6 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
-
-
 #import "OEXDBManager.h"
 #import "OEXStorageFactory.h"
 #import "ResourceData.h"
@@ -18,10 +16,6 @@
 #define VIDEO_URL @"http://edx-course-videos.s3.amazonaws.com/HARAMPX1/HARAMPX1T314-V006100_MB2.mp4"
 #define VIDEO_URL_1 @"http://edx-course-videos.s3.amazonaws.com/HARAMPX1/HARAMPX1T314-V006200_MB2.mp4"
 #define VIDEO_URL_2 @"http://edx-course-videos.s3.amazonaws.com/HARAMPX1/HARAMPX1T314-V010700_MB2.mp4"
-
-
-#define RESOURCE_URL @"http://mobile3.m.sandbox.edx.org/api/mobile/v0.5/video_outlines/courses/MITx/4.605x_2/3T2014"
-
 #define VIDEO_ID @"i4x://HarvardX/AmPoX.1/video/c1d1047455d44f939d2c0185daf94075"
 #define VIDEO_ID_1 @"i4x://HarvardX/AmPoX.1/video/c7cbd77bb9704a0993d8aab0592f9a93"
 #define VIDEO_ID_2 @"i4x://HarvardX/AmPoX.1/video/813744f07eb64f6aa1f442aeceee27e1"
@@ -33,68 +27,6 @@
 @implementation OEXDBTests
 
 
-// Set if the resource is completed
-- (void)testCompletedDownloadForResourceURL
-{
-    id obj_DBManger = [OEXStorageFactory getInstance];
-    
-    [obj_DBManger completedDownloadForResourceURL:RESOURCE_URL];
-    
-    OEXDownloadState state = [obj_DBManger downloadStateForResourceURL:RESOURCE_URL];
-    
-    if (state==OEXDownloadStateComplete)
-    {
-        XCTAssertTrue(state);
-    }
-    else
-    {
-        XCTAssertFalse(state);
-    }
-}
-
-
-
--(void)testDeleteResourceDataForURL
-{
-    id obj_DBManger = [OEXStorageFactory getInstance];
-    
-    [obj_DBManger deleteResourceDataForURL:RESOURCE_URL];
-    
-    ResourceData *objRes = [obj_DBManger resourceDataForURL:RESOURCE_URL];
-    
-    if(objRes)
-    {
-        XCTAssertTrue(objRes);
-    }
-    else
-    {
-        XCTAssertFalse(objRes);
-    }
-}
-
-
-
-
--(void)testDataForURLString
-{
-    id obj_DBManger = [OEXStorageFactory getInstance];
-    
-    NSData *data = [obj_DBManger dataForURLString:RESOURCE_URL];
-    
-    if(data)
-        XCTAssertNotNil(data, @"Data exists");
-    else
-        XCTAssertNil(data, @"Data returned is nil.");
-}
-
-
-
-
-//  -(void)updateData:(NSData *)data ForURLString:(NSString *)URLString;
-
-
-
-
 #pragma mark - Existing methods refactored with new DB
 
 // Disabled for now since this test makes lots of bad assumptions about the state of the user's data
@@ -102,7 +34,7 @@
 {
     id obj_Manager = [OEXStorageFactory getInstance];
     NSArray *arrResult = [obj_Manager getAllLocalVideoData];
-    if ([arrResult count]>0)
+    if ([arrResult count] > 0)
     {
         XCTAssertNotNil(arrResult, @"data available");
     }
@@ -110,40 +42,6 @@
         XCTAssertNotNil(arrResult, @"No local video is available");
     
 }
-
-
-/*
-// Get a last accesses data for passed CourseURL
-- (void)testLastAccessedDataForCourseURL
-{
-    id obj_Manager = [StorageFactory getInstance];
-    LastAccessed *data = [obj_Manager lastAccessedDataForCourseURL:COURSE_URL];
-    if(data)
-        XCTAssertNotNil(data, @"LastAccessed exists");
-    else
-        XCTAssertNil(data, @"LastAccessed does not exists");
-    
-}
-
-
-
-
-// Set a last accesses data for a course.
-- (void)testSetLastAccessedVideo
-{
-    id obj_Manager = [StorageFactory getInstance];
-    [obj_Manager setLastAccessedVideo:VIDEO_ID andVideoURL:VIDEO_URL forCourseURL:COURSE_URL];
-    LastAccessed *data = [obj_Manager lastAccessedDataForCourseURL:COURSE_URL];
-    if(data)
-        XCTAssertNotNil(data, @"Data exists");
-    else
-        XCTAssertNil(data, @"Data nil");
-    
-    
-}
- */
-
-
 
 // Get Video Download state for videoID
 // Disabled for now since this test makes lots of bad assumptions about the state of the user's data
@@ -155,7 +53,7 @@
     
     OEXDownloadState state = [obj_Manager videoStateForVideoID:data.video_id];
     
-    if (state==OEXDownloadStateComplete || state==OEXDownloadStateNew || state==OEXDownloadStatePartial)
+    if (state == OEXDownloadStateComplete || state == OEXDownloadStateNew || state == OEXDownloadStatePartial)
     {
         XCTAssertTrue(state);
     }
@@ -164,10 +62,6 @@
         XCTAssertFalse(state);
     }
 }
-
-
-
-
 
 // Get Video Watched state for videoID
 
@@ -177,7 +71,7 @@
     id obj_Manager = [OEXStorageFactory getInstance];
     OEXPlayedState state = [obj_Manager watchedStateForVideoID:VIDEO_ID];
     
-    if (state==OEXPlayedStatePartiallyWatched || state==OEXPlayedStateUnwatched || state==OEXPlayedStateWatched)
+    if (state == OEXPlayedStatePartiallyWatched || state == OEXPlayedStateUnwatched || state == OEXPlayedStateWatched)
     {
         XCTAssertTrue(state);
     }
@@ -186,9 +80,6 @@
         XCTAssertFalse(state);
     }
 }
-
-
-
 
 // Get Video last played time for videoID
 // Disabled for now since this test makes lots of bad assumptions about the state of the user's data
@@ -205,9 +96,7 @@
     {
         XCTAssertFalse(time);
     }
-    
 }
-
 
 // Set Video last played time for videoID
 // Disabled for now since this test makes lots of bad assumptions about the state of the user's data
@@ -224,9 +113,7 @@
     {
         XCTAssertFalse(time);
     }
-    
 }
-
 
 // Set the download state to NEW for a video as it is cancelled from the download screen.
 // Disabled for now since this test makes lots of bad assumptions about the state of the user's data
@@ -237,7 +124,7 @@
     [obj_Manager cancelledDownloadForVideo:data];
     OEXDownloadState state = [obj_Manager videoStateForVideoID:VIDEO_URL];
     
-    if (state==OEXDownloadStateNew)
+    if (state == OEXDownloadStateNew)
     {
         XCTAssertTrue(state);
     }
@@ -246,9 +133,6 @@
         XCTAssertFalse(state);
     }
 }
-
-
-
 
 // Set the download state to NEW for a video and delete the entry form the sandbox.
 // Disabled for now since this test makes lots of bad assumptions about the state of the user's data
@@ -258,7 +142,7 @@
     [obj_Manager deleteDataForVideoID:VIDEO_ID_1];
     OEXDownloadState state = [obj_Manager videoStateForVideoID:VIDEO_URL];
     
-    if (state==OEXDownloadStateNew)
+    if (state == OEXDownloadStateNew)
     {
         XCTAssertTrue(state);
     }
@@ -266,10 +150,7 @@
     {
         XCTAssertFalse(state);
     }
-    
-    
 }
-
 
 // Get array of videoData entries with download state passed.
 // Disabled for now since this test makes lots of bad assumptions about the state of the user's data
@@ -277,13 +158,14 @@
 {
     id obj_Manager = [OEXStorageFactory getInstance];
     NSArray *arrResult = [obj_Manager getVideosForDownloadState:OEXDownloadStateNew];
-    if ([arrResult count]>0)
+    if ([arrResult count] > 0)
     {
         XCTAssertNotNil(arrResult, @"data available");
     }
     else
+    {
         XCTAssertNotNil(arrResult, @"No video available with OEXDownloadStateNew.");
-    
+    }
 }
 
 // Get videoData entrie with dm_id passed.
@@ -295,15 +177,14 @@
 {
     id obj_Manager = [OEXStorageFactory getInstance];
     NSArray *arrResult = [obj_Manager videosForTaskIdentifier:(int)1];
-    if ([arrResult count]>0)
+    if ([arrResult count] > 0)
     {
         XCTAssertNotNil(arrResult, @"data available");
     }
     else
+    {
         XCTAssertNotNil(arrResult, @"No video available with taskIdentifier = 1.");
-    
+    }
 }
-
-
 
 @end


### PR DESCRIPTION
### Description

[LEARNER-5244](https://openedx.atlassian.net/browse/LEARNER-5244)

Remove legacy course API from code.