### PR TITLE
Fix Update Profile Crash

### DIFF
--- a/Source/ProfileAPI.swift
+++ b/Source/ProfileAPI.swift
@@ -43,10 +43,12 @@ public class ProfileAPI: NSObject {
         return networkManager.streamForRequest(request)
     }
 
-    class func profileUpdateRequest(profile: UserProfile) -> NetworkRequest<UserProfile> {
+    class func profileUpdateRequest(profile: UserProfile) -> NetworkRequest<UserProfile>? {
+        guard let userName = profile.username else { return nil }
+
         let json = JSON(profile.updateDictionary as AnyObject)
         let request = NetworkRequest(method: HTTPMethod.PATCH,
-            path: path(username: profile.username!),
+            path: path(username: userName),
             requiresAuth: true,
             body: RequestBody.jsonBody(json),
             headers: ["Content-Type": "application/merge-patch+json"], //should push this to a lower level once all our PATCHs support this content-type

--- a/Source/UserProfileManager.swift
+++ b/Source/UserProfileManager.swift
@@ -61,7 +61,10 @@ open class UserProfileManager : NSObject {
     }
     
     public func updateCurrentUserProfile(profile : UserProfile, handler : @escaping (Result<UserProfile>) -> Void) {
-        guard let request = ProfileAPI.profileUpdateRequest(profile: profile) else { return }
+        guard let request = ProfileAPI.profileUpdateRequest(profile: profile) else {
+            handler(Result.failure(NSError.oex_unknownNetworkError()))
+            return
+        }
 
         networkManager.taskForRequest(request) { [weak self] result -> Void in
             if let data = result.data {

--- a/Source/UserProfileManager.swift
+++ b/Source/UserProfileManager.swift
@@ -61,10 +61,11 @@ open class UserProfileManager : NSObject {
     }
     
     public func updateCurrentUserProfile(profile : UserProfile, handler : @escaping (Result<UserProfile>) -> Void) {
-        let request = ProfileAPI.profileUpdateRequest(profile: profile)
-        self.networkManager.taskForRequest(request) { result -> Void in
+        guard let request = ProfileAPI.profileUpdateRequest(profile: profile) else { return }
+
+        networkManager.taskForRequest(request) { [weak self] result -> Void in
             if let data = result.data {
-                self.currentUserUpdateStream.send(Success(v: data))
+                self?.currentUserUpdateStream.send(Success(v: data))
             }
             handler(result.data.toResult(result.error!))
         }


### PR DESCRIPTION
### Description

[LEARNER-7269](https://openedx.atlassian.net/browse/LEARNER-7269)

Sometimes the app was crashing while updating the profile. Although the crash is not reproducible, there was a place where username for unwrapped forcefully. It might be the reason for the crash.

### Notes
As the crash is not reproducible so I can't say the underline change will fix the crash. We have to wait for v2.20 to see either the crash got fixed or not.

### How to test this PR
- [x] Profile update should work in all cases.
