### PR TITLE
Use network constant URL_USER_DETAILS instead of hardcoding path

### DIFF
--- a/Source/CoursesAPI.swift
+++ b/Source/CoursesAPI.swift
@@ -16,9 +16,9 @@ struct CoursesAPI {
     }
     
     static func getUserEnrollments(username: String, organizationCode: String?) -> NetworkRequest<[UserCourseEnrollment]> {
-        var path = "api/mobile/v1/users/{username}/course_enrollments/".oex_format(withParameters: ["username": username])
+        var path = "{base_url}/{username}/course_enrollments/".oex_format(withParameters: ["base_url": URL_USER_DETAILS, "username": username])
         if let orgCode = organizationCode {
-            path = "api/mobile/v1/users/{username}/course_enrollments/?org={org}".oex_format(withParameters: ["username": username, "org": orgCode])
+            path = "{base_url}/{username}/course_enrollments/?org={org}".oex_format(withParameters: ["base_url": URL_USER_DETAILS, "username": username, "org": orgCode])
         }
         return NetworkRequest(
             method: .GET,

--- a/Source/OEXNetworkConstants.h
+++ b/Source/OEXNetworkConstants.h
@@ -25,7 +25,7 @@
 #define ONLINE_ONLY_VIDEO_URL_EXTENSIONS @[ @".m3u8" ]
 
 #define URL_EXCHANGE_TOKEN @"/oauth2/exchange_access_token/{backend}/"
-#define URL_USER_DETAILS @"/api/mobile/v0.5/users"
+#define URL_USER_DETAILS @"/api/mobile/v1/users"
 #define URL_COURSE_ENROLLMENTS @"/course_enrollments/"
 #define URL_COURSE_HANDOUTS @"/handouts"
 #define URL_COURSE_ANNOUNCEMENTS @"/updates"


### PR DESCRIPTION
### Description

SE-146, [OSPR-2917](https://openedx.atlassian.net/browse/OSPR-2917)

https://github.com/edx/edx-app-ios/pull/1130 updated the app to use the new mobile API v1, however the current named platform release [`open-release/hawthorn.2` only supports mobile API v0.5](https://github.com/edx/edx-platform/blob/open-release/hawthorn.2/lms/urls.py#L162-L165).

This change maintains the current master mobile API v1, but makes it easier for whitelisted app releases to use the legacy mobile API v0.5 instead (using patches).

### Notes

* This has been successfully tested with the app `release/2.17.0`, but we acknowledge that future releases may drop support for the legacy mobile API v0.5.

### How to test this PR

1. Build and run the app.
1. Login as a user on the LMS
1. Check that the user's course enrollments load successfully.

### Author Notes & Concerns

1. There are a number of other places in the code [where the `mobile/v0.5` API is hard coded](https://github.com/edx/edx-app-ios/search?q=%22mobile%2Fv0.5%22&unscoped_q=%22mobile%2Fv0.5%22).  
   We'd also prefer that these use easily patched variables, if this change would be accepted.
1. The tests failing for this PR seem unrelated to the code changes made, specifically:
   > ✗ testNextButton, XCTAssertEqual failed: ("chapter2") is not equal to ("chapter3") -
      ✗ testNextButton, XCTAssertEqual failed: ("true") is not equal to ("false") -
      ✗ testDelaySends, Asynchronous wait failed: Exceeded timeout of 15 seconds, with unfulfilled expectations: "stream fires".

   Also, [build 3457.3 errored](https://travis-ci.org/edx/edx-app-ios/jobs/469876429), apparently waiting for an answer to this prompt:
   > [?] Enter your api token:

   Any help would be appreciated!

### Reviewers

- [ ] @symbolist
- [ ] edX Reviewers TBD