### PR TITLE
Added support to OEXTextStyle for disabling dynamic type

### DIFF
--- a/Source/DetailToolbarButton.swift
+++ b/Source/DetailToolbarButton.swift
@@ -83,12 +83,14 @@ class DetailToolbarButton: UIView {
     private var titleStyle : OEXTextStyle {
         let style = OEXMutableTextStyle(weight: .semiBold, size: .small, color: OEXStyles.shared().primaryBaseColor())
         style.alignment = self.textAlignment
+        style.dynamicTypeSupported = false
         return style
     }
     
     private var destinationStyle : OEXTextStyle {
         let style = OEXMutableTextStyle(weight: .normal, size: .xSmall, color: OEXStyles.shared().neutralBase())
         style.alignment = self.textAlignment
+        style.dynamicTypeSupported = false
         return style
     }
 }

--- a/Source/OEXFonts.swift
+++ b/Source/OEXFonts.swift
@@ -55,7 +55,19 @@ public class OEXFonts: NSObject {
         
         return UIFont(descriptor: preferredFontDescriptor, size: preferredFontSize)
     }
-    
+
+    @objc public func font(for identifier: FontIdentifiers, size: CGFloat, dynamicTypeSupported: Bool) -> UIFont {
+        if dynamicTypeSupported {
+            return font(for: identifier, size: size)
+        }
+
+        if let fontName = fontsDictionary[getIdentifier(identifier: identifier)] as? String {
+            return UIFont(name: fontName, size: size)!
+        }
+
+        return UIFont(name:getIdentifier(identifier: FontIdentifiers.Irregular), size: size)!
+    }
+
     private func getIdentifier(identifier: FontIdentifiers) -> String {
         switch identifier {
         case .Regular:

--- a/Source/OEXStyles.h
+++ b/Source/OEXStyles.h
@@ -26,6 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (UIFont*)semiBoldSansSerifOfSize:(CGFloat)size;
 - (UIFont*)boldSansSerifOfSize:(CGFloat)size;
 
+- (UIFont*)sansSerifOfSize:(CGFloat)size dynamicTypeSupported:(BOOL) dynamicTypeSupported;
+- (UIFont*)lightSansSerifOfSize:(CGFloat)size dynamicTypeSupported:(BOOL) dynamicTypeSupported;
+- (UIFont*)semiBoldSansSerifOfSize:(CGFloat)size dynamicTypeSupported:(BOOL) dynamicTypeSupported;
+- (UIFont*)boldSansSerifOfSize:(CGFloat)size dynamicTypeSupported:(BOOL) dynamicTypeSupported;
+
 - (nullable NSString*)styleHTMLContent:(nullable NSString*)htmlString stylesheet:(NSString*)stylesheet;
 
 - (OEXSwitchStyle*)standardSwitchStyle;

--- a/Source/OEXStyles.m
+++ b/Source/OEXStyles.m
@@ -258,6 +258,26 @@ static OEXStyles* sSharedStyles;
                                        size:size];
 }
 
