### PR TITLE
Remove travis job of pushing of transifex resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,6 @@ script:
 
 after_success:
     - bash <(curl -s https://codecov.io/bash)
-    - pip install virtualenv
-    - virtualenv ~/env;
-    - source ~/env/bin/activate
-    # Install Transifex client and push strings to Transifex
-    # Reference: https://docs.transifex.com/integrations/github#section-integrating-with-travis-ci
-    - pip install transifex-client
-    - sudo echo $'[https://www.transifex.com]\nhostname = https://www.transifex.com\nusername = '"$TRANSIFEX_USER"$'\npassword = '"$TRANSIFEX_PASSWORD"$'\ntoken = '"$TRANSIFEX_API_TOKEN"$'\n' > ~/.transifexrc;
-    - tx push --source --no-interactive
-    - sleep 5 # https://github.com/travis-ci/travis-ci/issues/4725
 
 branches:
     only:

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -329,7 +329,7 @@
 /* 1 second remaining in course audit expiry*/
 "COURSE_AUDIT_REMAINING_SECONDS##{one}" = "{seconds} second";
 /* More than 1 seconds remaining in course audit expiry*/
-"COURSE_AUDIT_REMAINING_SECOUNDS" = "{seconds} seconds";
+"COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} seconds";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Your access to this course has expired";
 /* Title text for the Announcements section within the course dashboard */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -363,7 +363,7 @@
 /* 1 second remaining in course audit expiry*/
 "COURSE_AUDIT_REMAINING_SECONDS##{one}" = "{seconds} second";
 /* More than 1 seconds remaining in course audit expiry*/
-"COURSE_AUDIT_REMAINING_SECOUNDS" = "{seconds} seconds";
+"COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} seconds";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Your access to this course has expired";
 /* Option to show all different types of course content. Constrasts with 'Show Videos Only'. */


### PR DESCRIPTION
### Description

[LEARNER-6798](https://openedx.atlassian.net/browse/LEARNER-6798)

I have removed the pushing of source files to Transifex from the Travis script. And also I have removed changes those were made to tackle https://github.com/travis-ci/travis-ci/issues/4725 because the issue has been closed.

I have enabled auto pull to the following resources:
- [ios-app-localizable-strings](https://www.transifex.com/open-edx/edx-mobile-apps/ios-app-localizable-strings/)
- [ios-app-info-strings](https://www.transifex.com/open-edx/edx-mobile-apps/ios-app-info-strings/)
### Notes
Following files are common between both platforms(Android and iOS) so at the moment pulling sources for these files are from the [android repository](https://github.com/edx/edx-app-android). 
- [app-localizable-countries](https://www.transifex.com/open-edx/edx-mobile-apps/app-localizable-countries/)
- [app-localizable-languages](https://www.transifex.com/open-edx/edx-mobile-apps/app-localizable-languages/)
- [app-localizable-profiles](https://www.transifex.com/open-edx/edx-mobile-apps/app-localizable-profiles/)
