### PR TITLE
iOS - Implement deep linking for course announcement screen

### DIFF
--- a/Source/CourseDashboardViewController.swift
+++ b/Source/CourseDashboardViewController.swift
@@ -215,6 +215,10 @@ class CourseDashboardViewController: UITabBarController, UITabBarControllerDeleg
             let index = tabBarViewControllerIndex(with: CourseHandoutsViewController.self)
             selectedIndex = (index == 0) ? tabBarViewControllerIndex(with: AdditionalTabBarViewController.self) : index        
             break
+        case .courseAnnouncement:
+            let index = tabBarViewControllerIndex(with: CourseAnnouncementsViewController.self)
+            selectedIndex = (index == 0) ? tabBarViewControllerIndex(with: AdditionalTabBarViewController.self) : index
+            break
         default:
             selectedIndex = 0
             break

--- a/Source/Deep Linking/DeepLink.swift
+++ b/Source/Deep Linking/DeepLink.swift
@@ -14,6 +14,7 @@ enum DeepLinkType: String {
     case discussions = "course_discussion"
     case courseDates = "course_dates"
     case courseHandout = "course_handout"
+    case courseAnnouncement = "course_announcement"
     case discussionTopic = "discussion_topic"
     case discussionPost = "discussion_post"
     case courseDiscovery = "course_discovery"

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -350,6 +350,32 @@ typealias DismissCompletion = () -> Void
         }
     }
     
+    private func showCourseAnnouncement(with link: DeepLink) {
+        
+        var controllerAlreadyDisplayed: Bool {
+            if let topController = topMostViewController, let courseAnnouncementsViewController = topController as? CourseAnnouncementsViewController, courseAnnouncementsViewController.courseID == link.courseId {
+                return true
+            }
+            return false
+        }
+        
+        func showAnnouncement() {
+            if let topController = topMostViewController {
+                environment?.router?.showAnnouncment(from: topController, courseID: link.courseId ?? "")
+            }
+        }
+        
+        guard !controllerAlreadyDisplayed else { return }
+        
+        dismiss() { [weak self] in
+            if let topController = self?.topMostViewController {
+                self?.environment?.router?.showCourse(with: link, courseID: link.courseId ?? "", from: topController)
+            }
+            showAnnouncement()
+        }
+    }
+    
+    
     private func controllerAlreadyDisplayed(for type: DeepLinkType) -> Bool {
         guard let topViewController = topMostViewController else { return false }
         
@@ -407,7 +433,9 @@ typealias DismissCompletion = () -> Void
         case .courseHandout:
             showCourseHandout(with: link)
             break
-            
+        case .courseAnnouncement:
+            showCourseAnnouncement(with: link)
+            break
         default:
             break
         }

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -182,6 +182,11 @@ extension OEXRouter {
         }
     }
     
+    func showAnnouncment(from controller : UIViewController, courseID : String) {
+        let announcementViewController =  CourseAnnouncementsViewController(environment: environment, courseID: courseID)
+        controller.navigationController?.pushViewController(announcementViewController, animated: true)
+    }
+    
     private func popToRoot(controller: UIViewController) {
         controller.navigationController?.setToolbarHidden(true, animated: false)
         controller.navigationController?.popToRootViewController(animated: true)


### PR DESCRIPTION
### Description

[LEARNER-7198](https://openedx.atlassian.net/browse/LEARNER-7198)

In this PR, i implemented the deep linking for course announcement screen, now by clicking on the quick link the app will open up the course announcement screen on course dashboard screen.

Notes
How to test this PR
Add following links in notes, tap on the url will open the app and navigate to course announcement screen.

Course announcement Screen: https://edx.app.link/course_announcement