### PR TITLE
Handle Dynamic Type Text Change For Authenticated Web Content

### DIFF
--- a/Source/AuthenticatedWebViewController.swift
+++ b/Source/AuthenticatedWebViewController.swift
@@ -26,6 +26,7 @@ class HeaderViewInsets : ContentInsetsSource {
 private protocol WebContentController {
     var view : UIView {get}
     var scrollView : UIScrollView {get}
+    var isLoading: Bool {get}
     
     var alwaysRequiresOAuthUpdate : Bool { get}
     
@@ -80,6 +81,10 @@ private class WKWebViewContentController : WebContentController {
     
     var initialContentState : AuthenticatedWebViewController.State {
         return AuthenticatedWebViewController.State.LoadingContent
+    }
+
+    var isLoading: Bool {
+        return webView.isLoading
     }
 }
 
@@ -172,7 +177,7 @@ public class AuthenticatedWebViewController: UIViewController, WKNavigationDeleg
     }
 
     public func reload() {
-        guard let request = contentRequest else { return }
+        guard let request = contentRequest, !webController.isLoading else { return }
 
         state = .LoadingContent
         loadRequest(request: request)

--- a/Source/AuthenticatedWebViewController.swift
+++ b/Source/AuthenticatedWebViewController.swift
@@ -133,7 +133,7 @@ public class AuthenticatedWebViewController: UIViewController, WKNavigationDeleg
         
         automaticallyAdjustsScrollViewInsets = false
         webController.view.accessibilityIdentifier = "AuthenticatedWebViewController:authenticated-web-view"
-        handleDynamicTypeNotification()
+        addObservers()
     }
     
     required public init?(coder aDecoder: NSCoder) {
@@ -165,8 +165,8 @@ public class AuthenticatedWebViewController: UIViewController, WKNavigationDeleg
         }
     }
 
-    private func handleDynamicTypeNotification() {
-        NotificationCenter.default.oex_addObserver(observer: self, name: "UIContentSizeCategoryDidChangeNotification") { (_, observer, _) in
+    private func addObservers() {
+        NotificationCenter.default.oex_addObserver(observer: self, name: NOTIFICATION_DYNAMIC_TEXT_TYPE_UPDATE) { (_, observer, _) in
             observer.reload()
         }
     }


### PR DESCRIPTION
### Description

[LEARNER-6732](https://openedx.atlassian.net/browse/LEARNER-6732)

This PR handles dynamic text change of iOS App Settings for the authenticated web content. `AuthenticatedWebViewController` is now listing to `UIContentSizeCategoryDidChangeNotification` and `reload` itself whenever value of dynamic text changes in iOS App Settings.

### Notes

### How to test this PR
- Access any authenticated web content like course dates, user enrolled programs or xBlocks in edX app.
- Open iOS App Settings
- Navigate to General -> Accessibility -> Large Text
- Change the value of the slider
- Reopen/comeback to the edX app
- Opened authenticated web content should reload itself and shows the content according to newly selected dynamic text size value.

