### PR TITLE
Course Video Indexing on the CourseID

### DIFF
--- a/Source/OEXCourse.h
+++ b/Source/OEXCourse.h
@@ -47,7 +47,6 @@ OEXStartType OEXStartTypeForString(NSString* type);
 @property (readonly, nonatomic, strong) OEXCourseStartDisplayInfo* start_display_info;
 @property (readonly, nonatomic, copy, nullable) NSString* name;
 @property (readonly, nonatomic, copy, nullable) NSString* org;
-@property (readonly, nonatomic, copy, nullable) NSString* video_outline;
 @property (readonly, nonatomic, copy, nullable) NSString* effort;
 @property (readonly, nonatomic, copy, nullable) NSString* course_id;
 @property (readonly, nonatomic, copy, nullable) NSString* root_block_usage_key;

--- a/Source/OEXCourse.m
+++ b/Source/OEXCourse.m
@@ -71,7 +71,6 @@ NSString* NSStringForOEXStartType(OEXStartType type) {
 @property (nonatomic, copy) NSString* course_image_url;
 @property (nonatomic, copy) NSString* name;
 @property (nonatomic, copy) NSString* org;
-@property (nonatomic, copy) NSString* video_outline;
 @property (nonatomic, copy) NSString* course_id;
 @property (nonatomic, copy) NSString* root_block_usage_key;
 @property (nonatomic, copy) NSString* subscription_id;
@@ -106,7 +105,6 @@ NSString* NSStringForOEXStartType(OEXStartType type) {
         self.course_image_url = [info objectForKey:@"course_image"];
         self.name = [info objectForKey:@"name"];
         self.org = [info objectForKey:@"org"];
-        self.video_outline = [info objectForKey:@"video_outline"];
         self.course_id = [info objectForKey:@"id"];
         self.root_block_usage_key = [info objectForKey:@"root_block_usage_key"];
         self.number = [info objectForKey:@"number"];

--- a/Source/OEXDBManager.m
+++ b/Source/OEXDBManager.m
@@ -591,10 +591,10 @@ static OEXDBManager* _sharedManager = nil;
     
     for(VideoData* data in allVideos) {
         if(data &&
-           [data isEqual:[NSNull null]] &&
+           ![data isEqual:[NSNull null]] &&
            [data isKindOfClass:[VideoData class]] &&
            data.download_state &&
-           [data.download_state isEqual:[NSNull null]] &&
+           ![data.download_state isEqual:[NSNull null]] &&
            [data.download_state isKindOfClass:[NSNumber class]] &&
            ([data.download_state intValue] == state)) {
             [filteredArray addObject:data];

--- a/Source/OEXDownloadManager.m
+++ b/Source/OEXDownloadManager.m
@@ -137,6 +137,7 @@ static NSURLSession* videosBackgroundSession = nil;
             NSURLSessionDownloadTask* downloadTask = [downloadTasks objectAtIndex:taskIndex];
             video.download_state = [NSNumber numberWithInt:OEXDownloadStatePartial];
             video.dm_id = [NSNumber numberWithUnsignedInteger:downloadTask.taskIdentifier];
+            [self startBackgroundDownloadForVideo:video];
             [self.storage saveCurrentStateToDB];
             completionHandler(downloadTask);
         }

--- a/Source/OEXInterface+Swift.swift
+++ b/Source/OEXInterface+Swift.swift
@@ -27,8 +27,8 @@ extension OEXInterface : LastAccessedProvider {
         // how we decide their order in the UI.
         // But once we switch to the new course structure endpoint, that will no longer be the case
         guard let courseVideos = courseVideos,
-            let videoOutline = course.video_outline,
-            let videos = courseVideos.object(forKey: videoOutline) as? [OEXHelperVideoDownload] else {
+            let courseID = course.course_id,
+            let videos = courseVideos.object(forKey: courseID) as? [OEXHelperVideoDownload] else {
             return []
         }
         

--- a/Source/OEXInterface.h
+++ b/Source/OEXInterface.h
@@ -49,8 +49,6 @@ typedef void (^ DownloadVideosCompletionHandler)(BOOL cancelled);
 
 @property (nonatomic, weak, nullable) id <OEXStorageInterface>  storage;
 
-// [String(Course.video_outline) : OEXHelperVideoDownload]
-// TODO: Make this indexed by courseID instead of course.video_outline
 @property (nullable, nonatomic, strong, readonly) NSMutableDictionary* courseVideos;
 
 //Reachability

--- a/Source/OEXInterface.m
+++ b/Source/OEXInterface.m
@@ -413,7 +413,7 @@ static OEXInterface* _sharedInterface = nil;
     NSMutableDictionary* videos = [[NSMutableDictionary alloc] init];
     OEXCourse* course = [self courseWithID:courseID];
     
-    for(OEXHelperVideoDownload* video in [self.courseVideos objectForKey:course.video_outline]) {
+    for(OEXHelperVideoDownload* video in [self.courseVideos objectForKey:course.course_id]) {
         [videos setSafeObject:video forKey:video.summary.videoID];
     }
     return [videoIDs oex_map:^id(NSString* videoID) {
@@ -764,14 +764,14 @@ static OEXInterface* _sharedInterface = nil;
 
 - (void)addVideos:(NSArray*)videos forCourseWithID:(NSString*)courseID {
     OEXCourse* course = [self courseWithID:courseID];
-    NSMutableArray* videoDatas = [[_courseVideos objectForKey:course.video_outline] mutableCopy];
+    NSMutableArray* videoDatas = [[_courseVideos objectForKey:course.course_id] mutableCopy];
     NSMutableSet* knownVideoIDs = [[NSMutableSet alloc] init];
     NSMutableDictionary* videosMap = [[NSMutableDictionary alloc] init];
     if(videoDatas == nil) {
         // we don't have any videos for this course yet
         // so set it up
         videoDatas = [[NSMutableArray alloc] init];
-        [self.courseVideos setSafeObject:videoDatas forKey:course.video_outline];
+        [self.courseVideos setSafeObject:videoDatas forKey:course.course_id];
     }
     else {
         // we do have videos, so collect their IDs so we only add new ones
@@ -804,7 +804,7 @@ static OEXInterface* _sharedInterface = nil;
         }
     }];
     
-    [self.courseVideos setSafeObject:videoDatas forKey:course.video_outline];
+    [self.courseVideos setSafeObject:videoDatas forKey:course.course_id];
     
     [self makeRecordsForVideos:videoHelpers inCourse:course];
 }
@@ -817,7 +817,7 @@ static OEXInterface* _sharedInterface = nil;
         //Videos array
         NSMutableArray* videosArray = [[NSMutableArray alloc] init];
 
-        for(OEXHelperVideoDownload* video in [_courseVideos objectForKey : course.video_outline]) {
+        for(OEXHelperVideoDownload* video in [_courseVideos objectForKey : course.course_id]) {
             //Complete
             if(video.downloadState == OEXDownloadStateComplete && state == OEXDownloadStateComplete) {
                 [videosArray addObject:video];
@@ -846,7 +846,7 @@ static OEXInterface* _sharedInterface = nil;
     for(UserCourseEnrollment* courseEnrollment in _courses) {
         OEXCourse* course = courseEnrollment.course;
 
-        for(OEXHelperVideoDownload* video in [_courseVideos objectForKey : course.video_outline]) {
+        for(OEXHelperVideoDownload* video in [_courseVideos objectForKey : course.course_id]) {
             [mainArray addObject:video];
         }
     }
@@ -860,7 +860,7 @@ static OEXInterface* _sharedInterface = nil;
     for(UserCourseEnrollment* courseEnrollment in _courses) {
         OEXCourse* course = courseEnrollment.course;
 
-        for(OEXHelperVideoDownload* video in [_courseVideos objectForKey : course.video_outline]) {
+        for(OEXHelperVideoDownload* video in [_courseVideos objectForKey : course.course_id]) {
             //Complete
             if((video.downloadProgress == OEXMaxDownloadProgress) && (state == OEXDownloadStateComplete)) {
                 [mainArray addObject:video];
@@ -982,7 +982,7 @@ static OEXInterface* _sharedInterface = nil;
     // how we decide their order in the UI.
     // But once we switch to the new course structure endpoint, that will no longer be the case
     OEXCourse* course = [self courseWithID:courseID];
-    for(OEXHelperVideoDownload* video in [self.courseVideos objectForKey:course.video_outline]) {
+    for(OEXHelperVideoDownload* video in [self.courseVideos objectForKey:course.course_id]) {
         if([video.summary.videoID isEqual:videoID]) {
             return video;
         }

--- a/Source/OEXInterface.m
+++ b/Source/OEXInterface.m
@@ -729,7 +729,6 @@ static OEXInterface* _sharedInterface = nil;
         OEXDownloadState downloadState = [data.download_state intValue];
         
         video.course_id = course.course_id;
-        video.course_url = course.video_outline;
         
         if(!data) {
             downloadState = OEXDownloadStateNew;

--- a/Test/CourseContentPageViewControllerTests.swift
+++ b/Test/CourseContentPageViewControllerTests.swift
@@ -24,7 +24,7 @@ class CourseContentPageViewControllerTests: SnapshotTestCase {
         outline = CourseOutlineTestDataFactory.freshCourseOutline(course.course_id!)
         let interface = OEXInterface.shared()
         interface.t_setCourseEnrollments([UserCourseEnrollment(course: course)])
-        interface.t_setCourseVideos([course.video_outline!: OEXVideoSummaryTestDataFactory.localCourseVideos(CourseOutlineTestDataFactory.knownLocalVideoID)])
+        interface.t_setCourseVideos([course.course_id!: OEXVideoSummaryTestDataFactory.localCourseVideos(CourseOutlineTestDataFactory.knownLocalVideoID)])
         environment = TestRouterEnvironment(config: OEXConfig(dictionary:["TAB_LAYOUTS_ENABLED": true]), interface: interface)
         environment.mockCourseDataManager.querier = CourseOutlineQuerier(courseID: course.course_id!, interface: interface, outline: outline)
         router = OEXRouter(environment: environment)

--- a/Test/CourseDashboardViewControllerTests.swift
+++ b/Test/CourseDashboardViewControllerTests.swift
@@ -99,7 +99,7 @@ class CourseDashboardViewControllerTests: SnapshotTestCase {
         let environment = TestRouterEnvironment(config: config, interface: interface)
         environment.mockCourseDataManager.querier = CourseOutlineQuerier(courseID: outline.root, interface: interface, outline: outline)
         environment.interface?.t_setCourseEnrollments([UserCourseEnrollment(course: course)])
-        environment.interface?.t_setCourseVideos([course.video_outline!: OEXVideoSummaryTestDataFactory.localCourseVideos(CourseOutlineTestDataFactory.knownLocalVideoID)])
+        environment.interface?.t_setCourseVideos([course.course_id!: OEXVideoSummaryTestDataFactory.localCourseVideos(CourseOutlineTestDataFactory.knownLocalVideoID)])
         environment.mockEnrollmentManager.courses = [course]
         environment.logInTestUser()
         
@@ -129,7 +129,7 @@ class CourseDashboardViewControllerTests: SnapshotTestCase {
         let interface = OEXInterface.shared()
         let enrollment = UserCourseEnrollment(dictionary: ["certificate":["url":"test"], "course" : courseData])!
         
-        interface.t_setCourseVideos([course.video_outline!: OEXVideoSummaryTestDataFactory.localCourseVideos(CourseOutlineTestDataFactory.knownLocalVideoID)])
+        interface.t_setCourseVideos([course.course_id!: OEXVideoSummaryTestDataFactory.localCourseVideos(CourseOutlineTestDataFactory.knownLocalVideoID)])
         
         let environment = TestRouterEnvironment(config: config, interface: interface).logInTestUser()
         environment.mockCourseDataManager.querier = CourseOutlineQuerier(courseID: outline.root, interface: interface, outline: outline)

--- a/Test/CourseOutlineHeaderViewTests.swift
+++ b/Test/CourseOutlineHeaderViewTests.swift
@@ -25,7 +25,7 @@ class CourseOutlineHeaderViewTests : SnapshotTestCase {
     func testCourseVideosHeaderView() {
         let course = OEXCourse.accessibleTestCourse()
         let interface = OEXInterface.shared()
-        interface.t_setCourseVideos([course.video_outline!: OEXVideoSummaryTestDataFactory.localCourseVideos(CourseOutlineTestDataFactory.knownLocalVideoID)])
+        interface.t_setCourseVideos([course.course_id!: OEXVideoSummaryTestDataFactory.localCourseVideos(CourseOutlineTestDataFactory.knownLocalVideoID)])
         let mockEnv = TestRouterEnvironment(config: OEXConfig(dictionary: [:]), interface: interface)
         let courseVideosHeaderView = CourseVideosHeaderView(with: course, environment: mockEnv, videos: interface.downloadableVideos(of: course), blockID: nil)
         courseVideosHeaderView.bounds = CGRect(x: 0, y: 0, width: screenSize.width, height: CourseVideosHeaderView.height)

--- a/Test/CourseOutlineViewControllerTests.swift
+++ b/Test/CourseOutlineViewControllerTests.swift
@@ -27,7 +27,7 @@ class CourseOutlineViewControllerTests: SnapshotTestCase {
         environment = TestRouterEnvironment(config: config, interface: interface)
         environment.mockCourseDataManager.querier = CourseOutlineQuerier(courseID: outline.root, interface: interface, outline: outline)
         environment.interface?.t_setCourseEnrollments([UserCourseEnrollment(course: course)])
-        environment.interface?.t_setCourseVideos([course.video_outline!: OEXVideoSummaryTestDataFactory.localCourseVideos(CourseOutlineTestDataFactory.knownLocalVideoID)])
+        environment.interface?.t_setCourseVideos([course.course_id!: OEXVideoSummaryTestDataFactory.localCourseVideos(CourseOutlineTestDataFactory.knownLocalVideoID)])
         router = OEXRouter(environment: environment)
     }
     

--- a/Test/CourseSectionTableViewCellTests.swift
+++ b/Test/CourseSectionTableViewCellTests.swift
@@ -27,7 +27,7 @@ class CourseSectionTableViewCellTests: SnapshotTestCase {
         environment = TestRouterEnvironment(config: config, interface: interface)
         environment.mockCourseDataManager.querier = CourseOutlineQuerier(courseID: outline.root, interface: interface, outline: outline)
         environment.interface?.t_setCourseEnrollments([UserCourseEnrollment(course: course)])
-        environment.interface?.t_setCourseVideos([course.video_outline!: OEXVideoSummaryTestDataFactory.localCourseVideos(CourseOutlineTestDataFactory.knownLocalVideoID)])
+        environment.interface?.t_setCourseVideos([course.course_id!: OEXVideoSummaryTestDataFactory.localCourseVideos(CourseOutlineTestDataFactory.knownLocalVideoID)])
         router = OEXRouter(environment: environment)
     }
     

--- a/Test/OEXCourse+TestData.swift
+++ b/Test/OEXCourse+TestData.swift
@@ -32,8 +32,7 @@ public extension OEXCourse {
             "name" : "A Great Course",
             "course_image" : imagePath!.absoluteString ,
             "org" : "edX",
-            "courseware_access" : ["has_access" : accessible],
-            "video_outline": "https://www.example.com/video_outlines/testcourse"
+            "courseware_access" : ["has_access" : accessible]
         ]
         if let overview = overview {
             courseDictionary["overview"] = overview as AnyObject

--- a/Test/VideoPlayerTests.swift
+++ b/Test/VideoPlayerTests.swift
@@ -25,7 +25,7 @@ class VideoPlayerTests: XCTestCase {
         environment = TestRouterEnvironment(config: config, interface: interface)
         environment.mockCourseDataManager.querier = CourseOutlineQuerier(courseID: outline.root, interface: interface, outline: outline)
         environment.interface?.t_setCourseEnrollments([UserCourseEnrollment(course: course)])
-        environment.interface?.t_setCourseVideos([course.video_outline!: OEXVideoSummaryTestDataFactory.localCourseVideoWithoutEncodings(CourseOutlineTestDataFactory.knownLocalVideoID)])
+        environment.interface?.t_setCourseVideos([course.course_id!: OEXVideoSummaryTestDataFactory.localCourseVideoWithoutEncodings(CourseOutlineTestDataFactory.knownLocalVideoID)])
     }
 
     func loadVideoPlayer(_ completion: ( (_ videoPlayer : VideoPlayer) -> Void)? = nil) {


### PR DESCRIPTION


### Description

[LEARNER-7311](https://openedx.atlassian.net/browse/LEARNER-7311)

In OEXInterface courseVideos indexing was based on course_outline but a TODO was there to update the courseVideos indexing on course_id.
If a course video was downloading and user kills the app then on restarting the app, downloading on the underlying video restarted but downloading struck on 1-5% and never completed.
This PR address the video restart issue as well.

### How to test this PR
- [x] Go to any course and download video. The download should start and complete.
- [x] Go to the download videos view while videos are downloading. Download view should only show videos that are being downloaded.
- [x] Start download loading a video. Kill the app. Restart app, on restart video download, should start again.