### PR TITLE
AccessibilityHint for disabled user fields on edit profile screen

### DIFF
--- a/Source/UserProfileEditViewController.swift
+++ b/Source/UserProfileEditViewController.swift
@@ -299,6 +299,8 @@ class UserProfileEditViewController: UIViewController, UITableViewDelegate, UITa
         let enabled = !disabledFields.contains(field.name)
         cell.isUserInteractionEnabled = enabled
         cell.backgroundColor = enabled ? UIColor.clear : OEXStyles.shared().neutralXLight()
+
+        enabled ? (cell.accessibilityHint = nil) : (cell.accessibilityHint = Strings.Accessibility.disabledHint)
     }
     
     private func disableLimitedProfileCells(disabled: Bool) {

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -48,6 +48,8 @@
 "ACCESSIBILITY.DISCUSSION_FOLLOW_HINT" = "Double tap to follow.";
 /* Accessibility hint for Unfollow button for discussion responses*/
 "ACCESSIBILITY.DISCUSSION_UNFOLLOW_HINT" = "Double tap to unfollow.";
+/*Accessibility hint for disabled buttons, cells, etc like for disabled user profile fields on user edit profile screen*/
+"ACCESSIBILITY.DISABLED_HINT" = "Dimmed";
 /* Acessibility hint for the show downloads button. */
 "ACCESSIBILITY.SHOW_CURRENT_DOWNLOADS_BUTTON_HINT" = "Double tap to view current downloads";
 /* Accessibility hint for view all subjects label*/

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -48,6 +48,8 @@
 "ACCESSIBILITY.DISCUSSION_FOLLOW_HINT" = "Toque dos veces para seguir.";
 /* Accessibility hint for Unfollow button for discussion responses*/
 "ACCESSIBILITY.DISCUSSION_UNFOLLOW_HINT" = "Toque dos veces para dejar de seguir.";
+/*Accessibility hint for disabled buttons, cells, etc like for disabled user profile fields on user edit profile screen*/
+"ACCESSIBILITY.DISABLED_HINT" = "Dimmed";
 /* Acessibility label for the download progress button. {percent_complete} is an already localized numeric percentage like "44%" */
 /* Acessibility label for the download progress button. {percent_complete} is an already localized numeric percentage like "44%" */
 "ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON##{one}" = "Descarga en progreso: {percent_complete}";


### PR DESCRIPTION
### Description

[LEARNER-6800](https://openedx.atlassian.net/browse/LEARNER-6800)

This PR handles `AccessibilityHint` for user-editable fields on Edit Profile Screen. VoiceOver by default is not handling false value of `isUserInteractionEnabled` for the disabled fields. So I have added likewise feature by implementing  `AccessibilityHint` for editable fields.
### Notes

### How to test this PR
- Go to user profile screen from the main screen by clicking user avatar.
- Go to edit profile screen by clicking the edit button.
- Select `limited profile` option from the toggle control.
- Turn on voice over
- Voice over should say `dimmed` at the end for disabled fields.

