### PR TITLE
Cache xBlocks and Preloading xBlocks

### DIFF
--- a/Source/BlockViewControllerCacheManager.swift
+++ b/Source/BlockViewControllerCacheManager.swift
@@ -16,7 +16,7 @@ public class BlockViewControllerCacheManager: NSObject {
     
     override init() {
         super.init()
-        viewControllers.countLimit = 7
+        viewControllers.countLimit = 6
         NotificationCenter.default.oex_addObserver(observer: self, name: UIApplication.didReceiveMemoryWarningNotification.rawValue) {(_,observer, _) -> Void in
             observer.viewControllers.removeAllObjects()
         }

--- a/Source/BlockViewControllerCacheManager.swift
+++ b/Source/BlockViewControllerCacheManager.swift
@@ -11,9 +11,12 @@ import UIKit
 public class BlockViewControllerCacheManager: NSObject {
    
     private let viewControllers = NSCache<AnyObject, AnyObject>()
+
+    static let shared = BlockViewControllerCacheManager()
     
     override init() {
         super.init()
+        viewControllers.countLimit = 7
         NotificationCenter.default.oex_addObserver(observer: self, name: UIApplication.didReceiveMemoryWarningNotification.rawValue) {(_,observer, _) -> Void in
             observer.viewControllers.removeAllObjects()
         }

--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -57,7 +57,7 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
         courseQuerier = environment.dataManager.courseDataManager.querierForCourseWithID(courseID: courseID)
         initialLoadController = LoadStateViewController()
         
-        cacheManager = BlockViewControllerCacheManager()
+        cacheManager = BlockViewControllerCacheManager.shared
         courseOutlineMode = mode
         super.init(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
         self.setViewControllers([initialLoadController], direction: .forward, animated: false, completion: nil)
@@ -329,9 +329,6 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
         else {
             // Instantiate a new VC from the router if not found in cache already
             if let viewController = self.environment.router?.controllerForBlock(block: block, courseID: courseQuerier.courseID) {
-                if block.displayType.isCacheable {
-                    cacheManager.addToCache(viewController: viewController, blockID: block.blockID)
-                }
                 blockViewController = viewController
             }
             else {

--- a/Source/HTMLBlockViewController.swift
+++ b/Source/HTMLBlockViewController.swift
@@ -28,22 +28,18 @@ public class HTMLBlockViewController: UIViewController, CourseBlockViewControlle
         courseQuerier = environment.dataManager.courseDataManager.querierForCourseWithID(courseID: courseID)
         
         super.init(nibName : nil, bundle : nil)
-        
-        addChild(webController)
-        webController.didMove(toParent: self)
+
+        setupAndLoad()
     }
 
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    public override func viewDidLoad() {
-        super.viewDidLoad()
+
+    private func setupAndLoad() {
+        addChild(webController)
+        webController.didMove(toParent: self)
         view.addSubview(webController.view)
-    }
-    
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
         loadData()
     }
     

--- a/Test/CourseContentPageViewControllerTests.swift
+++ b/Test/CourseContentPageViewControllerTests.swift
@@ -148,7 +148,7 @@ class CourseContentPageViewControllerTests: SnapshotTestCase {
 
         loadAndVerifyControllerWithInitialChild(childID, parentID: outline.root) { (coursID, controller) -> ((XCTestExpectation) -> Void)? in
             return { expectation -> Void in
-                DispatchQueue.main.async {
+                self.wait(for: 0.5) {
                     self.environment.eventTracker.eventStream.listenOnce(self) {_ in
                         let events = self.environment.eventTracker.events.compactMap { return $0.asScreen }
 

--- a/Test/CourseContentPageViewControllerTests.swift
+++ b/Test/CourseContentPageViewControllerTests.swift
@@ -145,24 +145,17 @@ class CourseContentPageViewControllerTests: SnapshotTestCase {
         let childIDs = outline.blocks[outline.root]!.children
         XCTAssertTrue(childIDs.count > 2, "Need at least three children for this test")
         let childID = childIDs.first
-
+        
         loadAndVerifyControllerWithInitialChild(childID, parentID: outline.root) { (coursID, controller) -> ((XCTestExpectation) -> Void)? in
             return { expectation -> Void in
-                self.wait(for: 0.5) {
-                    self.environment.eventTracker.eventStream.listenOnce(self) {_ in
-                        let events = self.environment.eventTracker.events.compactMap { return $0.asScreen }
-
-                        if events.count < 2 {
-                            return
-                        }
-
-                        let event = events.first!
-                        XCTAssertNotNil(event)
-                        XCTAssertEqual(event.screenName, OEXAnalyticsScreenUnitDetail)
-                        XCTAssertEqual(event.courseID, self.outline.root)
-                        XCTAssertEqual(event.value, self.outline.blocks[self.outline.root]?.internalName)
-                        expectation.fulfill()
-                    }
+                self.environment.eventTracker.eventStream.listenOnce(self) {_ in
+                    let events = self.environment.eventTracker.events.compactMap { return $0.asScreen }
+                    let event = events.first!
+                    XCTAssertNotNil(event)
+                    XCTAssertEqual(event.screenName, OEXAnalyticsScreenUnitDetail)
+                    XCTAssertEqual(event.courseID, self.outline.root)
+                    XCTAssertEqual(event.value, self.outline.blocks[self.outline.root]?.internalName)
+                    expectation.fulfill()
                 }
             }
         }


### PR DESCRIPTION
### Description

[LEARNER-7181](https://openedx.atlassian.net/browse/LEARNER-7181)

Implement preloading of next & previous xblocks and caching seven blocks. This will increase the user experience significantly. For the cache, I have used NSCashe because NSCashe is purgeable cache and we don't have to worry about memory size.

### Notes

It's not sure that, seven xblocks will always be in cache because of purgeable cache. Cache items will totally depend on device memory.

### How to test this PR
