### PR TITLE
iOS - Implement deep linking for course handouts

### DIFF
--- a/Source/CourseDashboardViewController.swift
+++ b/Source/CourseDashboardViewController.swift
@@ -211,6 +211,10 @@ class CourseDashboardViewController: UITabBarController, UITabBarControllerDeleg
         case .courseDates:
             selectedIndex = tabBarViewControllerIndex(with: CourseDatesViewController.self)
             break
+        case .courseHandout:
+            let index = tabBarViewControllerIndex(with: CourseHandoutsViewController.self)
+            selectedIndex = (index == 0) ? tabBarViewControllerIndex(with: AdditionalTabBarViewController.self) : index        
+            break
         default:
             selectedIndex = 0
             break

--- a/Source/CourseHandoutsViewController.swift
+++ b/Source/CourseHandoutsViewController.swift
@@ -92,7 +92,7 @@ public class CourseHandoutsViewController: OfflineSupportViewController, UIWebVi
             let handoutStream = courseStream.transform {[weak self] enrollment in
                 return self?.streamForCourse(course: enrollment.course) ?? OEXStream<String>(error : NSError.oex_courseContentLoadError())
             }
-            self.handouts.backWithStream(handoutStream)
+            self.handouts.backWithStream((courseStream.value != nil) ? handoutStream : OEXStream<String>(error : NSError.oex_courseContentLoadError()))    
         }
     }
     

--- a/Source/Deep Linking/DeepLink.swift
+++ b/Source/Deep Linking/DeepLink.swift
@@ -13,6 +13,7 @@ enum DeepLinkType: String {
     case courseVideos = "course_videos"
     case discussions = "course_discussion"
     case courseDates = "course_dates"
+    case courseHandout = "course_handout"
     case discussionTopic = "discussion_topic"
     case discussionPost = "discussion_post"
     case courseDiscovery = "course_discovery"

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -325,6 +325,31 @@ typealias DismissCompletion = () -> Void
         }
     }
     
+    private func showCourseHandout(with link: DeepLink) {
+        
+        var controllerAlreadyDisplayed: Bool {
+            if let topController = topMostViewController, let courseHandoutController = topController as? CourseHandoutsViewController, courseHandoutController.courseID == link.courseId {
+                return true
+            }
+            return false
+        }
+        
+        func showHandout() {
+            if let topController = topMostViewController {
+                environment?.router?.showHandoutsFromController(controller: topController, courseID: link.courseId ?? "")
+            }
+        }
+        
+        guard !controllerAlreadyDisplayed else { return }
+        
+         dismiss() { [weak self] in
+            if let topController = self?.topMostViewController {
+                self?.environment?.router?.showCourse(with: link, courseID: link.courseId ?? "", from: topController)
+            }
+            showHandout()
+        }
+    }
+    
     private func controllerAlreadyDisplayed(for type: DeepLinkType) -> Bool {
         guard let topViewController = topMostViewController else { return false }
         
@@ -378,6 +403,9 @@ typealias DismissCompletion = () -> Void
             break
         case .discussionPost:
             showDiscussionResponses(with: link)
+            break
+        case .courseHandout:
+            showCourseHandout(with: link)
             break
             
         default:


### PR DESCRIPTION
### Description

[LEARNER-7197](https://openedx.atlassian.net/browse/LEARNER-7197)

In this PR, i implemented the deep linking for course handout screen, now by clicking on the quick link the app will open up the course handout screen on course dashboard screen.

Notes
How to test this PR
Add following links in notes, tap on the url will open the app and navigate to course handout screen.

Course Handout Screen: https://edx.app.link/course_handout