### PR TITLE
Add openedx-release to openedx.yaml

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -4,7 +4,7 @@
 nick: ios
 oeps: {}
 owner: edx/edx-mobile-push
+openedx-release: {ref: release/latest}
 tags:
   - mobile
   - ios
-track-pulls: true


### PR DESCRIPTION
### Description

This will let us tag the mobile apps along with the rest of the Open edX releases.

### Notes

### How to test this PR
