### PR TITLE
iOS - Fix the crash of pageview controller

### DIFF
--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -77,8 +77,8 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
         super.viewWillAppear(animated)
         self.navigationController?.setToolbarHidden(false, animated: animated)
         courseQuerier.blockWithID(id: blockID).extendLifetimeUntilFirstResult (success:
-            { block in
-                self.environment.analytics.trackScreen(withName: OEXAnalyticsScreenUnitDetail, courseID: self.courseID, value: block.internalName)
+            {[weak self] block in
+                self?.environment.analytics.trackScreen(withName: OEXAnalyticsScreenUnitDetail, courseID: self?.courseID ?? "", value: block.internalName)
             },
             failure: {
                 Logger.logError("ANALYTICS", "Unable to load block: \($0)")
@@ -271,10 +271,8 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
         if let currentController = viewControllers?.first,
             let nextController = self.siblingWithDirection(direction: direction, fromController: currentController)
         {
-            setPageControllers(with: [nextController], direction: direction, animated: false, completion: { [weak self] (finished) in
-                if finished {
-                    self?.updateTransitionState(is: false)
-                }
+            setPageControllers(with: [nextController], direction: direction, animated: true, completion: { [weak self] (finished) in
+                self?.updateTransitionState(is: false)
             })
         }
     }

--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -271,8 +271,10 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
         if let currentController = viewControllers?.first,
             let nextController = self.siblingWithDirection(direction: direction, fromController: currentController)
         {
-            setPageControllers(with: [nextController], direction: direction, animated: true, completion: { [weak self] (finished) in
-                self?.updateTransitionState(is: false)
+            setPageControllers(with: [nextController], direction: direction, animated: false, completion: { [weak self] (finished) in
+                if finished {
+                    self?.updateTransitionState(is: false)
+                }
             })
         }
     }

--- a/Source/VideoBlockViewController.swift
+++ b/Source/VideoBlockViewController.swift
@@ -104,9 +104,7 @@ class VideoBlockViewController : UIViewController, CourseBlockViewController, St
     }
     
     override func viewDidAppear(_ animated : Bool) {
-        
-        loadVideoIfNecessary()
-        
+
         // There's a weird OS bug where the bottom layout guide doesn't get set properly until
         // the layout cycle after viewDidAppear so cause a layout cycle
         view.setNeedsUpdateConstraints()
@@ -114,6 +112,8 @@ class VideoBlockViewController : UIViewController, CourseBlockViewController, St
         view.setNeedsLayout()
         view.layoutIfNeeded()
         super.viewDidAppear(animated)
+
+        loadVideoIfNecessary()
         
         if !(environment.interface?.canDownload() ?? false) {
             guard let video = environment.interface?.stateForVideo(withID: blockID, courseID : courseID), video.downloadState == .complete else {


### PR DESCRIPTION
### Description

[LEARNER-7377](https://openedx.atlassian.net/browse/LEARNER-7377)

When we move next and previous on course content screen the app got crash, We faced this crash a lot of times before and tried to fix in different ways but it still reproduce. I tried to test this crash by disabling the back and forward animation and switch views without animation, the app do not crash. In this PR i disable the animation and tried to fix the crash. 