### PR TITLE
iOS - a11y- Fix Sign-in screen social login button accessibility issue

### DIFF
--- a/Source/OEXExternalAuthOptionsView.h
+++ b/Source/OEXExternalAuthOptionsView.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OEXExternalAuthOptionsView : UIView
 
-- (id)initWithFrame:(CGRect)frame providers:(NSArray<id<OEXExternalAuthProvider>>*)providers tapAction:(void(^)(id<OEXExternalAuthProvider>))tapAction;
+- (id)initWithFrame:(CGRect)frame providers:(NSArray<id<OEXExternalAuthProvider>>*)providers accessibilityLabel:(NSString*)accessibilityLabel  tapAction:(void(^)(id<OEXExternalAuthProvider>))tapAction;
 
 /// Vertical space between rows in cases where this needs to wrap
 /// to multiple rows

--- a/Source/OEXExternalAuthOptionsView.m
+++ b/Source/OEXExternalAuthOptionsView.m
@@ -27,7 +27,8 @@ static CGFloat OEXExternalAuthButtonAspectRatio = 3.4;
 
 @implementation OEXExternalAuthOptionsView
 
-- (id)initWithFrame:(CGRect)frame providers:(nonnull NSArray *)providers tapAction:(void(^)(id<OEXExternalAuthProvider>))tapAction {
+- (id)initWithFrame:(CGRect)frame providers:(nonnull NSArray *)providers accessibilityLabel:(NSString*)accessibilityLabel tapAction:(void(^)(id<OEXExternalAuthProvider>))tapAction {
+    
     self = [super initWithFrame:frame];
     if(self != nil) {
         
@@ -41,7 +42,7 @@ static CGFloat OEXExternalAuthButtonAspectRatio = 3.4;
             else if ([provider isKindOfClass:[OEXGoogleAuthProvider class]]) {
                 button.accessibilityIdentifier = @"ExternalAuthOptionsView:google-button";
             }
-            button.accessibilityLabel = [NSString stringWithFormat:@"%@ %@",[Strings registrationRegisterPrompt],button.titleLabel.text];
+            button.accessibilityLabel = [NSString stringWithFormat:@"%@ %@",accessibilityLabel,button.titleLabel.text];
             [button oex_addAction:^(id  _Nonnull control) {
                 tapAction(provider);
             } forEvents:UIControlEventTouchUpInside];

--- a/Source/OEXExternalRegistrationOptionsView.m
+++ b/Source/OEXExternalRegistrationOptionsView.m
@@ -37,7 +37,7 @@
         self.activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
         self.activityIndicator.hidden = YES;
         __weak __typeof(self) owner = self;
-        self.authOptionsView = [[OEXExternalAuthOptionsView alloc] initWithFrame:self.bounds providers:providers tapAction:^(id<OEXExternalAuthProvider> provider) {
+        self.authOptionsView = [[OEXExternalAuthOptionsView alloc] initWithFrame:self.bounds providers:providers accessibilityLabel:[Strings registrationRegisterPrompt] tapAction:^(id<OEXExternalAuthProvider> provider) {
             [owner choseProvider:provider];
         }];
         self.authOptionsView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;

--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -136,9 +136,8 @@
     if([self isFacebookEnabled]) {
         [providers addObject:[[OEXFacebookAuthProvider alloc] init]];
     }
-
     __weak __typeof(self) owner = self;
-    OEXExternalAuthOptionsView* externalAuthOptions = [[OEXExternalAuthOptionsView alloc] initWithFrame:self.externalAuthContainer.bounds providers:providers tapAction:^(id<OEXExternalAuthProvider> provider) {
+    OEXExternalAuthOptionsView* externalAuthOptions = [[OEXExternalAuthOptionsView alloc] initWithFrame:self.externalAuthContainer.bounds providers:providers accessibilityLabel:[Strings signInPrompt] tapAction:^(id<OEXExternalAuthProvider> provider) {
         [owner externalLoginWithProvider:provider];
     }];
     [self.externalAuthContainer addSubview:externalAuthOptions];

--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -147,6 +147,7 @@
 
     [self.lbl_OrSignIn setText:[Strings orSignInWith]];
     [self.lbl_OrSignIn setTextColor:[UIColor colorWithRed:60.0 / 255.0 green:64.0 / 255.0 blue:69.0 / 255.0 alpha:1.0]];
+    [self.lbl_OrSignIn setIsAccessibilityElement:false];
     
     if (self.environment.config.isRegistrationEnabled) {
         UIBarButtonItem *closeButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"ic_cancel"] style:UIBarButtonItemStylePlain target:self action:@selector(navigateBack)];

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -707,7 +707,7 @@
 "SIGN_IN_TEXT"="Sign In";
 /* Message shown while user waits for response to a sign in request */
 "SIGN_IN_BUTTON_TEXT_ON_SIGN_IN"="Signing In";
-/* Heading on sign-in screen allowing users to sign in using external services like Facebook and Google.*/
+/*  Accessibility text prefix for  Facebook and Google Buttons*/
 "SIGN_IN_PROMPT"="Sign in with";
 /*Sign up screen title and button initiating sign up process on the main screen */
 "REGISTER_TEXT"="Register";

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -707,6 +707,8 @@
 "SIGN_IN_TEXT"="Sign In";
 /* Message shown while user waits for response to a sign in request */
 "SIGN_IN_BUTTON_TEXT_ON_SIGN_IN"="Signing In";
+/* Heading on sign-in screen allowing users to sign in using external services like Facebook and Google.*/
+"SIGN_IN_PROMPT"="Sign in with";
 /*Sign up screen title and button initiating sign up process on the main screen */
 "REGISTER_TEXT"="Register";
 /* Indicates a date in the near future */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -707,7 +707,7 @@
 "SIGN_IN_TEXT"="Iniciar sesión";
 /* Message shown while user waits for response to a sign in request */
 "SIGN_IN_BUTTON_TEXT_ON_SIGN_IN"="Iniciando sesión";
-/* Heading on sign-in screen allowing users to sign in using external services like Facebook and Google.*/
+/* Accessibility text prefix for  Facebook and Google Buttons*/
 "SIGN_IN_PROMPT"="Sign in with";
 /*Sign up screen title and button initiating sign up process on the main screen */
 "REGISTER_TEXT"="Registrarse";

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -707,6 +707,8 @@
 "SIGN_IN_TEXT"="Iniciar sesión";
 /* Message shown while user waits for response to a sign in request */
 "SIGN_IN_BUTTON_TEXT_ON_SIGN_IN"="Iniciando sesión";
+/* Heading on sign-in screen allowing users to sign in using external services like Facebook and Google.*/
+"SIGN_IN_PROMPT"="Sign in with";
 /*Sign up screen title and button initiating sign up process on the main screen */
 "REGISTER_TEXT"="Registrarse";
 /* Indicates a date in the near future */


### PR DESCRIPTION
### Description

[LEARNER-5862](https://openedx.atlassian.net/browse/LEARNER-5862)

On sign in screen when user tap on 'Google' or 'Facebook' buttons, app was saying register with google and register with Facebook button now i fixed this issue and the accessibility label are saying 
sign-in with google and sign-in with Facebook.