### PR TITLE
Implement feature flag parity for Segment-Firebase implementation

### DIFF
--- a/Source/FirebaseConfig.swift
+++ b/Source/FirebaseConfig.swift
@@ -11,11 +11,18 @@ import Foundation
 fileprivate enum FirebaseKeys: String, RawStringExtractable {
     case enabled = "ENABLED"
     case analyticsEnabled = "ANALYTICS_ENABLED"
+    case analyticsSource = "ANALYTICS_SOURCE"
     case cloudMessagingEnabled = "CLOUD_MESSAGING_ENABLED"
     case apiKey = "API_KEY"
     case clientID = "CLIENT_ID"
     case googleAppID = "GOOGLE_APP_ID"
     case gcmSenderID = "GCM_SENDER_ID"
+}
+
+enum AnalyticsSource: String {
+    case firebase = "firebase"
+    case segment = "segment"
+    case none = "none"
 }
 
 class FirebaseConfig: NSObject {
@@ -26,6 +33,7 @@ class FirebaseConfig: NSObject {
     @objc let cliendID: String?
     @objc let googleAppID: String?
     @objc let gcmSenderID: String?
+    let analyticsSource: AnalyticsSource
     
     @objc var requiredKeysAvailable: Bool {
         return (apiKey != nil && cliendID != nil && googleAppID != nil && gcmSenderID != nil)
@@ -36,12 +44,22 @@ class FirebaseConfig: NSObject {
         cliendID = dictionary[FirebaseKeys.clientID] as? String
         googleAppID = dictionary[FirebaseKeys.googleAppID] as? String
         gcmSenderID = dictionary[FirebaseKeys.gcmSenderID] as? String
+        let analyticsSource = dictionary[FirebaseKeys.analyticsSource] as? String
+        self.analyticsSource = AnalyticsSource(rawValue: analyticsSource ?? AnalyticsSource.none.rawValue) ?? AnalyticsSource.none
         super.init()
         enabled =  requiredKeysAvailable && (dictionary[FirebaseKeys.enabled] as? Bool == true)
         let analyticsEnabled = dictionary[FirebaseKeys.analyticsEnabled] as? Bool ?? false
         let cloudMessagingEnabled = dictionary[FirebaseKeys.cloudMessagingEnabled] as? Bool ?? false
         self.analyticsEnabled = enabled && analyticsEnabled
         self.cloudMessagingEnabled = enabled && cloudMessagingEnabled
+    }
+
+    @objc var isAnalyticsSourceSegment: Bool {
+        return analyticsSource == AnalyticsSource.segment
+    }
+
+    @objc var isAnalyticsSourceFirebase: Bool {
+        return analyticsSource == AnalyticsSource.firebase
     }
 }
 

--- a/Source/OEXAppDelegate.m
+++ b/Source/OEXAppDelegate.m
@@ -198,7 +198,7 @@
         //Segment to Google Analytics integration
         [configuration use:[SEGGoogleAnalyticsIntegrationFactory instance]];
         
-        if (config.firebaseConfig.requiredKeysAvailable) {
+        if (config.firebaseConfig.requiredKeysAvailable && config.firebaseConfig.isAnalyticsSourceSegment) {
             //Segment to Google Firebase integration
             [configuration use:[SEGFirebaseIntegrationFactory instance]];
         }
@@ -208,7 +208,7 @@
     //Initialize Firebase
     // Make Sure the google app id is valid before configuring firebase, the app can produce crash.
     //Firebase do not get exception with invalid google app ID, https://github.com/firebase/firebase-ios-sdk/issues/1581
-    if (config.firebaseConfig.enabled && !segmentIO.isEnabled) {
+    if (config.firebaseConfig.enabled && !config.firebaseConfig.isAnalyticsSourceSegment) {
         [FIRApp configure];
         [FIRAnalytics setAnalyticsCollectionEnabled:YES];
     }

--- a/Source/OEXEnvironment.m
+++ b/Source/OEXEnvironment.m
@@ -68,7 +68,7 @@
                 [analytics addTracker:[[SegmentAnalyticsTracker alloc] init]];
             }
             
-            if (env.config.firebaseConfig.analyticsEnabled && !segmentConfig.isEnabled) {
+            if (env.config.firebaseConfig.analyticsEnabled && env.config.firebaseConfig.isAnalyticsSourceFirebase) {
                 [analytics addTracker:[[FirebaseAnalyticsTracker alloc] init]];
             }
             

--- a/Test/FirebaseConfigTests.swift
+++ b/Test/FirebaseConfigTests.swift
@@ -22,7 +22,9 @@ class FirebaseConfigTests: XCTestCase {
         XCTAssertFalse(config.firebaseConfig.enabled)
         XCTAssertFalse(config.firebaseConfig.analyticsEnabled)
         XCTAssertFalse(config.firebaseConfig.cloudMessagingEnabled)
-        
+        XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceSegment)
+        XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceFirebase)
+        XCTAssertEqual(config.firebaseConfig.analyticsSource, AnalyticsSource.none)
     }
 
     func testEmptyFirebaseConfig() {
@@ -30,6 +32,9 @@ class FirebaseConfigTests: XCTestCase {
         XCTAssertFalse(config.firebaseConfig.enabled)
         XCTAssertFalse(config.firebaseConfig.analyticsEnabled)
         XCTAssertFalse(config.firebaseConfig.cloudMessagingEnabled)
+        XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceFirebase)
+        XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceSegment)
+        XCTAssertEqual(config.firebaseConfig.analyticsSource, AnalyticsSource.none)
     }
 
     func testFirebaseConfig() {
@@ -37,6 +42,7 @@ class FirebaseConfigTests: XCTestCase {
             "FIREBASE" : [
                 "ENABLED": true,
                 "ANALYTICS_ENABLED": true,
+                "ANALYTICS_SOURCE": "segment",
                 "CLOUD_MESSAGING_ENABLED": true,
                 "API_KEY" : apiKey,
                 "CLIENT_ID" : clientID,
@@ -50,6 +56,8 @@ class FirebaseConfigTests: XCTestCase {
         XCTAssertTrue(config.firebaseConfig.enabled)
         XCTAssertTrue(config.firebaseConfig.analyticsEnabled)
         XCTAssertTrue(config.firebaseConfig.cloudMessagingEnabled)
+        XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceFirebase)
+        XCTAssertTrue(config.firebaseConfig.isAnalyticsSourceSegment)
     }
 
     func testFirebaseDisableConfig() {
@@ -272,5 +280,47 @@ class FirebaseConfigTests: XCTestCase {
         let firebaseEnable = config.firebaseConfig.enabled && !(config.segmentConfig?.isEnabled ?? false)
         XCTAssertTrue(config.segmentConfig?.isEnabled ?? false)
         XCTAssertFalse(firebaseEnable)
+    }
+
+    func testAnalyticsSourceNoneConfig() {
+        let configDictionary = [
+            "FIREBASE" : [
+                "ANALYTICS_SOURCE": "none",
+            ]
+        ]
+
+        let config = OEXConfig(dictionary: configDictionary)
+
+        XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceSegment)
+        XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceFirebase)
+        XCTAssertEqual(config.firebaseConfig.analyticsSource, AnalyticsSource.none)
+    }
+
+    func testAnalyticsSourceSegmentConfig() {
+        let configDictionary = [
+            "FIREBASE" : [
+                "ANALYTICS_SOURCE": "segment",
+            ]
+        ]
+
+        let config = OEXConfig(dictionary: configDictionary)
+
+        XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceFirebase)
+        XCTAssertTrue(config.firebaseConfig.isAnalyticsSourceSegment)
+        XCTAssertEqual(config.firebaseConfig.analyticsSource, AnalyticsSource.segment)
+    }
+
+    func testAnalyticsSourceFirebaseConfig() {
+        let configDictionary = [
+            "FIREBASE" : [
+                "ANALYTICS_SOURCE": "firebase",
+            ]
+        ]
+
+        let config = OEXConfig(dictionary: configDictionary)
+
+        XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceSegment)
+        XCTAssertTrue(config.firebaseConfig.isAnalyticsSourceFirebase)
+        XCTAssertEqual(config.firebaseConfig.analyticsSource, AnalyticsSource.firebase)
     }
 }


### PR DESCRIPTION
### Description

[LEARNER-7325](https://openedx.atlassian.net/browse/LEARNER-7325)

This PR simplifies the logic of Firebase Analytics either it will be fired from Firebase or Segment.

### Notes

### How to test this PR
- [ ] If the value of `ANALYTICS_SOURCE` is `segment` then firebase analytics should be fired from segment SDK.
- [ ] If the value of `ANALYTICS_SOURCE` is `firebase` and `ANALYTICS_ENABLED` is enabled then f analytics should be fired from Firebase SDK.
- [ ] If the value of `ANALYTICS_SOURCE` is `none` then firebase analytics should not be fired.