### PR TITLE
Implement deep linking for course dates screen

### DIFF
--- a/Source/CourseDashboardViewController.swift
+++ b/Source/CourseDashboardViewController.swift
@@ -201,11 +201,16 @@ class CourseDashboardViewController: UITabBarController, UITabBarControllerDeleg
         switch type {
         case .courseDashboard:
             selectedIndex = tabBarViewControllerIndex(with: CourseOutlineViewController.self, courseOutlineMode: .full)
+            break
         case .courseVideos:
             selectedIndex = tabBarViewControllerIndex(with: CourseOutlineViewController.self, courseOutlineMode: .video)
             break
         case .discussions, .discussionTopic, .discussionPost:
             selectedIndex = tabBarViewControllerIndex(with: DiscussionTopicsViewController.self)
+            break
+        case .courseDates:
+            selectedIndex = tabBarViewControllerIndex(with: CourseDatesViewController.self)
+            break
         default:
             selectedIndex = 0
             break

--- a/Source/Deep Linking/DeepLink.swift
+++ b/Source/Deep Linking/DeepLink.swift
@@ -12,6 +12,7 @@ enum DeepLinkType: String {
     case courseDashboard = "course_dashboard"
     case courseVideos = "course_videos"
     case discussions = "course_discussion"
+    case courseDates = "course_dates"
     case discussionTopic = "discussion_topic"
     case discussionPost = "discussion_post"
     case courseDiscovery = "course_discovery"

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -356,7 +356,7 @@ typealias DismissCompletion = () -> Void
         }
         
         switch type {
-        case .courseDashboard, .courseVideos, .discussions:
+        case .courseDashboard, .courseVideos, .discussions, .courseDates:
             showCourseDashboardViewController(with: link)
             break
         case .program:


### PR DESCRIPTION
### Description

[LEARNER-7196](https://openedx.atlassian.net/browse/LEARNER-7196)

In this PR, i implemented the deep linking for course dates screen, now by clicking on the quick link the app will open up the course dates tab on course dashboard screen.

Notes
How to test this PR
Add following links in notes, tap on the url will open the app and navigate to course dates screen.

Program Detail Screen: https://edx.app.link/course_dates