### PR TITLE
iOS - Implement deep linking for Degree or Degree Detail Screen

### DIFF
--- a/Source/Deep Linking/DeepLink.swift
+++ b/Source/Deep Linking/DeepLink.swift
@@ -20,6 +20,8 @@ enum DeepLinkType: String {
     case courseDiscovery = "course_discovery"
     case programDiscovery = "program_discovery"
     case programDiscoveryDetail = "program_discovery_detail"
+    case degreeDiscovery = "degree_discovery"
+    case degreeDiscoveryDetail = "degree_discovery_detail"
     case courseDetail = "course_detail"
     case program = "program"
     case programDetail = "program_detail"
@@ -53,6 +55,9 @@ class DeepLink: NSObject {
         }
         else if type == .program && pathID != nil {
             return .programDetail
+        }
+        else if type == .degreeDiscovery && pathID != nil {
+            return .degreeDiscoveryDetail
         }
         return type
     }

--- a/Source/DiscoveryViewController.swift
+++ b/Source/DiscoveryViewController.swift
@@ -195,6 +195,10 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
             let selectedIndex = index(for: SegmentOption.program.rawValue)
             segmentedControl.selectedSegmentIndex = selectedIndex
             controllerVisibility(with: selectedIndex)
+        case .degreeDiscovery, .degreeDiscoveryDetail:
+            let selectedIndex = index(for: SegmentOption.degree.rawValue)
+            segmentedControl.selectedSegmentIndex = selectedIndex
+            controllerVisibility(with: selectedIndex)
         default:
             break
         }

--- a/Source/EnrolledTabBarViewController.swift
+++ b/Source/EnrolledTabBarViewController.swift
@@ -188,7 +188,7 @@ class EnrolledTabBarViewController: UITabBarController, UITabBarControllerDelega
         switch type {
         case .program, .programDetail:
             selectedIndex = tabBarViewControllerIndex(with: ProgramsViewController.self)
-        case .courseDiscovery, .courseDetail, .programDiscovery, .programDiscoveryDetail:
+        case .courseDiscovery, .courseDetail, .programDiscovery, .programDiscoveryDetail, .degreeDiscovery, .degreeDiscoveryDetail:
             selectedIndex = tabBarViewControllerIndex(with: DiscoveryViewController.self)
         default:
             selectedIndex = 0

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -238,6 +238,9 @@ extension OEXRouter {
         else if type == .programDiscoveryDetail {
             showProgramDetail(from: controller, with: pathID, bottomBar: bottomBar)
         }
+        else if type == .degreeDiscoveryDetail {
+            showProgramDetail(from: controller, with: pathID, bottomBar: bottomBar, type: .degree)
+        }
     }
 
     func showDiscussionResponsesFromViewController(controller: UIViewController, courseID : String, thread : DiscussionThread, isDiscussionBlackedOut: Bool) {
@@ -406,8 +409,8 @@ extension OEXRouter {
         return nil
     }
     
-    func showProgramDetail(from controller: UIViewController, with pathId: String, bottomBar: UIView?) {
-        let programDetailViewController = ProgramsDiscoveryViewController(with: environment, pathId: pathId, bottomBar: bottomBar?.copy() as? UIView)
+    func showProgramDetail(from controller: UIViewController, with pathId: String, bottomBar: UIView?, type: ProgramDiscoveryScreen? = .program) {
+        let programDetailViewController = ProgramsDiscoveryViewController(with: environment, pathId: pathId, bottomBar: bottomBar?.copy() as? UIView, type: type)
         pushViewController(controller: programDetailViewController, fromController: controller)
     }
 

--- a/Source/ProgramsDiscoveryViewController.swift
+++ b/Source/ProgramsDiscoveryViewController.swift
@@ -9,6 +9,12 @@
 import UIKit
 import WebKit
 
+// This enum is use for Deep linking
+public enum ProgramDiscoveryScreen {
+    case program
+    case degree
+}
+
 class ProgramsDiscoveryViewController: UIViewController, InterfaceOrientationOverriding {
     
     typealias Environment = OEXConfigProvider & OEXSessionProvider & OEXStylesProvider & OEXRouterProvider & OEXAnalyticsProvider & OEXSessionProvider
@@ -22,12 +28,14 @@ class ProgramsDiscoveryViewController: UIViewController, InterfaceOrientationOve
     private var discoveryConfig: ProgramDiscovery? {
         return environment.config.discovery.program
     }
+    private(set) var viewType: ProgramDiscoveryScreen
     
     // MARK:- Initializer -
-    init(with environment: Environment, bottomBar: UIView?, searchQuery: String? = nil) {
+    init(with environment: Environment, bottomBar: UIView?, searchQuery: String? = nil, type: ProgramDiscoveryScreen? = .program) {
         self.environment = environment
         self.bottomBar = bottomBar
         self.searchQuery = searchQuery
+        self.viewType = type ?? .program
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -36,8 +44,8 @@ class ProgramsDiscoveryViewController: UIViewController, InterfaceOrientationOve
         self.showBottomBar = showBottomBar
     }
     
-    convenience init(with environment: Environment, pathId: String, bottomBar: UIView?) {
-        self.init(with: environment, bottomBar: bottomBar, searchQuery: nil)
+    convenience init(with environment: Environment, pathId: String, bottomBar: UIView?, type: ProgramDiscoveryScreen? = .program) {
+        self.init(with: environment, bottomBar: bottomBar, searchQuery: nil, type: type)
         self.pathId = pathId
     }
     

--- a/Source/ProgramsDiscoveryViewController.swift
+++ b/Source/ProgramsDiscoveryViewController.swift
@@ -80,6 +80,7 @@ class ProgramsDiscoveryViewController: UIViewController, InterfaceOrientationOve
     }
     
     func loadProgramDetails(with pathId: String) {
+        self.pathId = pathId
         addBackBarButton()
         if let detailTemplate = discoveryConfig?.webview.detailTemplate?.replacingOccurrences(of: URIString.pathPlaceHolder.rawValue, with: pathId),
             let url = URL(string: detailTemplate) {

--- a/Source/WebView/DiscoveryHelper.swift
+++ b/Source/WebView/DiscoveryHelper.swift
@@ -156,7 +156,10 @@ extension DiscoveryHelper {
             break
         case .programDetail:
             guard let pathId = programDetailPathId(from: url) else { return false }
-            environment.router?.showProgramDetail(from: controller, with: pathId, bottomBar: bottomBar)
+            
+            // Setting this view type for  Deep Linking
+            let type = (controller is DegreesViewController) ? ProgramDiscoveryScreen.degree: ProgramDiscoveryScreen.program
+            environment.router?.showProgramDetail(from: controller, with: pathId, bottomBar: bottomBar, type: type)
             break
         }
         return true


### PR DESCRIPTION
### Description

[LEARNER-7220](https://openedx.atlassian.net/browse/LEARNER-7220)

In this PR i implemented the deep linking for degree tab and degree details on discovery screen, now by clicking on the quick link the app will open up the degree tab or degree details on course discovery screen depending on provided pathID. 

### How to test this PR

Add following links in notes, tap on the url will open the app and navigate to degree tab on discovery screen.

Degrees Screen: https://edx.app.link/degree_discovery

Add following links in notes, tap on the url will open the app and navigate to degree detail page.

Degree Detail Screen: https://edx.app.link/degree_discovery_detail

