### PR TITLE
iOS - Add a third tab to the discovery view named 'degrees'

### DIFF
--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -54,10 +54,10 @@ typealias DismissCompletion = () -> Void
             return .courseDetail
         } else if let discoveryViewController = controller as? DiscoveryViewController {
             let segmentType = discoveryViewController.segmentType(of: discoveryViewController.segmentedControl.selectedSegmentIndex)
-            if segmentType == segment.programs.rawValue {
+            if segmentType == SegmentOption.program.rawValue {
                 return .programDiscovery
             }
-            else if segmentType == segment.courses.rawValue {
+            else if segmentType == SegmentOption.course.rawValue {
                 return .courseDiscovery
             }
         } else if controller is OEXFindCoursesViewController  {

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -110,7 +110,7 @@ typealias DismissCompletion = () -> Void
         
         switch link.type {
         case .courseDetail:
-            guard let courseId = link.courseId, environment?.config.discovery.course.isEnabled ?? false else { return }
+            guard environment?.config.discovery.course.isEnabled ?? false, let courseId = link.courseId else { return }
                 if let discoveryViewController = topMostViewController as? DiscoveryViewController {
                     discoveryViewController.switchSegment(with: .courseDiscovery)
                     environment?.router?.showDiscoveryDetail(from: discoveryViewController, type: .courseDetail, coursePathID: courseId, bottomBar: discoveryViewController.bottomBar)
@@ -122,7 +122,7 @@ typealias DismissCompletion = () -> Void
                 }
             break
         case .programDetail:
-            guard let courseId = link.courseId, environment?.config.discovery.program.isEnabled ?? false else { return }
+            guard environment?.config.discovery.program.isEnabled ?? false, let courseId = link.courseId else { return }
                 if let discoveryViewController = topMostViewController as? DiscoveryViewController {
                     discoveryViewController.switchSegment(with: .programDiscovery)
                     environment?.router?.showDiscoveryDetail(from: discoveryViewController, type: .programDetail, coursePathID: courseId, bottomBar: discoveryViewController.bottomBar)
@@ -135,7 +135,11 @@ typealias DismissCompletion = () -> Void
             break
         case .programDiscovery:
             guard environment?.config.discovery.program.isEnabled ?? false else { return }
-            fallthrough
+            if let discoveryViewController = topMostViewController as? DiscoveryViewController {
+                discoveryViewController.switchSegment(with: link.type)
+                return
+            }
+            break
         case .courseDiscovery:
             guard environment?.config.discovery.course.isEnabled ?? false else { return }
             if let discoveryViewController = topMostViewController as? DiscoveryViewController {

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -53,7 +53,13 @@ typealias DismissCompletion = () -> Void
         else if controller is OEXCourseInfoViewController {
             return .courseDetail
         } else if let discoveryViewController = controller as? DiscoveryViewController {
-            return discoveryViewController.segmentType(of: discoveryViewController.segmentedControl.selectedSegmentIndex) == segment.programs.rawValue ? .programDiscovery : .courseDiscovery
+            let segmentType = discoveryViewController.segmentType(of: discoveryViewController.segmentedControl.selectedSegmentIndex)
+            if segmentType == segment.programs.rawValue {
+                return .programDiscovery
+            }
+            else if segmentType == segment.courses.rawValue {
+                return .courseDiscovery
+            }
         } else if controller is OEXFindCoursesViewController  {
             return .courseDiscovery
         } else if let programsDiscoveryViewController = controller as? ProgramsDiscoveryViewController {
@@ -104,7 +110,7 @@ typealias DismissCompletion = () -> Void
         
         switch link.type {
         case .courseDetail:
-            guard let courseId = link.courseId else { return }
+            guard let courseId = link.courseId, environment?.config.discovery.course.isEnabled ?? false else { return }
                 if let discoveryViewController = topMostViewController as? DiscoveryViewController {
                     discoveryViewController.switchSegment(with: .courseDiscovery)
                     environment?.router?.showDiscoveryDetail(from: discoveryViewController, type: .courseDetail, coursePathID: courseId, bottomBar: discoveryViewController.bottomBar)
@@ -116,7 +122,7 @@ typealias DismissCompletion = () -> Void
                 }
             break
         case .programDetail:
-                guard let courseId = link.courseId else { return }
+            guard let courseId = link.courseId, environment?.config.discovery.program.isEnabled ?? false else { return }
                 if let discoveryViewController = topMostViewController as? DiscoveryViewController {
                     discoveryViewController.switchSegment(with: .programDiscovery)
                     environment?.router?.showDiscoveryDetail(from: discoveryViewController, type: .programDetail, coursePathID: courseId, bottomBar: discoveryViewController.bottomBar)
@@ -127,12 +133,17 @@ typealias DismissCompletion = () -> Void
                     return
                 }
             break
-        case .courseDiscovery, .programDiscovery:
+        case .programDiscovery:
+            guard environment?.config.discovery.program.isEnabled ?? false else { return }
+            fallthrough
+        case .courseDiscovery:
+            guard environment?.config.discovery.course.isEnabled ?? false else { return }
             if let discoveryViewController = topMostViewController as? DiscoveryViewController {
                 discoveryViewController.switchSegment(with: link.type)
                 return
             }
             break
+            
         default:
             break
         }

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -53,7 +53,7 @@ typealias DismissCompletion = () -> Void
         else if controller is OEXCourseInfoViewController {
             return .courseDetail
         } else if let discoveryViewController = controller as? DiscoveryViewController {
-            return discoveryViewController.segmentedControl.selectedSegmentIndex == segment.programs.rawValue ? .programDiscovery : .courseDiscovery
+            return discoveryViewController.segmentType(of: discoveryViewController.segmentedControl.selectedSegmentIndex) == segment.programs.rawValue ? .programDiscovery : .courseDiscovery
         } else if controller is OEXFindCoursesViewController  {
             return .courseDiscovery
         } else if let programsDiscoveryViewController = controller as? ProgramsDiscoveryViewController {

--- a/Source/DegreesViewController.swift
+++ b/Source/DegreesViewController.swift
@@ -11,29 +11,22 @@ import WebKit
 
 class DegreesViewController: UIViewController {
 
-    typealias Environment = OEXConfigProvider & OEXSessionProvider & OEXStylesProvider & OEXRouterProvider & OEXAnalyticsProvider & OEXSessionProvider
+    typealias Environment = OEXConfigProvider & OEXSessionProvider & OEXStylesProvider & OEXRouterProvider & OEXAnalyticsProvider
     
     private let environment: Environment
     private var showBottomBar: Bool = true
-    private let searchQuery: String?
-    private(set) var bottomBar: UIView?
-    private(set) var pathId: String?
+    fileprivate(set) var bottomBar: UIView?
     private var webviewHelper: DiscoveryWebViewHelper?
     private var discoveryConfig: DegreeDiscovery? {
         return environment.config.discovery.degree
     }
     
     // MARK:- Initializer -
-    init(with environment: Environment, bottomBar: UIView?, searchQuery: String? = nil) {
+    init(with environment: Environment, showBottomBar: Bool, bottomBar: UIView?) {
         self.environment = environment
         self.bottomBar = bottomBar
-        self.searchQuery = searchQuery
-        super.init(nibName: nil, bundle: nil)
-    }
-    
-    convenience init(with environment: Environment, showBottomBar: Bool, bottomBar: UIView?, searchQuery: String? = nil) {
-        self.init(with: environment, bottomBar: bottomBar, searchQuery: searchQuery)
         self.showBottomBar = showBottomBar
+        super.init(nibName: nil, bundle: nil)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -43,22 +36,18 @@ class DegreesViewController: UIViewController {
     override func viewDidLoad() {
         navigationItem.title = Strings.degrees
         super.viewDidLoad()
-        loadDegrees(with: discoveryConfig?.webview.baseURL)
+        loadDegrees()
     }
     
-    private func loadDegrees(with url: URL?) {
-        if let url = url {
-            load(url: url, searchQuery: searchQuery, showBottomBar: showBottomBar, showSearch: true, searchBaseURL: url)
+    private func loadDegrees() {
+        if let url = discoveryConfig?.webview.baseURL {
+            webviewHelper = DiscoveryWebViewHelper(environment: environment, delegate: self, bottomBar: showBottomBar ? bottomBar : nil, showSearch: true, searchQuery: nil, discoveryType: .program)
+            webviewHelper?.baseURL = url
+            webviewHelper?.load(withURL: url)
         }
         else {
-            assert(false, "Unable to get search URL.")
+            assert(false, "Unable to get base URL.")
         }
-    }
-    
-    private func load(url :URL, searchQuery: String? = nil, showBottomBar: Bool = true, showSearch: Bool = false, searchBaseURL: URL? = nil) {
-        webviewHelper = DiscoveryWebViewHelper(environment: environment, delegate: self, bottomBar: showBottomBar ? bottomBar : nil, showSearch: showSearch, searchQuery: searchQuery, discoveryType: .program)
-        webviewHelper?.baseURL = searchBaseURL
-        webviewHelper?.load(withURL: url)
     }
 }
 

--- a/Source/DegreesViewController.swift
+++ b/Source/DegreesViewController.swift
@@ -39,6 +39,11 @@ class DegreesViewController: UIViewController {
         loadDegrees()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        environment.analytics.trackScreen(withName: AnalyticsScreenName.DiscoverDegree.rawValue)
+    }
+    
     private func loadDegrees() {
         guard let url = degreeConfig?.webview.baseURL else {
             assert(false, "Unable to get base URL.")

--- a/Source/DegreesViewController.swift
+++ b/Source/DegreesViewController.swift
@@ -39,17 +39,12 @@ class DegreesViewController: UIViewController {
         loadDegrees()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        environment.analytics.trackScreen(withName: AnalyticsScreenName.DiscoverDegree.rawValue)
-    }
-    
     private func loadDegrees() {
         guard let url = degreeConfig?.webview.baseURL else {
             assert(false, "Unable to get base URL.")
             return
         }
-        webviewHelper = DiscoveryWebViewHelper(environment: environment, delegate: self, bottomBar: showBottomBar ? bottomBar : nil, showSearch: true, searchQuery: nil, discoveryType: .degree)
+        webviewHelper = DiscoveryWebViewHelper(environment: environment, delegate: self, bottomBar: showBottomBar ? bottomBar : nil, showSearch: degreeConfig?.webview.searchEnabled ?? false, searchQuery: nil, discoveryType: .degree)
         webviewHelper?.baseURL = url
         webviewHelper?.load(withURL: url)
     }

--- a/Source/DegreesViewController.swift
+++ b/Source/DegreesViewController.swift
@@ -40,14 +40,13 @@ class DegreesViewController: UIViewController {
     }
     
     private func loadDegrees() {
-        if let url = degreeConfig?.webview.baseURL {
-            webviewHelper = DiscoveryWebViewHelper(environment: environment, delegate: self, bottomBar: showBottomBar ? bottomBar : nil, showSearch: true, searchQuery: nil, discoveryType: .program)
-            webviewHelper?.baseURL = url
-            webviewHelper?.load(withURL: url)
-        }
-        else {
+        guard let url = degreeConfig?.webview.baseURL else {
             assert(false, "Unable to get base URL.")
+            return
         }
+        webviewHelper = DiscoveryWebViewHelper(environment: environment, delegate: self, bottomBar: showBottomBar ? bottomBar : nil, showSearch: true, searchQuery: nil, discoveryType: .degree)
+        webviewHelper?.baseURL = url
+        webviewHelper?.load(withURL: url)
     }
 }
 

--- a/Source/DegreesViewController.swift
+++ b/Source/DegreesViewController.swift
@@ -15,9 +15,9 @@ class DegreesViewController: UIViewController {
     
     private let environment: Environment
     private var showBottomBar: Bool = true
-    fileprivate(set) var bottomBar: UIView?
+    fileprivate var bottomBar: UIView?
     private var webviewHelper: DiscoveryWebViewHelper?
-    private var discoveryConfig: DegreeDiscovery? {
+    private var degreeConfig: DegreeDiscovery? {
         return environment.config.discovery.degree
     }
     
@@ -34,13 +34,13 @@ class DegreesViewController: UIViewController {
     }
     
     override func viewDidLoad() {
-        navigationItem.title = Strings.degrees
         super.viewDidLoad()
+        navigationItem.title = Strings.degrees
         loadDegrees()
     }
     
     private func loadDegrees() {
-        if let url = discoveryConfig?.webview.baseURL {
+        if let url = degreeConfig?.webview.baseURL {
             webviewHelper = DiscoveryWebViewHelper(environment: environment, delegate: self, bottomBar: showBottomBar ? bottomBar : nil, showSearch: true, searchQuery: nil, discoveryType: .program)
             webviewHelper?.baseURL = url
             webviewHelper?.load(withURL: url)

--- a/Source/DegreesViewController.swift
+++ b/Source/DegreesViewController.swift
@@ -1,0 +1,75 @@
+//
+//  DegreesViewController.swift
+//  edX
+//
+//  Created by Salman on 29/01/2019.
+//  Copyright © 2019 edX. All rights reserved.
+//
+
+import UIKit
+import WebKit
+
+class DegreesViewController: UIViewController {
+
+    typealias Environment = OEXConfigProvider & OEXSessionProvider & OEXStylesProvider & OEXRouterProvider & OEXAnalyticsProvider & OEXSessionProvider
+    
+    private let environment: Environment
+    private var showBottomBar: Bool = true
+    private let searchQuery: String?
+    private(set) var bottomBar: UIView?
+    private(set) var pathId: String?
+    private var webviewHelper: DiscoveryWebViewHelper?
+    private var discoveryConfig: DegreeDiscovery? {
+        return environment.config.discovery.degree
+    }
+    
+    // MARK:- Initializer -
+    init(with environment: Environment, bottomBar: UIView?, searchQuery: String? = nil) {
+        self.environment = environment
+        self.bottomBar = bottomBar
+        self.searchQuery = searchQuery
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    convenience init(with environment: Environment, showBottomBar: Bool, bottomBar: UIView?, searchQuery: String? = nil) {
+        self.init(with: environment, bottomBar: bottomBar, searchQuery: searchQuery)
+        self.showBottomBar = showBottomBar
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        navigationItem.title = Strings.degrees
+        super.viewDidLoad()
+        loadDegrees(with: discoveryConfig?.webview.baseURL)
+    }
+    
+    private func loadDegrees(with url: URL?) {
+        if let url = url {
+            load(url: url, searchQuery: searchQuery, showBottomBar: showBottomBar, showSearch: true, searchBaseURL: url)
+        }
+        else {
+            assert(false, "Unable to get search URL.")
+        }
+    }
+    
+    private func load(url :URL, searchQuery: String? = nil, showBottomBar: Bool = true, showSearch: Bool = false, searchBaseURL: URL? = nil) {
+        webviewHelper = DiscoveryWebViewHelper(environment: environment, delegate: self, bottomBar: showBottomBar ? bottomBar : nil, showSearch: showSearch, searchQuery: searchQuery, discoveryType: .program)
+        webviewHelper?.baseURL = searchBaseURL
+        webviewHelper?.load(withURL: url)
+    }
+}
+
+extension DegreesViewController: WebViewNavigationDelegate {
+    
+    func webView(_ webView: WKWebView, shouldLoad request: URLRequest) -> Bool {
+        guard let url = request.url else { return true }
+        return !DiscoveryHelper.navigate(to: url, from: self, bottomBar: bottomBar)
+    }
+    
+    func webViewContainingController() -> UIViewController {
+        return self
+    }
+}

--- a/Source/DiscoveryConfig.swift
+++ b/Source/DiscoveryConfig.swift
@@ -26,6 +26,7 @@ enum DiscoveryKeys: String, RawStringExtractable {
     case subjectFilterEnabled = "SUBJECT_FILTER_ENABLED"
     case exploreSubjectsURL = "EXPLORE_SUBJECTS_URL"
     case program = "PROGRAM"
+    case degree = "DEGREE"
 }
 
 class DiscoveryWebviewConfig: NSObject {
@@ -47,10 +48,12 @@ class DiscoveryWebviewConfig: NSObject {
 class DiscoveryConfig: NSObject {
     let course: CourseDiscovery
     let program: ProgramDiscovery
+    let degree: DegreeDiscovery
     
     init(dictionary: [String: AnyObject]) {
         course = CourseDiscovery(dictionary: dictionary[DiscoveryKeys.course] as? [String: AnyObject] ?? [:])
         program = ProgramDiscovery(with: course, dictionary: dictionary[DiscoveryKeys.program] as? [String: AnyObject] ?? [:])
+        degree = DegreeDiscovery(with: course, dictionary: dictionary[DiscoveryKeys.degree] as? [String: AnyObject] ?? [:])
     }
 }
 
@@ -68,6 +71,19 @@ class CourseDiscovery: DiscoveryBase {
 
 class ProgramDiscovery: DiscoveryBase {
     
+    private let courseDiscovery: CourseDiscovery
+    
+    init(with courseDiscovery: CourseDiscovery, dictionary: [String : AnyObject]) {
+        self.courseDiscovery = courseDiscovery
+        super.init(dictionary: dictionary)
+    }
+    
+    var isEnabled: Bool {
+        return courseDiscovery.type == .webview && type == .webview
+    }
+}
+
+class DegreeDiscovery: DiscoveryBase {
     private let courseDiscovery: CourseDiscovery
     
     init(with courseDiscovery: CourseDiscovery, dictionary: [String : AnyObject]) {

--- a/Source/DiscoveryConfig.swift
+++ b/Source/DiscoveryConfig.swift
@@ -83,18 +83,7 @@ class ProgramDiscovery: DiscoveryBase {
     }
 }
 
-class DegreeDiscovery: DiscoveryBase {
-    private let courseDiscovery: CourseDiscovery
-    
-    init(with courseDiscovery: CourseDiscovery, dictionary: [String : AnyObject]) {
-        self.courseDiscovery = courseDiscovery
-        super.init(dictionary: dictionary)
-    }
-    
-    var isEnabled: Bool {
-        return courseDiscovery.type == .webview && type == .webview
-    }
-}
+class DegreeDiscovery: ProgramDiscovery { }
 
 class DiscoveryBase: NSObject {
     private(set) var type: DiscoveryConfigType

--- a/Source/DiscoveryViewController.swift
+++ b/Source/DiscoveryViewController.swift
@@ -76,7 +76,7 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
             case .course:
                 guard environment.config.discovery.course.isEnabled else { break }
                 let coursesController = self.environment.config.discovery.course.type == .webview ? OEXFindCoursesViewController(environment: environment, showBottomBar: false, bottomBar: bottomBar, searchQuery: self.searchQuery) : CourseCatalogViewController(environment: self.environment)
-                item = SegmentItem(title: option.title, viewController: coursesController, index: index, type: option.rawValue)
+                item = SegmentItem(title: option.title, viewController: coursesController, index: index, type: option.rawValue, analyticsScreenName: OEXAnalyticsScreenFindCourses)
                 segmentItems.append(item)
                 segmentedControl.insertSegment(withTitle: option.title, at: index, animated: false)
                 index = segmentItems.count
@@ -84,7 +84,7 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
                 guard environment.config.discovery.program.isEnabled else { break }
                 let programDiscoveryViewController = ProgramsDiscoveryViewController(with: environment, showBottomBar: false, bottomBar: bottomBar)
                 programDiscoveryViewController.view.isHidden = true
-                item = SegmentItem(title: option.title, viewController: programDiscoveryViewController, index: index, type: option.rawValue)
+                item = SegmentItem(title: option.title, viewController: programDiscoveryViewController, index: index, type: option.rawValue, analyticsScreenName: AnalyticsScreenName.DiscoverProgram.rawValue)
                 segmentItems.append(item)
                 segmentedControl.insertSegment(withTitle: option.title, at: index, animated: false)
                 index = segmentItems.count
@@ -92,7 +92,7 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
                 guard environment.config.discovery.degree.isEnabled else { break }
                 let degreesViewController = DegreesViewController(with: environment, showBottomBar: false, bottomBar: bottomBar)
                 degreesViewController.view.isHidden = true
-                item = SegmentItem(title: option.title, viewController: degreesViewController, index: index, type: option.rawValue)
+                item = SegmentItem(title: option.title, viewController: degreesViewController, index: index, type: option.rawValue, analyticsScreenName: AnalyticsScreenName.DiscoverDegree.rawValue)
                 segmentItems.append(item)
                 segmentedControl.insertSegment(withTitle: option.title, at: index, animated: false)
                 index = segmentItems.count
@@ -123,6 +123,7 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
         for item in segmentItems {
             if item.index == segmentIndex {
                 item.viewController.view.isHidden = false
+                environment.analytics.trackScreen(withName: item.analyticsScreenName)
             }
             else {
                 item.viewController.view.isHidden = true

--- a/Source/DiscoveryViewController.swift
+++ b/Source/DiscoveryViewController.swift
@@ -8,29 +8,23 @@
 
 import UIKit
 
- enum segment: Int {
-    case courses
-    case programs
-    case degrees
+ enum SegmentOption: Int {
+    case course, program, degree
+    static let options = [course, program, degree]
+    
+    var title: String {
+        switch self {
+        case .course:
+            return Strings.courses
+        case .program:
+            return Strings.programs
+        case .degree:
+            return Strings.degrees
+        }
+    }
 }
 
 class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding {
-    
-    private enum segmentOptions: Int {
-        case Course, Program, Degree
-        static let options = [Course, Program, Degree]
-        
-        func title(config: OEXConfig? = nil) -> String {
-            switch self {
-            case .Course:
-                return Strings.courses
-            case .Program:
-                return Strings.programs
-            case .Degree:
-                return Strings.degrees
-            }
-        }
-    }
     
     private var segmentItems : [SegmentItem] = []
     private var environment: RouterEnvironment
@@ -45,7 +39,7 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
     lazy var segmentedControl: UISegmentedControl = {
         let control = UISegmentedControl()
         let styles = self.environment.styles
-        control.selectedSegmentIndex = segment.courses.rawValue
+        control.selectedSegmentIndex = SegmentOption.course.rawValue
         control.tintColor = styles.primaryBaseColor()
         control.setTitleTextAttributes([NSForegroundColorAttributeName: styles.neutralWhite()], for: .selected)
         control.setTitleTextAttributes([NSForegroundColorAttributeName: styles.neutralBlack()], for: .normal)
@@ -77,30 +71,30 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
         segmentItems = []
         var index = 0
         var item : SegmentItem
-        for option in segmentOptions.options {
+        for option in SegmentOption.options {
             switch option {
-            case .Course:
+            case .course:
                 guard environment.config.discovery.course.isEnabled else { break }
                 let coursesController = self.environment.config.discovery.course.type == .webview ? OEXFindCoursesViewController(environment: environment, showBottomBar: false, bottomBar: bottomBar, searchQuery: self.searchQuery) : CourseCatalogViewController(environment: self.environment)
-                item = SegmentItem(title: option.title(), viewController: coursesController, index: index, type: segment.courses.rawValue)
+                item = SegmentItem(title: option.title, viewController: coursesController, index: index, type: option.rawValue)
                 segmentItems.append(item)
-                segmentedControl.insertSegment(withTitle: option.title(), at: index, animated: false)
+                segmentedControl.insertSegment(withTitle: option.title, at: index, animated: false)
                 index = segmentItems.count
-            case .Program:
+            case .program:
                 guard environment.config.discovery.program.isEnabled else { break }
                 let programDiscoveryViewController = ProgramsDiscoveryViewController(with: environment, showBottomBar: false, bottomBar: bottomBar)
                 programDiscoveryViewController.view.isHidden = true
-                item = SegmentItem(title: option.title(), viewController: programDiscoveryViewController, index: index, type: segment.programs.rawValue)
+                item = SegmentItem(title: option.title, viewController: programDiscoveryViewController, index: index, type: option.rawValue)
                 segmentItems.append(item)
-                segmentedControl.insertSegment(withTitle: option.title(), at: index, animated: false)
+                segmentedControl.insertSegment(withTitle: option.title, at: index, animated: false)
                 index = segmentItems.count
-            case .Degree:
+            case .degree:
                 guard environment.config.discovery.degree.isEnabled else { break }
                 let degreesViewController = DegreesViewController(with: environment, showBottomBar: false, bottomBar: bottomBar)
                 degreesViewController.view.isHidden = true
-                item = SegmentItem(title: option.title(), viewController: degreesViewController, index: index, type: segment.degrees.rawValue)
+                item = SegmentItem(title: option.title, viewController: degreesViewController, index: index, type: option.rawValue)
                 segmentItems.append(item)
-                segmentedControl.insertSegment(withTitle: option.title(), at: index, animated: false)
+                segmentedControl.insertSegment(withTitle: option.title, at: index, animated: false)
                 index = segmentItems.count
             }
         }
@@ -192,26 +186,26 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
     func switchSegment(with type: DeepLinkType) {
         switch type {
         case .courseDiscovery:
-            let index = self.index(for: segment.courses.rawValue)
-            segmentedControl.selectedSegmentIndex = index
-            controllerVisibility(with: index)
+            let selectedIndex = index(for: SegmentOption.course.rawValue)
+            segmentedControl.selectedSegmentIndex = selectedIndex
+            controllerVisibility(with: selectedIndex)
             break
         case .programDiscovery, .programDetail:
-            let index = self.index(for: segment.programs.rawValue)
-            segmentedControl.selectedSegmentIndex = index
-            controllerVisibility(with: index)
+            let selectedIndex = index(for: SegmentOption.program.rawValue)
+            segmentedControl.selectedSegmentIndex = selectedIndex
+            controllerVisibility(with: selectedIndex)
         default:
             break
         }
     }
     
     func segmentType(of selectedIndex: Int) -> Int {
-        var segmentType = segment.courses.rawValue
+        var segmentType = SegmentOption.course.rawValue
         for item in segmentItems {
             if item.index == selectedIndex {
                 segmentType = item.type
             }
         }
         return segmentType
-    }    
+    }
 }

--- a/Source/DiscoveryViewController.swift
+++ b/Source/DiscoveryViewController.swift
@@ -82,7 +82,7 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
             case .Course:
                 guard environment.config.discovery.course.isEnabled else { break }
                 let coursesController = self.environment.config.discovery.course.type == .webview ? OEXFindCoursesViewController(environment: environment, showBottomBar: false, bottomBar: bottomBar, searchQuery: self.searchQuery) : CourseCatalogViewController(environment: self.environment)
-                item = SegmentItem(title: option.title(), viewController: coursesController, index: index)
+                item = SegmentItem(title: option.title(), viewController: coursesController, index: index, type: segment.courses.rawValue)
                 segmentItems.append(item)
                 segmentedControl.insertSegment(withTitle: option.title(), at: index, animated: false)
                 index = segmentItems.count
@@ -90,7 +90,7 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
                 guard environment.config.discovery.program.isEnabled else { break }
                 let programDiscoveryViewController = ProgramsDiscoveryViewController(with: environment, showBottomBar: false, bottomBar: bottomBar)
                 programDiscoveryViewController.view.isHidden = true
-                item = SegmentItem(title: option.title(), viewController: programDiscoveryViewController, index: index)
+                item = SegmentItem(title: option.title(), viewController: programDiscoveryViewController, index: index, type: segment.programs.rawValue)
                 segmentItems.append(item)
                 segmentedControl.insertSegment(withTitle: option.title(), at: index, animated: false)
                 index = segmentItems.count
@@ -98,7 +98,7 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
                 guard environment.config.discovery.degree.isEnabled else { break }
                 let degreesViewController = DegreesViewController(with: environment, showBottomBar: false, bottomBar: bottomBar)
                 degreesViewController.view.isHidden = true
-                item = SegmentItem(title: option.title(), viewController: degreesViewController, index: index)
+                item = SegmentItem(title: option.title(), viewController: degreesViewController, index: index, type: segment.degrees.rawValue)
                 segmentItems.append(item)
                 segmentedControl.insertSegment(withTitle: option.title(), at: index, animated: false)
                 index = segmentItems.count
@@ -177,18 +177,41 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
         }
     }
 
+    func index(for segmentType: Int) -> Int {
+        var requiredIndex = 0
+        for item in segmentItems {
+            if item.type == segmentType {
+                requiredIndex = item.index
+                break
+            }
+        }
+        return requiredIndex
+    }
+    
     // MARK: Deep Linking    
     func switchSegment(with type: DeepLinkType) {
         switch type {
         case .courseDiscovery:
-            segmentedControl.selectedSegmentIndex = segment.courses.rawValue
-            controllerVisibility(with: segment.courses.rawValue)
+            let index = self.index(for: segment.courses.rawValue)
+            segmentedControl.selectedSegmentIndex = index
+            controllerVisibility(with: index)
             break
         case .programDiscovery, .programDetail:
-            segmentedControl.selectedSegmentIndex = segment.programs.rawValue
-            controllerVisibility(with: segment.programs.rawValue)
+            let index = self.index(for: segment.programs.rawValue)
+            segmentedControl.selectedSegmentIndex = index
+            controllerVisibility(with: index)
         default:
             break
         }
     }
+    
+    func segmentType(of selectedIndex: Int) -> Int {
+        var segmentType = segment.courses.rawValue
+        for item in segmentItems {
+            if item.index == selectedIndex {
+                segmentType = item.type
+            }
+        }
+        return segmentType
+    }    
 }

--- a/Source/DiscoveryWebViewHelper.swift
+++ b/Source/DiscoveryWebViewHelper.swift
@@ -17,6 +17,7 @@ fileprivate enum QueryParameterKeys {
 @objc enum DiscoveryType: Int {
     case course
     case program
+    case degree
 }
 
 class DiscoveryWebViewHelper: NSObject {
@@ -51,8 +52,8 @@ class DiscoveryWebViewHelper: NSObject {
     }
     
     private var bottomSpace: CGFloat {
-        guard let bottomBar = bottomBar else { return StandardVerticalMargin }
-        return bottomBar.frame.height
+        //TODO: this should be the height of bottomBar but for now giving it static value as the NSCopying making new object's frame as zero
+        return 90
     }
     
     convenience init(environment: Environment?, delegate: WebViewNavigationDelegate?, bottomBar: UIView?, discoveryType: DiscoveryType = .course) {
@@ -69,11 +70,10 @@ class DiscoveryWebViewHelper: NSObject {
         let discoveryConfig = discoveryType == .program ? environment?.config.discovery.program : environment?.config.discovery.course
         searchBarEnabled = (discoveryConfig?.webview.searchEnabled ?? false) && showSearch
         super.init()
-        searchBar.placeholder = discoveryType == .program ? Strings.searchProgramsPlaceholderText : Strings.searchCoursesPlaceholderText
+        searchBarPlaceholder()
         webView.navigationDelegate = self
         webView.scrollView.decelerationRate = UIScrollViewDecelerationRateNormal
         webView.accessibilityIdentifier = discoveryType == .course ? "find-courses-webview" : "find-programs-webview"
-        
         guard let container = delegate?.webViewContainingController() else { return }
         container.view.addSubview(contentView)
         contentView.snp.makeConstraints { make in
@@ -143,6 +143,22 @@ class DiscoveryWebViewHelper: NSObject {
         addObserver()
     }
     
+    private func searchBarPlaceholder() {
+        switch discoveryType {
+        case .course:
+            searchBar.placeholder = Strings.searchCoursesPlaceholderText
+            break
+        case .program:
+            searchBar.placeholder = Strings.searchProgramsPlaceholderText
+            break
+        case .degree:
+            searchBar.placeholder = Strings.searchDegreesPlaceholderText
+            break
+        default:
+            break
+        }
+    }
+    
     private func addObserver() {
         // Add URL change oberver on webview, so URL change of webview can be tracked and handled.
         urlObservation = webView.observe(\.url, changeHandler: { [weak self] (webView, change) in
@@ -165,6 +181,9 @@ class DiscoveryWebViewHelper: NSObject {
             if !URLHasSearchFilter {
                 searchBar.text = nil
             }
+            break
+        default:
+            break
         }
     }
     

--- a/Source/DiscoveryWebViewHelper.swift
+++ b/Source/DiscoveryWebViewHelper.swift
@@ -50,6 +50,11 @@ class DiscoveryWebViewHelper: NSObject {
         return (webView.url as NSURL?)?.oex_queryParameters() as? [String : String]
     }
     
+    private var bottomSpace: CGFloat {
+        guard let bottomBar = bottomBar else { return StandardVerticalMargin }
+        return bottomBar.frame.height
+    }
+    
     convenience init(environment: Environment?, delegate: WebViewNavigationDelegate?, bottomBar: UIView?, discoveryType: DiscoveryType = .course) {
         self.init(environment: environment, delegate: delegate, bottomBar: bottomBar, showSearch: false, searchQuery: nil, showSubjects: false, discoveryType: discoveryType)
     }
@@ -127,6 +132,12 @@ class DiscoveryWebViewHelper: NSObject {
             make.trailing.equalTo(contentView)
             make.bottom.equalTo(contentView)
             make.top.equalTo(topConstraintItem)
+            if !isUserLoggedIn {
+                make.bottom.equalTo(contentView).offset(-bottomSpace)
+            }
+            else {
+                make.bottom.equalTo(contentView)
+            }
         }
 
         addObserver()

--- a/Source/OEXAnalytics+Swift.swift
+++ b/Source/OEXAnalytics+Swift.swift
@@ -70,6 +70,7 @@ public enum AnalyticsScreenName: String {
     case CourseVideos = "Videos: Course Videos"
     case SubjectsDiscovery = "Discover: All Subjects"
     case DiscoverProgram = "Find Programs"
+    case DiscoverDegree = "Find Degrees"
     case ProgramInfo = "Program Info"
 }
 

--- a/Source/OEXAppDelegate.m
+++ b/Source/OEXAppDelegate.m
@@ -219,7 +219,7 @@
     //Initialize Fabric
     OEXFabricConfig* fabric = [config fabricConfig];
     if(fabric.appKey && fabric.isEnabled) {
-        [Fabric with:@[CrashlyticsKit]];
+        //[Fabric with:@[CrashlyticsKit]];
     }
 }
 

--- a/Source/OEXAppDelegate.m
+++ b/Source/OEXAppDelegate.m
@@ -219,7 +219,7 @@
     //Initialize Fabric
     OEXFabricConfig* fabric = [config fabricConfig];
     if(fabric.appKey && fabric.isEnabled) {
-        //[Fabric with:@[CrashlyticsKit]];
+        [Fabric with:@[CrashlyticsKit]];
     }
 }
 

--- a/Source/OEXAppDelegate.m
+++ b/Source/OEXAppDelegate.m
@@ -219,7 +219,7 @@
     //Initialize Fabric
     OEXFabricConfig* fabric = [config fabricConfig];
     if(fabric.appKey && fabric.isEnabled) {
-        [Fabric with:@[CrashlyticsKit]];
+       [Fabric with:@[CrashlyticsKit]];
     }
 }
 

--- a/Source/OEXAppDelegate.m
+++ b/Source/OEXAppDelegate.m
@@ -219,7 +219,7 @@
     //Initialize Fabric
     OEXFabricConfig* fabric = [config fabricConfig];
     if(fabric.appKey && fabric.isEnabled) {
-       [Fabric with:@[CrashlyticsKit]];
+        [Fabric with:@[CrashlyticsKit]];
     }
 }
 

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -329,8 +329,9 @@ extension OEXRouter {
     func discoveryViewController(bottomBar: UIView? = nil, searchQuery: String? = nil) -> UIViewController? {
         let isCourseDiscoveryEnabled = environment.config.discovery.course.isEnabled
         let isProgramDiscoveryEnabled = environment.config.discovery.program.isEnabled
+        let isDegreeDiscveryEnabled = environment.config.discovery.degree.isEnabled
         
-        if isCourseDiscoveryEnabled && isProgramDiscoveryEnabled {
+        if isCourseDiscoveryEnabled && isProgramDiscoveryEnabled && isDegreeDiscveryEnabled {
             return DiscoveryViewController(with: environment, bottomBar: bottomBar, searchQuery: searchQuery)
         }
         else if isCourseDiscoveryEnabled {
@@ -338,6 +339,9 @@ extension OEXRouter {
         }
         else if isProgramDiscoveryEnabled {
             return ProgramsDiscoveryViewController(with: environment, bottomBar: bottomBar, searchQuery: searchQuery)
+        }
+        else if isDegreeDiscveryEnabled {
+            return DegreesViewController(with: environment, bottomBar: bottomBar, searchQuery: searchQuery)
         }
         return nil
     }

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -331,17 +331,13 @@ extension OEXRouter {
         let isProgramDiscoveryEnabled = environment.config.discovery.program.isEnabled
         let isDegreeDiscveryEnabled = environment.config.discovery.degree.isEnabled
         
-        if isCourseDiscoveryEnabled && isProgramDiscoveryEnabled && isDegreeDiscveryEnabled {
+        if (isCourseDiscoveryEnabled && isProgramDiscoveryEnabled && isDegreeDiscveryEnabled) ||
+            (isCourseDiscoveryEnabled && isProgramDiscoveryEnabled) ||
+            (isCourseDiscoveryEnabled && isDegreeDiscveryEnabled) {
             return DiscoveryViewController(with: environment, bottomBar: bottomBar, searchQuery: searchQuery)
         }
         else if isCourseDiscoveryEnabled {
             return environment.config.discovery.course.type == .webview ? OEXFindCoursesViewController(environment: environment, showBottomBar: true, bottomBar: bottomBar, searchQuery: searchQuery) : CourseCatalogViewController(environment: environment)
-        }
-        else if isProgramDiscoveryEnabled {
-            return ProgramsDiscoveryViewController(with: environment, bottomBar: bottomBar, searchQuery: searchQuery)
-        }
-        else if isDegreeDiscveryEnabled {
-            return DegreesViewController(with: environment, bottomBar: bottomBar, searchQuery: searchQuery)
         }
         return nil
     }

--- a/Source/ProgramsDiscoveryViewController.swift
+++ b/Source/ProgramsDiscoveryViewController.swift
@@ -69,9 +69,6 @@ class ProgramsDiscoveryViewController: UIViewController, InterfaceOrientationOve
         if let _ = pathId {
             environment.analytics.trackScreen(withName: AnalyticsScreenName.ProgramInfo.rawValue)
         }
-        else {
-            environment.analytics.trackScreen(withName: AnalyticsScreenName.DiscoverProgram.rawValue)
-        }
     }
     
     func loadProgramDetails(with pathId: String) {

--- a/Source/SegmentItem.swift
+++ b/Source/SegmentItem.swift
@@ -13,4 +13,5 @@ struct SegmentItem {
     let title: String
     let viewController: UIViewController
     let index: Int
+    let type: Int
 }

--- a/Source/SegmentItem.swift
+++ b/Source/SegmentItem.swift
@@ -14,4 +14,5 @@ struct SegmentItem {
     let viewController: UIViewController
     let index: Int
     let type: Int
+    let analyticsScreenName: String
 }

--- a/Source/SegmentItem.swift
+++ b/Source/SegmentItem.swift
@@ -1,0 +1,16 @@
+//
+//  SegmentItem.swift
+//  edX
+//
+//  Created by Salman on 30/01/2019.
+//  Copyright © 2019 edX. All rights reserved.
+//
+
+import UIKit
+
+// SegmentItem represent each tab in UISegmentedControl
+struct SegmentItem {
+    let title: String
+    let viewController: UIViewController
+    let index: Int
+}

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -432,6 +432,8 @@
 "DISCOVER"="Discovery";
 /*Title for the programs in tabbar and navigation bar*/
 "PROGRAMS"="Programs";
+/*Title for the degrees in navigation bar*/
+"DEGREES"="Degrees";
 /*Debug option title in tabbar */
 "DEBUG"="Debug";
 /* Error message shown when email address is not properly formatted */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -703,6 +703,8 @@
 "SEARCH_COURSES_PLACEHOLDER_TEXT"="Search course";
 /*Placeholder text for search program textfield*/
 "SEARCH_PROGRAMS_PLACEHOLDER_TEXT"="Search program";
+/*Placeholder text for search degree textfield*/
+"SEARCH_DEGREES_PLACEHOLDER_TEXT"="Search degree";
 /* Discussion search results  */
 "SEARCH_RESULTS"="Search results";
 /* Text shown below the video, in portrait mode */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -703,6 +703,8 @@
 "SEARCH_COURSES_PLACEHOLDER_TEXT"="Search course";
 /*Placeholder text for search programs textfield*/
 "SEARCH_PROGRAMS_PLACEHOLDER_TEXT"="Search program";
+/*Placeholder text for search degree textfield*/
+"SEARCH_DEGREES_PLACEHOLDER_TEXT"="Search degree";
 /* Discussion search results  */
 "SEARCH_RESULTS"="Resultados de búsqueda";
 /* Text shown below the video, in portrait mode */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -432,6 +432,8 @@
 "DISCOVER"="Exploración";
 /*Title for the programs in tabbar and navigation bar*/
 "PROGRAMS"="Programs";
+/*Title for the degrees in navigation bar*/
+"DEGREES"="Degrees";
 /*Debug option title in tabbar */
 "DEBUG"="Debug";
 /* Error message shown when email address is not properly formatted */

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		224D457921B90753003A382C /* UIFont+Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224D457821B90753003A382C /* UIFont+Attributes.swift */; };
 		224F1F532067B4E0009B3639 /* CustomSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224F1F522067B4E0009B3639 /* CustomSlider.swift */; };
 		22547414220038BC000E5957 /* DegreesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22547413220038BC000E5957 /* DegreesViewController.swift */; };
+		225474162201B765000E5957 /* SegmentItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 225474152201B765000E5957 /* SegmentItem.swift */; };
 		2254EF03207610FF00BA183C /* CustomPlayerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2254EF02207610FF00BA183C /* CustomPlayerButton.swift */; };
 		2255C94E2111BADC005F7C8C /* ProgramConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2255C94D2111BADC005F7C8C /* ProgramConfig.swift */; };
 		2255C95021183FCC005F7C8C /* ProgramConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2255C94F21183FCC005F7C8C /* ProgramConfigTests.swift */; };
@@ -1027,6 +1028,7 @@
 		224D457821B90753003A382C /* UIFont+Attributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Attributes.swift"; sourceTree = "<group>"; };
 		224F1F522067B4E0009B3639 /* CustomSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSlider.swift; sourceTree = "<group>"; };
 		22547413220038BC000E5957 /* DegreesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DegreesViewController.swift; sourceTree = "<group>"; };
+		225474152201B765000E5957 /* SegmentItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentItem.swift; sourceTree = "<group>"; };
 		2254EF02207610FF00BA183C /* CustomPlayerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPlayerButton.swift; sourceTree = "<group>"; };
 		2255C94D2111BADC005F7C8C /* ProgramConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramConfig.swift; sourceTree = "<group>"; };
 		2255C94F21183FCC005F7C8C /* ProgramConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramConfigTests.swift; sourceTree = "<group>"; };
@@ -3099,6 +3101,7 @@
 				B7EC83BE21A2D34600D6A89C /* ProgramsDiscoveryViewController.swift */,
 				B7EC83C021A2DE9E00D6A89C /* DiscoveryViewController.swift */,
 				22547413220038BC000E5957 /* DegreesViewController.swift */,
+				225474152201B765000E5957 /* SegmentItem.swift */,
 			);
 			name = "Course Enrollment";
 			sourceTree = "<group>";
@@ -4926,6 +4929,7 @@
 				B42DA1891A1539F000E3AD4E /* OEXFileUtility.m in Sources */,
 				224D457921B90753003A382C /* UIFont+Attributes.swift in Sources */,
 				777EFEFD1A7AFF0E00F8BF06 /* OEXRouter.m in Sources */,
+				225474162201B765000E5957 /* SegmentItem.swift in Sources */,
 				9EC6E0FE1BDE106500729704 /* IrregularBorderView.swift in Sources */,
 				8F562F881A1F2D2C00320DB3 /* OEXGoogleSocial.m in Sources */,
 				69C12C661E07F5F8004E7261 /* VideoTranscript.swift in Sources */,

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		2240FD561FF266E4001D6589 /* TabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2240FD551FF266E4001D6589 /* TabBarItem.swift */; };
 		224D457921B90753003A382C /* UIFont+Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224D457821B90753003A382C /* UIFont+Attributes.swift */; };
 		224F1F532067B4E0009B3639 /* CustomSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224F1F522067B4E0009B3639 /* CustomSlider.swift */; };
+		22547414220038BC000E5957 /* DegreesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22547413220038BC000E5957 /* DegreesViewController.swift */; };
 		2254EF03207610FF00BA183C /* CustomPlayerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2254EF02207610FF00BA183C /* CustomPlayerButton.swift */; };
 		2255C94E2111BADC005F7C8C /* ProgramConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2255C94D2111BADC005F7C8C /* ProgramConfig.swift */; };
 		2255C95021183FCC005F7C8C /* ProgramConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2255C94F21183FCC005F7C8C /* ProgramConfigTests.swift */; };
@@ -1025,6 +1026,7 @@
 		2240FD551FF266E4001D6589 /* TabBarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarItem.swift; sourceTree = "<group>"; };
 		224D457821B90753003A382C /* UIFont+Attributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Attributes.swift"; sourceTree = "<group>"; };
 		224F1F522067B4E0009B3639 /* CustomSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSlider.swift; sourceTree = "<group>"; };
+		22547413220038BC000E5957 /* DegreesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DegreesViewController.swift; sourceTree = "<group>"; };
 		2254EF02207610FF00BA183C /* CustomPlayerButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPlayerButton.swift; sourceTree = "<group>"; };
 		2255C94D2111BADC005F7C8C /* ProgramConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramConfig.swift; sourceTree = "<group>"; };
 		2255C94F21183FCC005F7C8C /* ProgramConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramConfigTests.swift; sourceTree = "<group>"; };
@@ -3096,6 +3098,7 @@
 				9C9B7F661A8CC68400A857B2 /* OEXCourseInfoViewController.m */,
 				B7EC83BE21A2D34600D6A89C /* ProgramsDiscoveryViewController.swift */,
 				B7EC83C021A2DE9E00D6A89C /* DiscoveryViewController.swift */,
+				22547413220038BC000E5957 /* DegreesViewController.swift */,
 			);
 			name = "Course Enrollment";
 			sourceTree = "<group>";
@@ -4878,6 +4881,7 @@
 				B7CCC72D209B16B100A66923 /* ConstraintLayoutGuide.swift in Sources */,
 				B4B285E51A9A49FF00DD603A /* OEXFabricConfig.m in Sources */,
 				1A81971B1C060FA50030254D /* ShareHelper.swift in Sources */,
+				22547414220038BC000E5957 /* DegreesViewController.swift in Sources */,
 				223A98FC1FA8610B0018DF67 /* AdditionalTabBarViewController.swift in Sources */,
 				77F76A6E1B0BD32A00ED3E39 /* OEXSession+Authorization.swift in Sources */,
 				B7A1EA83209C41C400BD369A /* SnapKit+SafeAreaLayoutGuide.swift in Sources */,


### PR DESCRIPTION
### Description

[LEARNER-6918](https://openedx.atlassian.net/browse/LEARNER-6918)

In this PR i added the third tab name "degree" in discovery view.

### How to test this PR

Add the following configurations under the "DISCOVERY" object to enable degree
```
DEGREE:
        TYPE: 'webview'
        WEBVIEW:
            BASE_URL: 'https://webview.edx.org/course?type=Masters'
            DETAIL_TEMPLATE: 'https://webview.edx.org/{path_id}'
            SEARCH_ENABLED: true
```


- If you are not logged in, tap on the search courses, the third tab degree should be there.
- If you are logged in, switch the discovery tab view, there should be third tab degree there.
