### PR TITLE
Fix Update Profile Crash

### DIFF
--- a/Source/CourseOutline.swift
+++ b/Source/CourseOutline.swift
@@ -84,7 +84,7 @@ public struct CourseOutline {
                         type = .Problem
                     case CourseBlock.Category.Video :
                         let bodyData = (body[Fields.StudentViewData].object as? NSDictionary).map { [Fields.Summary.rawValue : $0 ] }
-                        let summary = OEXVideoSummary(dictionary: bodyData ?? [:], videoID: blockID, unitURL: blockURL?.absoluteString, name : name ?? Strings.untitled)
+                        let summary = OEXVideoSummary(dictionary: bodyData ?? [:], videoID: blockID, unitURL: blockURL?.absoluteString ?? "", name : name ?? Strings.untitled)
                         type = .Video(summary)
                     case CourseBlock.Category.Discussion:
                         // Inline discussion is in progress feature. Will remove this code when it's ready to ship

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)initWithDictionary:(NSDictionary*)dictionary;
 // TODO: Factor the video code to get this from the block instead of the video summary
-- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID unitURL:(nullable NSString*)unitURL name:(NSString*)name;
+- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID unitURL:(NSString*)unitURL name:(NSString*)name;
 
 /// Generate a simple stub video summary. Used only for testing
 - (id)initWithVideoID:(NSString*)videoID name:(NSString*)name encodings:(NSDictionary<NSString*, OEXVideoEncoding *> *)encodings;

--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -84,7 +84,7 @@
     return self;
 }
 
-- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID unitURL:(nullable NSString*)unitURL name:(NSString*)name {
+- (id)initWithDictionary:(NSDictionary*)dictionary videoID:(NSString*)videoID unitURL:(NSString*)unitURL name:(NSString*)name {
     self = [self initWithDictionary:dictionary];
     if(self != nil) {
         self.videoID = videoID;

--- a/Source/ProfileAPI.swift
+++ b/Source/ProfileAPI.swift
@@ -43,10 +43,12 @@ public class ProfileAPI: NSObject {
         return networkManager.streamForRequest(request)
     }
 
-    class func profileUpdateRequest(profile: UserProfile) -> NetworkRequest<UserProfile> {
+    class func profileUpdateRequest(profile: UserProfile) -> NetworkRequest<UserProfile>? {
+        guard let userName = profile.username else { return nil }
+
         let json = JSON(profile.updateDictionary as AnyObject)
         let request = NetworkRequest(method: HTTPMethod.PATCH,
-            path: path(username: profile.username!),
+            path: path(username: userName),
             requiresAuth: true,
             body: RequestBody.jsonBody(json),
             headers: ["Content-Type": "application/merge-patch+json"], //should push this to a lower level once all our PATCHs support this content-type

--- a/Source/UserProfileManager.swift
+++ b/Source/UserProfileManager.swift
@@ -61,10 +61,11 @@ open class UserProfileManager : NSObject {
     }
     
     public func updateCurrentUserProfile(profile : UserProfile, handler : @escaping (Result<UserProfile>) -> Void) {
-        let request = ProfileAPI.profileUpdateRequest(profile: profile)
-        self.networkManager.taskForRequest(request) { result -> Void in
+        guard let request = ProfileAPI.profileUpdateRequest(profile: profile) else { return }
+
+        networkManager.taskForRequest(request) { [weak self] result -> Void in
             if let data = result.data {
-                self.currentUserUpdateStream.send(Success(v: data))
+                self?.currentUserUpdateStream.send(Success(v: data))
             }
             handler(result.data.toResult(result.error!))
         }


### PR DESCRIPTION
### Description

[LEARNER-7269](https://openedx.atlassian.net/browse/LEARNER-7269)

Sometimes the app was crashing while updating the profile. Although the crash is not reproducible, there was a place where username for unwrapped forcefully. It might be the reason for the crash.

### Notes
As the crash is not reproducible so I can't say the underline change will fix the crash. We have to wait for v2.20 to see either the crash got fixed or not.

### How to test this PR
- [ ] Profile update should work in all cases.
