### PR TITLE
iOS - Login Bottom Bar is not appearing for Program Discovery Detail Page

### DIFF
--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -343,7 +343,7 @@ extension OEXRouter {
     }
     
     func showProgramDetail(from controller: UIViewController, with pathId: String, bottomBar: UIView?) {
-        let programDetailViewController = ProgramsDiscoveryViewController(with: environment, pathId: pathId, bottomBar: bottomBar)
+        let programDetailViewController = ProgramsDiscoveryViewController(with: environment, pathId: pathId, bottomBar: bottomBar?.copy() as? UIView)
         pushViewController(controller: programDetailViewController, fromController: controller)
     }
 


### PR DESCRIPTION
### Description

[LEARNER-7006](https://openedx.atlassian.net/browse/LEARNER-7006)

Login Bottom Bar is not appearing for Program Discovery Detail Page

### Notes

### How to test this PR
- Go to Startup Screen
- Tap on search courses, discovery view will open.
- The bottom bar should show
- Tap on program tab and go in program detail screen, the bottom bar should show. Press back button the main discovery screen should show with bottom bar.