### PR TITLE
iOS - Video player analytics are not working

### DIFF
--- a/Source/CourseOutline.swift
+++ b/Source/CourseOutline.swift
@@ -84,7 +84,7 @@ public struct CourseOutline {
                         type = .Problem
                     case CourseBlock.Category.Video :
                         let bodyData = (body[Fields.StudentViewData].object as? NSDictionary).map { [Fields.Summary.rawValue : $0 ] }
-                        let summary = OEXVideoSummary(dictionary: bodyData ?? [:], videoID: blockID, unitURL: blockURL?.absoluteString ?? "", name : name ?? Strings.untitled)
+                        let summary = OEXVideoSummary(dictionary: bodyData ?? [:], videoID: blockID, unitURL: blockURL?.absoluteString, name : name ?? Strings.untitled)
                         type = .Video(summary)
                     case CourseBlock.Category.Discussion:
                         // Inline discussion is in progress feature. Will remove this code when it's ready to ship

--- a/Source/CourseOutline.swift
+++ b/Source/CourseOutline.swift
@@ -84,7 +84,7 @@ public struct CourseOutline {
                         type = .Problem
                     case CourseBlock.Category.Video :
                         let bodyData = (body[Fields.StudentViewData].object as? NSDictionary).map { [Fields.Summary.rawValue : $0 ] }
-                        let summary = OEXVideoSummary(dictionary: bodyData ?? [:], videoID: blockID, blockURL: blockURL?.absoluteString ?? "", name : name ?? Strings.untitled)
+                        let summary = OEXVideoSummary(dictionary: bodyData ?? [:], videoID: blockID, unitURL: blockURL?.absoluteString ?? "", name : name ?? Strings.untitled)
                         type = .Video(summary)
                     case CourseBlock.Category.Discussion:
                         // Inline discussion is in progress feature. Will remove this code when it's ready to ship

--- a/Source/CourseOutline.swift
+++ b/Source/CourseOutline.swift
@@ -84,7 +84,7 @@ public struct CourseOutline {
                         type = .Problem
                     case CourseBlock.Category.Video :
                         let bodyData = (body[Fields.StudentViewData].object as? NSDictionary).map { [Fields.Summary.rawValue : $0 ] }
-                        let summary = OEXVideoSummary(dictionary: bodyData ?? [:], videoID: blockID, name : name ?? Strings.untitled)
+                        let summary = OEXVideoSummary(dictionary: bodyData ?? [:], videoID: blockID, blockURL: blockURL?.absoluteString ?? "", name : name ?? Strings.untitled)
                         type = .Video(summary)
                     case CourseBlock.Category.Discussion:
                         // Inline discussion is in progress feature. Will remove this code when it's ready to ship

--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -552,7 +552,7 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         setVideoSpeed(speed: speed)
         
         if let videoId = video?.summary?.videoID, let courseId = video?.course_id, let unitUrl = video?.summary?.unitURL {
-            environment.analytics.trackVideoSpeed(videoId, currentTime: currentTime, courseID: courseId, unitURL: unitUrl, oldSpeed: String(format: "%.1f", oldSpeed), newSpeed: String.init(format: "%.1f", rate))
+            environment.analytics.trackVideoSpeed(videoId, currentTime: currentTime, courseID: courseId, unitURL: unitUrl, oldSpeed: String(format: "%.1f", oldSpeed), newSpeed: String(format: "%.1f", OEXInterface.getOEXVideoSpeed(speed)))
         }
     }
     

--- a/Source/OEXAppDelegate.m
+++ b/Source/OEXAppDelegate.m
@@ -223,7 +223,7 @@
     //Initialize Fabric
     OEXFabricConfig* fabric = [config fabricConfig];
     if(fabric.appKey && fabric.isEnabled) {
-        [Fabric with:@[CrashlyticsKit]];
+        //[Fabric with:@[CrashlyticsKit]];
     }
 }
 

--- a/Source/OEXAppDelegate.m
+++ b/Source/OEXAppDelegate.m
@@ -223,7 +223,7 @@
     //Initialize Fabric
     OEXFabricConfig* fabric = [config fabricConfig];
     if(fabric.appKey && fabric.isEnabled) {
-        //[Fabric with:@[CrashlyticsKit]];
+        [Fabric with:@[CrashlyticsKit]];
     }
 }
 

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)initWithDictionary:(NSDictionary*)dictionary;
 // TODO: Factor the video code to get this from the block instead of the video summary
-- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID name:(NSString*)name;
+- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID blockURL:(NSString*)blockURL name:(NSString*)name;
 
 /// Generate a simple stub video summary. Used only for testing
 - (id)initWithVideoID:(NSString*)videoID name:(NSString*)name encodings:(NSDictionary<NSString*, OEXVideoEncoding *> *)encodings;

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)initWithDictionary:(NSDictionary*)dictionary;
 // TODO: Factor the video code to get this from the block instead of the video summary
-- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID blockURL:(NSString*)blockURL name:(NSString*)name;
+- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID unitURL:(NSString*)unitURL name:(NSString*)name;
 
 /// Generate a simple stub video summary. Used only for testing
 - (id)initWithVideoID:(NSString*)videoID name:(NSString*)name encodings:(NSDictionary<NSString*, OEXVideoEncoding *> *)encodings;

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)initWithDictionary:(NSDictionary*)dictionary;
 // TODO: Factor the video code to get this from the block instead of the video summary
-- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID unitURL:(NSString*)unitURL name:(NSString*)name;
+- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID unitURL:(nullable NSString*)unitURL name:(NSString*)name;
 
 /// Generate a simple stub video summary. Used only for testing
 - (id)initWithVideoID:(NSString*)videoID name:(NSString*)name encodings:(NSDictionary<NSString*, OEXVideoEncoding *> *)encodings;

--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -84,7 +84,7 @@
     return self;
 }
 
-- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID unitURL:(NSString*)unitURL name:(NSString*)name {
+- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID unitURL:(nullable NSString*)unitURL name:(NSString*)name {
     self = [self initWithDictionary:dictionary];
     if(self != nil) {
         self.videoID = videoID;

--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -43,8 +43,6 @@
             self.sectionURL = [dictionary objectForKey:@"section_url"];
         }
         
-        self.unitURL = [dictionary objectForKey:@"unit_url"];
-        
         NSDictionary* summary = [dictionary objectForKey:@"summary"];
         
         // Data from inside summary dictionary
@@ -86,11 +84,12 @@
     return self;
 }
 
-- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID name:(NSString*)name {
+- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID blockURL:(NSString*)blockURL name:(NSString*)name {
     self = [self initWithDictionary:dictionary];
     if(self != nil) {
         self.videoID = videoID;
         self.name = name;
+        self.unitURL = blockURL;
     }
     return self;
 }

--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -84,12 +84,12 @@
     return self;
 }
 
-- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID blockURL:(NSString*)blockURL name:(NSString*)name {
+- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID unitURL:(NSString*)unitURL name:(NSString*)name {
     self = [self initWithDictionary:dictionary];
     if(self != nil) {
         self.videoID = videoID;
         self.name = name;
-        self.unitURL = blockURL;
+        self.unitURL = unitURL;
     }
     return self;
 }

--- a/Test/OEXVideoSummaryTests.m
+++ b/Test/OEXVideoSummaryTests.m
@@ -112,11 +112,10 @@
                                    @"duration" : duration,
                                    @"id" : videoID,
                                    @"size" : size,
-                                   },
-                           @"unit_url" : unitURL
+                                   }
                            };
     
-    OEXVideoSummary* summary = [[OEXVideoSummary alloc] initWithDictionary:info];
+    OEXVideoSummary* summary = [[OEXVideoSummary alloc] initWithDictionary:info videoID:videoID unitURL:unitURL name:name];
     
     XCTAssertEqualObjects(summary.sectionURL, sectionURL);
     XCTAssertEqualObjects(summary.category, category);


### PR DESCRIPTION
### Description

[LEARNER-7304](https://openedx.atlassian.net/browse/LEARNER-7304)

Video player analytics(Speed change, Seek) was not working, In PR i have fixed the analytics now its working.

### How to test this PR
- Run Video
- Open Speed Change setting menu and change speed/ Seek the video by moving progress slider forward or backward.
- [ ] Video player Analytic events should appear on [Segment Console](https://app.segment.com/edx/sources).