+- (UIFont*)sansSerifOfSize:(CGFloat)size dynamicTypeSupported:(BOOL) dynamicTypeSupported {
+    return [self.oexFonts fontFor:FontIdentifiersRegular
+                             size:size dynamicTypeSupported:dynamicTypeSupported];
+}
+
+- (UIFont*)semiBoldSansSerifOfSize:(CGFloat)size dynamicTypeSupported:(BOOL) dynamicTypeSupported {
+    return [self.oexFonts fontFor:FontIdentifiersSemiBold
+                             size:size dynamicTypeSupported:dynamicTypeSupported];
+}
+
+- (UIFont*)boldSansSerifOfSize:(CGFloat)size dynamicTypeSupported:(BOOL) dynamicTypeSupported {
+    return [self.oexFonts fontFor:FontIdentifiersBold
+                             size:size dynamicTypeSupported:dynamicTypeSupported];
+}
+
+- (UIFont*)lightSansSerifOfSize:(CGFloat)size dynamicTypeSupported:(BOOL) dynamicTypeSupported {
+    return [self.oexFonts fontFor:FontIdentifiersLight
+                             size:size dynamicTypeSupported:dynamicTypeSupported];
+}
+
 - (NSString*)styleHTMLContent:(NSString*)htmlString stylesheet:(NSString*)stylesheet {
     NSString* path = [[NSBundle mainBundle] pathForResource:stylesheet ofType:@"css"];
     NSError* error = nil;

--- a/Source/OEXTextStyle.h
+++ b/Source/OEXTextStyle.h
@@ -69,6 +69,8 @@ typedef NS_ENUM(NSUInteger, OEXTextSize) {
 @property (readonly, copy, nonatomic) OEXTextStyle*(^withSize)(OEXTextSize size);
 /// Duplicates the current style but with the specified color
 @property (readonly, copy, nonatomic) OEXTextStyle*(^withColor)(UIColor* color);
+/// Controls Dynamic type support. default true
+@property (nonatomic) BOOL dynamicTypeSupported;
 
 - (NSAttributedString*)attributedStringWithText:(nullable NSString*)text;
 

--- a/Source/OEXTextStyle.m
+++ b/Source/OEXTextStyle.m
@@ -41,6 +41,7 @@
         self.letterSpacing = OEXLetterSpacingNormal;
         self.lineBreakMode = NSLineBreakByTruncatingTail;
         self.alignment = NSTextAlignmentNatural;
+        self.dynamicTypeSupported = true;
     }
     return self;
 }
@@ -133,13 +134,13 @@
     CGFloat pointSize = [[self class] pointSizeForTextSize:size];
     switch (weight) {
         case OEXTextWeightNormal:
-            return [[OEXStyles sharedStyles] sansSerifOfSize:pointSize] ?: [UIFont systemFontOfSize:pointSize];
+            return [[OEXStyles sharedStyles] sansSerifOfSize:pointSize dynamicTypeSupported:self.dynamicTypeSupported] ?: [UIFont systemFontOfSize:pointSize];
         case OEXTextWeightLight:
-            return [[OEXStyles sharedStyles] lightSansSerifOfSize:pointSize] ?: [UIFont systemFontOfSize:pointSize];
+            return [[OEXStyles sharedStyles] lightSansSerifOfSize:pointSize dynamicTypeSupported:self.dynamicTypeSupported] ?: [UIFont systemFontOfSize:pointSize];
         case OEXTextWeightSemiBold:
-            return [[OEXStyles sharedStyles] semiBoldSansSerifOfSize:pointSize] ?: [UIFont boldSystemFontOfSize:pointSize];
+            return [[OEXStyles sharedStyles] semiBoldSansSerifOfSize:pointSize dynamicTypeSupported:self.dynamicTypeSupported] ?: [UIFont boldSystemFontOfSize:pointSize];
         case OEXTextWeightBold:
-            return [[OEXStyles sharedStyles] boldSansSerifOfSize:pointSize] ?: [UIFont boldSystemFontOfSize:pointSize];
+            return [[OEXStyles sharedStyles] boldSansSerifOfSize:pointSize dynamicTypeSupported:self.dynamicTypeSupported] ?: [UIFont boldSystemFontOfSize:pointSize];
     }
 }
 


### PR DESCRIPTION
### Description

[LEARNER-7192](https://openedx.atlassian.net/browse/LEARNER-7192)

Every element was adopting `Dynamic Text Support` even if there wasn't enough space to grow for larger text size and in the result, UI broke. In this PR I have added support in OEXTextStyle to disable `Dynamic Text Support` for an element or even developer can disable `Dynamic Text Support` for the whole app by changing just one variable `dynamicTypeSupported`. In the other way, a developer can only enable `Dynamic Text Support` for certain elements.

### Notes

### How to test this PR
