### PR TITLE
Make degree tab dependent on program

### DIFF
--- a/Source/DiscoveryConfig.swift
+++ b/Source/DiscoveryConfig.swift
@@ -53,7 +53,7 @@ class DiscoveryConfig: NSObject {
     init(dictionary: [String: AnyObject]) {
         course = CourseDiscovery(dictionary: dictionary[DiscoveryKeys.course] as? [String: AnyObject] ?? [:])
         program = ProgramDiscovery(with: course, dictionary: dictionary[DiscoveryKeys.program] as? [String: AnyObject] ?? [:])
-        degree = DegreeDiscovery(with: course, dictionary: dictionary[DiscoveryKeys.degree] as? [String: AnyObject] ?? [:])
+        degree = DegreeDiscovery(with: program, dictionary: dictionary[DiscoveryKeys.degree] as? [String: AnyObject] ?? [:])
     }
 }
 
@@ -83,7 +83,19 @@ class ProgramDiscovery: DiscoveryBase {
     }
 }
 
-class DegreeDiscovery: ProgramDiscovery { }
+class DegreeDiscovery: DiscoveryBase {
+    
+    private let programDiscovery: ProgramDiscovery
+    
+    init(with programDiscovery: ProgramDiscovery, dictionary: [String : AnyObject]) {
+        self.programDiscovery = programDiscovery
+        super.init(dictionary: dictionary)
+    }
+    
+    var isEnabled: Bool {
+        return programDiscovery.isEnabled && type == .webview
+    }
+}
 
 class DiscoveryBase: NSObject {
     private(set) var type: DiscoveryConfigType


### PR DESCRIPTION
### Description

[LEARNER-7049](https://openedx.atlassian.net/browse/LEARNER-7049)

Currently, the degrees have the URI prefix edxapp://program_info, which is what we use for Program Discovery and resolve in-app using the DETAIL_TEMPLATE key in the Program Discovery map config.

If the Program Discovery isn't present in the config and Degree Discovery is enabled, the app starts to crash whenever a Degree item is opened in-app.

In this PR we are making the degree tab dependent on programs discovery.

