### PR TITLE
Implement feature flag parity for Segment-Firebase implementation

### DIFF
--- a/Source/FirebaseConfig.swift
+++ b/Source/FirebaseConfig.swift
@@ -10,7 +10,6 @@ import Foundation
 
 fileprivate enum FirebaseKeys: String, RawStringExtractable {
     case enabled = "ENABLED"
-    case analyticsEnabled = "ANALYTICS_ENABLED"
     case analyticsSource = "ANALYTICS_SOURCE"
     case cloudMessagingEnabled = "CLOUD_MESSAGING_ENABLED"
     case apiKey = "API_KEY"
@@ -27,7 +26,6 @@ enum AnalyticsSource: String {
 
 class FirebaseConfig: NSObject {
     @objc var enabled: Bool = false
-    @objc var analyticsEnabled: Bool = false
     @objc var cloudMessagingEnabled: Bool = false
     @objc let apiKey: String?
     @objc let cliendID: String?
@@ -48,9 +46,7 @@ class FirebaseConfig: NSObject {
         self.analyticsSource = AnalyticsSource(rawValue: analyticsSource ?? AnalyticsSource.none.rawValue) ?? AnalyticsSource.none
         super.init()
         enabled =  requiredKeysAvailable && (dictionary[FirebaseKeys.enabled] as? Bool == true)
-        let analyticsEnabled = dictionary[FirebaseKeys.analyticsEnabled] as? Bool ?? false
         let cloudMessagingEnabled = dictionary[FirebaseKeys.cloudMessagingEnabled] as? Bool ?? false
-        self.analyticsEnabled = enabled && analyticsEnabled
         self.cloudMessagingEnabled = enabled && cloudMessagingEnabled
     }
 

--- a/Source/OEXEnvironment.m
+++ b/Source/OEXEnvironment.m
@@ -68,11 +68,11 @@
                 [analytics addTracker:[[SegmentAnalyticsTracker alloc] init]];
             }
             
-            if (env.config.firebaseConfig.analyticsEnabled && env.config.firebaseConfig.isAnalyticsSourceFirebase) {
+            if (env.config.firebaseConfig.enabled && env.config.firebaseConfig.isAnalyticsSourceFirebase) {
                 [analytics addTracker:[[FirebaseAnalyticsTracker alloc] init]];
             }
             
-            if((segmentConfig.apiKey != nil && segmentConfig.isEnabled) || env.config.firebaseConfig.analyticsEnabled) {
+            if((segmentConfig.apiKey != nil && segmentConfig.isEnabled) || (env.config.firebaseConfig.enabled && env.config.firebaseConfig.isAnalyticsSourceFirebase)) {
                 [analytics addTracker:[[LoggingAnalyticsTracker alloc] init]];
             }
             

--- a/Test/FirebaseConfigTests.swift
+++ b/Test/FirebaseConfigTests.swift
@@ -20,7 +20,6 @@ class FirebaseConfigTests: XCTestCase {
     func testNoFirebaseConfig() {
         let config = OEXConfig(dictionary:[:])
         XCTAssertFalse(config.firebaseConfig.enabled)
-        XCTAssertFalse(config.firebaseConfig.analyticsEnabled)
         XCTAssertFalse(config.firebaseConfig.cloudMessagingEnabled)
         XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceSegment)
         XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceFirebase)
@@ -30,7 +29,6 @@ class FirebaseConfigTests: XCTestCase {
     func testEmptyFirebaseConfig() {
         let config = OEXConfig(dictionary:["FIREBASE":[:]])
         XCTAssertFalse(config.firebaseConfig.enabled)
-        XCTAssertFalse(config.firebaseConfig.analyticsEnabled)
         XCTAssertFalse(config.firebaseConfig.cloudMessagingEnabled)
         XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceFirebase)
         XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceSegment)
@@ -54,7 +52,6 @@ class FirebaseConfigTests: XCTestCase {
         let config = OEXConfig(dictionary: configDictionary)
         XCTAssertTrue(config.firebaseConfig.requiredKeysAvailable)
         XCTAssertTrue(config.firebaseConfig.enabled)
-        XCTAssertTrue(config.firebaseConfig.analyticsEnabled)
         XCTAssertTrue(config.firebaseConfig.cloudMessagingEnabled)
         XCTAssertFalse(config.firebaseConfig.isAnalyticsSourceFirebase)
         XCTAssertTrue(config.firebaseConfig.isAnalyticsSourceSegment)
@@ -64,7 +61,6 @@ class FirebaseConfigTests: XCTestCase {
         let configDictionary = [
             "FIREBASE" : [
                 "ENABLED": false,
-                "ANALYTICS_ENABLED": true,
                 "CLOUD_MESSAGING_ENABLED": true,
                 "API_KEY" : apiKey,
                 "CLIENT_ID" : clientID,
@@ -76,7 +72,6 @@ class FirebaseConfigTests: XCTestCase {
         let config = OEXConfig(dictionary: configDictionary)
         XCTAssertTrue(config.firebaseConfig.requiredKeysAvailable)
         XCTAssertFalse(config.firebaseConfig.enabled)
-        XCTAssertFalse(config.firebaseConfig.analyticsEnabled)
         XCTAssertFalse(config.firebaseConfig.cloudMessagingEnabled)
     }
 
@@ -84,7 +79,6 @@ class FirebaseConfigTests: XCTestCase {
         let configDictionary = [
             "FIREBASE" : [
                 "ENABLED": true,
-                "ANALYTICS_ENABLED": false,
                 "API_KEY" : apiKey,
                 "CLIENT_ID" : clientID,
                 "GOOGLE_APP_ID" : googleAppID,
@@ -95,7 +89,6 @@ class FirebaseConfigTests: XCTestCase {
         let config = OEXConfig(dictionary: configDictionary)
         XCTAssertTrue(config.firebaseConfig.requiredKeysAvailable)
         XCTAssertTrue(config.firebaseConfig.enabled)
-        XCTAssertFalse(config.firebaseConfig.analyticsEnabled)
         XCTAssertFalse(config.firebaseConfig.cloudMessagingEnabled)
     }
 
@@ -103,7 +96,6 @@ class FirebaseConfigTests: XCTestCase {
         let configDictionary = [
             "FIREBASE" : [
                 "ENABLED": true,
-                "ANALYTICS_ENABLED": true,
                 "CLOUD_MESSAGING_ENABLED": false,
                 "API_KEY" : apiKey,
                 "CLIENT_ID" : clientID,
@@ -115,7 +107,6 @@ class FirebaseConfigTests: XCTestCase {
         let config = OEXConfig(dictionary: configDictionary)
         XCTAssertTrue(config.firebaseConfig.requiredKeysAvailable)
         XCTAssertTrue(config.firebaseConfig.enabled)
-        XCTAssertTrue(config.firebaseConfig.analyticsEnabled)
         XCTAssertFalse(config.firebaseConfig.cloudMessagingEnabled)
     }
     
@@ -123,7 +114,6 @@ class FirebaseConfigTests: XCTestCase {
         let configDictionary = [
             "FIREBASE" : [
                 "ENABLED": true,
-                "ANALYTICS_ENABLED": true,
                 "CLOUD_MESSAGING_ENABLED": true,
                 "API_KEY" : apiKey,
                 "CLIENT_ID" : clientID,
@@ -135,7 +125,6 @@ class FirebaseConfigTests: XCTestCase {
         let config = OEXConfig(dictionary: configDictionary)
         XCTAssertTrue(config.firebaseConfig.requiredKeysAvailable)
         XCTAssertTrue(config.firebaseConfig.enabled)
-        XCTAssertTrue(config.firebaseConfig.analyticsEnabled)
         XCTAssertTrue(config.firebaseConfig.cloudMessagingEnabled)
         XCTAssertEqual(config.firebaseConfig.apiKey, apiKey)
     }
@@ -144,7 +133,6 @@ class FirebaseConfigTests: XCTestCase {
         let configDictionary = [
             "FIREBASE" : [
                 "ENABLED": true,
-                "ANALYTICS_ENABLED": true,
                 "CLOUD_MESSAGING_ENABLED": true,
                 "API_KEY" : apiKey,
                 "CLIENT_ID" : clientID,
@@ -156,7 +144,6 @@ class FirebaseConfigTests: XCTestCase {
         let config = OEXConfig(dictionary: configDictionary)
         XCTAssertTrue(config.firebaseConfig.requiredKeysAvailable)
         XCTAssertTrue(config.firebaseConfig.enabled)
-        XCTAssertTrue(config.firebaseConfig.analyticsEnabled)
         XCTAssertTrue(config.firebaseConfig.cloudMessagingEnabled)
         XCTAssertEqual(config.firebaseConfig.cliendID, clientID)
     }
@@ -165,7 +152,6 @@ class FirebaseConfigTests: XCTestCase {
         let configDictionary = [
             "FIREBASE" : [
                 "ENABLED": true,
-                "ANALYTICS_ENABLED": true,
                 "CLOUD_MESSAGING_ENABLED": true,
                 "API_KEY" : apiKey,
                 "CLIENT_ID" : clientID,
@@ -177,7 +163,6 @@ class FirebaseConfigTests: XCTestCase {
         let config = OEXConfig(dictionary: configDictionary)
         XCTAssertTrue(config.firebaseConfig.requiredKeysAvailable)
         XCTAssertTrue(config.firebaseConfig.enabled)
-        XCTAssertTrue(config.firebaseConfig.analyticsEnabled)
         XCTAssertTrue(config.firebaseConfig.cloudMessagingEnabled)
         XCTAssertEqual(config.firebaseConfig.googleAppID, googleAppID)
     }
@@ -186,7 +171,6 @@ class FirebaseConfigTests: XCTestCase {
         let configDictionary = [
             "FIREBASE" : [
                 "ENABLED": true,
-                "ANALYTICS_ENABLED": true,
                 "CLOUD_MESSAGING_ENABLED": true,
                 "API_KEY" : apiKey,
                 "CLIENT_ID" : clientID,
@@ -198,7 +182,6 @@ class FirebaseConfigTests: XCTestCase {
         let config = OEXConfig(dictionary: configDictionary)
         XCTAssertTrue(config.firebaseConfig.requiredKeysAvailable)
         XCTAssertTrue(config.firebaseConfig.enabled)
-        XCTAssertTrue(config.firebaseConfig.analyticsEnabled)
         XCTAssertTrue(config.firebaseConfig.cloudMessagingEnabled)
         XCTAssertEqual(config.firebaseConfig.gcmSenderID, gcmSenderID)
     }
@@ -207,7 +190,6 @@ class FirebaseConfigTests: XCTestCase {
         let configDictionary = [
             "FIREBASE" : [
                 "ENABLED": true,
-                "ANALYTICS_ENABLED": true,
                 "CLOUD_MESSAGING_ENABLED": true,
                 "API_KEY" : apiKey,
                 "CLIENT_ID" : clientID,
@@ -219,7 +201,6 @@ class FirebaseConfigTests: XCTestCase {
         let config = OEXConfig(dictionary: configDictionary)
         XCTAssertTrue(config.firebaseConfig.requiredKeysAvailable)
         XCTAssertTrue(config.firebaseConfig.enabled)
-        XCTAssertTrue(config.firebaseConfig.analyticsEnabled)
         XCTAssertTrue(config.firebaseConfig.cloudMessagingEnabled)
     }
     
@@ -227,7 +208,6 @@ class FirebaseConfigTests: XCTestCase {
         let configDictionary = [
             "FIREBASE" : [
                 "ENABLED": true,
-                "ANALYTICS_ENABLED": false,
                 "CLOUD_MESSAGING_ENABLED": false,
             ]
         ]
@@ -235,7 +215,6 @@ class FirebaseConfigTests: XCTestCase {
         let config = OEXConfig(dictionary: configDictionary)
         XCTAssertFalse(config.firebaseConfig.requiredKeysAvailable)
         XCTAssertFalse(config.firebaseConfig.enabled)
-        XCTAssertFalse(config.firebaseConfig.analyticsEnabled)
         XCTAssertFalse(config.firebaseConfig.cloudMessagingEnabled)
     }
     
@@ -243,7 +222,6 @@ class FirebaseConfigTests: XCTestCase {
         let configDictionary = [
             "FIREBASE" : [
                 "ENABLED": true,
-                "ANALYTICS_ENABLED": false,
                 "CLOUD_MESSAGING_ENABLED": true,
                 "CLIENT_ID" : clientID,
                 "GOOGLE_APP_ID" : googleAppID,
@@ -254,7 +232,6 @@ class FirebaseConfigTests: XCTestCase {
         let config = OEXConfig(dictionary: configDictionary)
         XCTAssertFalse(config.firebaseConfig.requiredKeysAvailable)
         XCTAssertFalse(config.firebaseConfig.enabled)
-        XCTAssertFalse(config.firebaseConfig.analyticsEnabled)
         XCTAssertFalse(config.firebaseConfig.cloudMessagingEnabled)
     }
     
@@ -262,7 +239,6 @@ class FirebaseConfigTests: XCTestCase {
         let configDictionary = [
             "FIREBASE" : [
                 "ENABLED": true,
-                "ANALYTICS_ENABLED": false,
                 "CLOUD_MESSAGING_ENABLED": true,
                 "API_KEY" : apiKey,
                 "CLIENT_ID" : clientID,


### PR DESCRIPTION
### Description

[LEARNER-7373](https://openedx.atlassian.net/browse/LEARNER-7373)

Removing ANALYTICS_ENABLED and now Analytics enable/disable will be handled by `ANALYTICS_SOURCE`. `ANALYTICS_SOURCE` will work in the following ways:

1. `ANALYTICS_SOURCE: segment` firebase analytics will be fired using Segment SDK. 
2. `ANALYTICS_SOURCE: firebase` and firebase is also enabled then firebase analytics will be fired using Firebase SDK. 
3. `ANALYTICS_SOURCE: none` firebase analytics are disabled.

### Config PR's
1. https://github.com/edx/edx-mobile-config/pull/95
2. https://github.com/edx/edx-mobile-config/pull/97

### Testing

- [x] `ANALYTICS_SOURCE: segment` Firebase analytics should be fired using the Segment SDK
- [x] `ANALYTICS_SOURCE: firebase` and firebase is enabled Firebase analytics should be fired using the Firebase SDK
- [x]  `ANALYTICS_SOURCE: none` Firebase analytics shouldn't be working.
