### PR TITLE
iOS - OEXVideoPlayerSettings Crash fix 

### DIFF
--- a/Source/CutomePlayer/OEXVideoPlayerSettings.swift
+++ b/Source/CutomePlayer/OEXVideoPlayerSettings.swift
@@ -62,9 +62,10 @@ class VideoPlayerSettings : NSObject {
                 var rows = [RowType]()
                 for lang: String in transcripts.keys {
                     let locale = NSLocale(localeIdentifier: lang)
-                    let displayLang: String = locale.displayName(forKey: NSLocale.Key.languageCode, value: lang)!
-                    let item: RowType = (title: displayLang, value: lang)
-                    rows.append(item)
+                    if let displayLang: String = locale.displayName(forKey: NSLocale.Key.languageCode, value: lang) {
+                        let item: RowType = (title: displayLang, value: lang)
+                        rows.append(item)
+                    }
                 }
     
                 let cc = OEXVideoPlayerSetting(title: "Closed Captions", rows: rows, isSelected: { (row) -> Bool in


### PR DESCRIPTION
### Description

[LEARNER-6495](https://openedx.atlassian.net/browse/LEARNER-6495)

The iOS app was producing the crash on video player setting. This PR fixed that crash.

Fabric: https://fabric.io/edx-inc/ios/apps/org.edx.mobile/issues/5afc992e11e9fa0aa5c7fc8e?time=last-ninety-days

