### PR TITLE
Update Escaping Mechanism for Query Parameters in API Requests

### DIFF
--- a/Libraries/Alamofire/Alamofire.swift
+++ b/Libraries/Alamofire/Alamofire.swift
@@ -160,8 +160,7 @@ public enum ParameterEncoding {
     }
 
     func escape(_ string: String) -> String {
-        let legalURLCharactersToBeEscaped: CFString = ":&=;+!@#$()',*" as CFString
-        return CFURLCreateStringByAddingPercentEscapes(nil, string as CFString!, nil, legalURLCharactersToBeEscaped, CFStringBuiltInEncodings.UTF8.rawValue) as String
+        return string.addingPercentEncoding(withAllowedCharacters: .URLQueryAllowed) ?? string
     }
 }
 
@@ -1703,4 +1702,24 @@ extension URLSessionConfiguration {
     public func defaultHTTPHeaders() -> NSDictionary {
         return Manager.defaultHTTPHeaders as NSDictionary
     }
+}
+
+extension CharacterSet {
+    /// Creates a CharacterSet from RFC 3986 allowed characters.
+    ///
+    /// RFC 3986 states that the following characters are "reserved" characters.
+    ///
+    /// - General Delimiters: ":", "#", "[", "]", "@", "?", "/"
+    /// - Sub-Delimiters: "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "="
+    ///
+    /// In RFC 3986 - Section 3.4, it states that the "?" and "/" characters should not be escaped to allow
+    /// query strings to include a URL. Therefore, all "reserved" characters with the exception of "?" and "/"
+    /// should be percent-escaped in the query string.
+    public static let URLQueryAllowed: CharacterSet = {
+        let generalDelimitersToEncode = ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
+        let subDelimitersToEncode = "!$&'()*+,;="
+        let encodableDelimiters = CharacterSet(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
+
+        return CharacterSet.urlQueryAllowed.subtracting(encodableDelimiters)
+    }()
 }


### PR DESCRIPTION
### Description

[LEARNER-6925](https://openedx.atlassian.net/browse/LEARNER-6925)

Mobile was using `CFURLCreateStringByAddingPercentEscapes` to escape legal URL characters. The CFURLCreateStringByAddingPercentEscapes was deprecated in iOS 9.0. The current version of iOS is 12.1.4, so iOS 9.0 is pretty much older iOS version and Xcode is giving the warning to update it.

I have created a CharacterSet from RFC 3986 allowed characters to handle query parameters in API requests. 

### Notes

### How to test this PR

Run the app and access all the areas of the app. App should behave exactly the same as it was behaving before the update.