### PR TITLE
Properly render html-like markup contained in video transcripts

### DIFF
--- a/Source/VideoTranscriptTableViewCell.swift
+++ b/Source/VideoTranscriptTableViewCell.swift
@@ -50,10 +50,10 @@ class VideoTranscriptTableViewCell: UITableViewCell {
     
     func setTranscriptText(text: String? , highlighted: Bool) {
         if !highlighted {
-            titleLabel.attributedText = standardTitleStyle.attributedString(withText: text)
+            titleLabel.attributedText = standardTitleStyle.markdownString(withText: text)
         }
         else{
-            titleLabel.attributedText = highlightedTitleStyle.attributedString(withText: text)
+            titleLabel.attributedText = highlightedTitleStyle.markdownString(withText: text)
         }
     }
 }


### PR DESCRIPTION
### Description

When playing a video which has a transcript that contains certain formatting tags in the attached SRT files, the tags are displayed verbatim in the app without the proper styling being applied (unlike the web site which displays them correctly). 

These tags are just basic style tags borrowed from HTML, see: https://en.wikipedia.org/wiki/SubRip#Formatting.

**Note:** this is a work-in-progress prototype to get the discussion out there. Please pardon any formatting errors or failed CI builds, I won't have a Mac handy until tomorrow...

[OSPR-3397](https://openedx.atlassian.net/browse/OSPR-3397)

### Proposed Change

Utilize the convenience that UIKit's `NSAttributedString` provides by initializing it with raw data, specifying a `DocumentType` of `.html`, and **get the basic bold / italic / etc styling for free**.

This was already being done in `OEXTextStyle` in `markdownStringWithText`, so I've used this.

cc @marcotuts @saeedbashir Please let me know your thoughts on which approach seems best aligned with edX for the product.

### Screenshots

Before:

![SRT-tags](https://user-images.githubusercontent.com/1342396/57374726-d9d51200-719b-11e9-824f-d3280c05db0f.png)

After:

![2019-06-24T17:25:3302:00](https://user-images.githubusercontent.com/1342396/60033305-9f222d00-96a8-11e9-8b2e-6d60b78a6bd7.png)


### How to test this PR

You will need to play a video that has a transcript file (.SRT) associated with it that contains HTML tags. 
There is an instance for testing available, which has a video block with modified transcript files on the course titled "edX Demonstration Course" at "Example Week 1: Getting Started Lesson 1 - Getting Started".

Edit the `private.yml` file and run the whitelabel script to point the client to this instance:

```
API_HOST_URL: 'https://ironwood-cloudera.opencraft.hosting'
--
OAUTH_CLIENT_ID: '4d84f9ff3cd75d8fdf43'
```


  
### Reviewers
- [ ] @pomegranited
- [ ] edX reviewer[s] TBD

