### PR TITLE
iOS - Add Japanese language support.

### DIFF
--- a/Source/SubjectsDiscovery/Subjects JSON/ja.lproj/subjects.json
+++ b/Source/SubjectsDiscovery/Subjects JSON/ja.lproj/subjects.json
@@ -1,0 +1,182 @@
+[
+    {
+        "name": "Architecture",
+        "image_name": "architecture",
+        "filter": "Architecture",
+        "type": "normal"
+    },
+    {
+        "name": "Art & Culture",
+        "image_name": "art",
+        "filter": "Art & Culture",
+        "type": "normal"
+    },
+    {
+        "name": "Biology & Life Sciences",
+        "image_name": "biology",
+        "filter": "Biology & Life Sciences",
+        "type": "normal"
+    },
+    {
+        "name": "Business & Management",
+        "image_name": "business",
+        "filter": "Business & Management",
+        "type": "popular"
+    },
+    {
+        "name": "Chemistry",
+        "image_name": "chemistry",
+        "filter": "Chemistry",
+        "type": "normal"
+    },
+    {
+        "name": "Communication",
+        "image_name": "communication",
+        "filter": "Communication",
+        "type": "normal"
+    },
+    {
+        "name": "Computer Science",
+        "image_name": "computer_science",
+        "filter": "Computer Science",
+        "type": "popular"
+    },
+    {
+        "name": "Data Analysis & Statistics",
+        "image_name": "data_science",
+        "filter": "Data Analysis & Statistics",
+        "type": "popular"
+    },
+    {
+        "name": "Design",
+        "image_name": "design",
+        "filter": "Design",
+        "type": "normal"
+    },
+    {
+        "name": "Economics & Finance",
+        "image_name": "economics_finance",
+        "filter": "Economics & Finance",
+        "type": "normal"
+    },
+    {
+        "name": "Education & Teacher Training",
+        "image_name": "education",
+        "filter": "Education & Teacher Training",
+        "type": "normal"
+    },
+    {
+        "name": "Electronics",
+        "image_name": "electronics",
+        "filter": "Electronics",
+        "type": "normal"
+    },
+    {
+        "name": "Energy & Earth Sciences",
+        "image_name": "energy",
+        "filter": "Energy & Earth Sciences",
+        "type": "normal"
+    },
+    {
+        "name": "Engineering",
+        "image_name": "engineering",
+        "filter": "Engineering",
+        "type": "normal"
+    },
+    {
+        "name": "Environmental Studies",
+        "image_name": "environmental_studies",
+        "filter": "Environmental Studies",
+        "type": "normal"
+    },
+    {
+        "name": "Ethics",
+        "image_name": "ethics",
+        "filter": "Ethics",
+        "type": "normal"
+    },
+    {
+        "name": "Food & Nutrition",
+        "image_name": "food_nutrition",
+        "filter": "Food & Nutrition",
+        "type": "normal"
+    },
+    {
+        "name": "Health & Safety",
+        "image_name": "health",
+        "filter": "Health & Safety",
+        "type": "normal"
+    },
+    {
+        "name": "History",
+        "image_name": "history",
+        "filter": "History",
+        "type": "normal"
+    },
+    {
+        "name": "Humanities",
+        "image_name": "humanities",
+        "filter": "Humanities",
+        "type": "popular"
+    },
+    {
+        "name": "Language",
+        "image_name": "language",
+        "filter": "Language",
+        "type": "popular"
+    },
+    {
+        "name": "Law",
+        "image_name": "law",
+        "filter": "Law",
+        "type": "normal"
+    },
+    {
+        "name": "Literature",
+        "image_name": "literature",
+        "filter": "Literature",
+        "type": "normal"
+    },
+    {
+        "name": "Math",
+        "image_name": "math",
+        "filter": "Math",
+        "type": "normal"
+    },
+    {
+        "name": "Medicine",
+        "image_name": "medicine",
+        "filter": "Medicine",
+        "type": "normal"
+    },
+    {
+        "name": "Music",
+        "image_name": "music",
+        "filter": "Music",
+        "type": "normal"
+    },
+    {
+        "name": "Philosophy & Ethics",
+        "image_name": "philosophy_ethics",
+        "filter": "Philosophy & Ethics",
+        "type": "normal"
+    },
+    {
+        "name": "Physics",
+        "image_name": "physics",
+        "filter": "Physics",
+        "type": "normal"
+    },
+    {
+        "name": "Science",
+        "image_name": "science",
+        "filter": "Science",
+        "type": "normal"
+    },
+    {
+        "name": "Social Sciences",
+        "image_name": "social_sciences",
+        "filter": "Social Sciences",
+        "type": "normal"
+    }
+]

--- a/Source/ja.lproj/InfoPlist.strings
+++ b/Source/ja.lproj/InfoPlist.strings
@@ -1,0 +1,10 @@
+/*
+ InfoPlist.strings
+ edX
+ 
+ Created by Saeed Bashir on 7/10/17.
+ Copyright © 2017 edX. All rights reserved.
+ */
+
+NSPhotoLibraryUsageDescription = "プロフィール画像を選択することができます";
+NSCameraUsageDescription = "プロフィール画像をとることができます";

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -1,0 +1,809 @@
+/*
+ Localizable.strings
+ edXVideoLocker
+ 
+ Created by Nirbhay Agarwal on 07/07/14.
+ Copyright (c) 2014-2015 edX. All rights reserved.
+ */
+
+// Please keep in alphabetical order
+
+/* Alert dialog confirmation button when user chooses to download a large video */
+"ACCEPT_LARGE_VIDEO_DOWNLOAD"="ダウンロード";
+/*Accessibility label for bulk download view when in downloading state */
+"ACCESSIBILITY.DOWNLOADING_VIDEOS_TITLE" = "Downloading Videos";
+/* Label for check box when it's checked. */
+"ACCESSIBILITY_CHECKBOX_CHECKED" = "チェック";
+/* Label for check box when it's checked. */
+"ACCESSIBILITY_CHECKBOX_UNCHECKED" = "チェックを外す";
+/* Label for action hint on check box when it's checked. */
+"ACCESSIBILITY_CHECKBOX_HINT_CHECKED" = "チェックボックスの選択を解除";
+/* Label for action hint on check box when it's checked. */
+"ACCESSIBILITY_CHECKBOX_HINT_UNCHECKED" = "選択するにはタップしてください";
+/* Appending By before course organization and number on My Find Courses*/
+"ACCESSIBILITY_BY" = "By";
+/*Accessibility hint for user bio on user profile screen*/
+"ACCESSIBILITY.ACCOUNT.BIO_LABEL" = "Description";
+/* Accessibility hint for subject name label */
+"ACCESSIBILITY.BROWSER_BY_SUBJECT_HINT" = "Double tap to browse by subject, {subject_name}";
+/* Accessibility hint for bulk download switch when in new state */
+"ACCESSIBILITY.BULK_DOWNLOAD_HINT" = "Toggling the switch on, will download all videos of this course";
+/* Accessibility hint for bulk download switch when in new partial or downloading state */
+"ACCESSIBILITY.BULK_DOWNLOAD_DOWNLOADING_HINT" = "Toggling the switch off, will cancel downloading of all videos and will delete all downloaded videos of this course.";
+/* Accessibility hint for bulk download switch when in downloaded state */
+"ACCESSIBILITY.BULK_DOWNLOAD_DOWNLOADED_HINT" = "Toggling the switch off, will delete all downloaded videos of this course.";
+/* Accessibility hint for close button*/
+"ACCESSIBILITY.CLOSE_HINT" = "閉じるにはダブルタップしてください";
+/* Accessibility label for posted data of discussion responses*/
+"ACCESSIBILITY.DISCUSSION_POSTED_ON" = " 投稿日時 {date}";
+/* Accessibility hint for Vote button for discussion responses*/
+"ACCESSIBILITY.DISCUSSION_VOTE_HINT" = "投票するにはダブルタップしてください";
+/* Accessibility hint for Unvote button for discussion responses*/
+"ACCESSIBILITY.DISCUSSION_UNVOTE_HINT" = "投票をやめるにはダブルタップしてください。";
+/* Accessibility hint for Report button for discussion responses*/
+"ACCESSIBILITY.DISCUSSION_REPORT_HINT" = "報告するにはダブルタップしてください";
+/* Accessibility hint for Unreport button for discussion responses*/
+"ACCESSIBILITY.DISCUSSION_UNREPORT_HINT" = "報告をやめるにはダブルタップしてください。";
+/* Accessibility hint for Follow button for discussion responses*/
+"ACCESSIBILITY.DISCUSSION_FOLLOW_HINT" = "フォローするにはダブルタップしてください";
+/* Accessibility hint for Unfollow button for discussion responses*/
+"ACCESSIBILITY.DISCUSSION_UNFOLLOW_HINT" = "フォローを解除するにはダブルタップしてください。";
+/*Accessibility hint for disabled buttons, cells, etc like for disabled user profile fields on user edit profile screen*/
+"ACCESSIBILITY.DISABLED_HINT" = "Dimmed";
+/* Acessibility hint for the show downloads button. */
+"ACCESSIBILITY.SHOW_CURRENT_DOWNLOADS_BUTTON_HINT" = "Double tap to view current downloads";
+/* Accessibility hint for view all subjects label*/
+"ACCESSIBILITY.VIEW_ALL_SUBJECTS_HINT" = "Double tap to view all subjects";
+/* Acessibility label for the download progress button. {percent_complete} is an already localized numeric percentage like "44%" */
+/* Acessibility label for the download progress button. {percent_complete} is an already localized numeric percentage like "44%" */
+"ACCESSIBILITY_DOWNLOAD_PROGRESS_BUTTON##{other}" = " ダウンロード中：{percent_complete} ％";
+/* Accessibility hint for video download list row cells. {video_name} is the name of video being downloaded. {percent_complete} is an already localized numeric percentage like "44%". */
+/* Accessibility hint for video download list row cells. {video_name} is the name of video being downloaded. {percent_complete} is an already localized numeric percentage like "44%". */
+"ACCESSIBILITY_DOWNLOAD_VIEW_CELL##{other}" = "{video_name} をダウンロード中。{percent_complete} ％済み。";
+/* Accessibility hint for number of downloadable videos */
+/* Accessibility hint for number of downloadable videos */
+"ACCESSIBILITY_DOWNLOADABLE_VIDEOS##{other}" = "{video_count} 件ダウンロード";
+/* Accessibility label for fullscreen button on video player */
+"ACCESSIBILITY_FULLSCREEN" = "全画面表示";
+/* Accessibility label for fullscreen button on video player when player is in fullscreen mode*/
+"ACCESSIBILITY_EXIT_FULLSCREEN" = "全画面表示解除";
+/* Accessibility hint for error*/
+"ACCESSIBILITY.ERROR_TEXT" = "Error";
+/* Accessibility label for HTML Icon in the Courseware screens */
+"ACCESSIBILITY_HTML" = "HTML";
+/* Accessibility label for Pause Button in the Video Player */
+"ACCESSIBILITY_PAUSE" = "一時停止";
+/* Accessibility label for Play Button in the Video Player */
+"ACCESSIBILITY_PLAY" = "再生";
+/* Accessibility lable for the avatar image */
+"ACCESSIBILITY_USER_AVATAR" = "あなたのアバター";
+/* Accessibility label for Problem Icon in the Courseware screens */
+"ACCESSIBILITY_PROBLEM" = "問題";
+/* Optional text needs to be added for accesibility*/
+"ACCESSIBILITY.OPTIONAL_INPUT"="Optional";
+/* Required text needs to be added for accesibility*/
+"ACCESSIBILITY_REQUIRED_INPUT"="Required";
+/* Accessibility label for Rewind Button in the Video Player */
+"ACCESSIBILITY_REWIND" = "巻き戻し";
+/* Call to action for Rewind Button in the Video Player */
+"ACCESSIBILITY_REWIND_HINT" = "30秒巻き戻し";
+/* Accessibility label for Seek bar in the Video Player */
+"ACCESSIBILITY_SEEK_BAR" = "シークバー";
+/* Accessibility label for Settings Button in the Video Player */
+"ACCESSIBILITY_SETTINGS" = "設定";
+/* Call to action for Course content on Home Screen */
+"ACCESSIBILITY_SHOWS_COURSE_CONTENT" = "講座コンテンツを見るにはダブルタップしてください。";
+/* We don't have a accessility trait for dropdown, so we will be achieving dropdown trait through accessibility label */
+"ACCESSIBILITY_DROPDOWN_TRAIT" = "Dropdown.";
+/* Call to action for Opening Dropdown */
+"ACCESSIBILITY_SHOWS_DROPDOWN_HINT" = "ドロップダウンを見るにはダブルタップしてください。";
+/* Call to action for Selecting Option */
+"ACCESSIBILITY_SELECT_VALUE_HINT" = "選択するにはダブルタップしてください。";
+/* Accessibility label for Unknown Icon in the Courseware screens */
+"ACCESSIBILITY_UNKNOWN" = "不明";
+/* Accessibility label for Video Icon in the Courseware screens */
+"ACCESSIBILITY_VIDEO" = "動画";
+/* Text spoken for Navigation Button on Course List Screen */
+"ACCESSIBILITY_MENU" = "説明メニュー";
+/* Accessibility label for close button when left drawer is open*/
+"ACCESSIBILITY_CLOSE_MENU" = "説明メニューを閉じる";
+/* Accessibility label for hiding keyboard*/
+"ACCESSIBILITY_HIDE_KEYBOARD" = "キーボード非表示";
+/* Accessibility Hint to view user profile*/
+"ACCESSIBILITY_SHOW_USER_PROFILE_HINT" = "ユーザープロフィールを見るにはダブルタップしてください。";
+/*Accessibility text for pinned discussion thread(Posts screen)*/
+"ACCESSIBILITY.DISCUSSION_PINNED" = "ピン済み";
+/*Accessibility text for closed discussion thread(Posts screen)*/
+"ACCESSIBILITY.DISCUSSION_CLOSED" = "終了";
+/*Accessibility text for followed discussion thread(Posts screen)*/
+"ACCESSIBILITY.DISCUSSION_FOLLOWED" = "フォロー済";
+/* Accessibility text for unread discussion comments count (Posts screen) - {count} is a number of unread comments */
+"ACCESSIBILITY.DISCUSSION_UNREAD_REPLIES"="{count} 件の未読";
+/*Accessibility text for unread discussion thread (Posts screen)*/
+"ACCESSIBILITY.DISCUSSION_UNREAD_THREAD" = "未読のスレッド";
+/*Accessibility text for read discussion thread (Posts screen)*/
+"ACCESSIBILITY.DISCUSSION_READ_THREAD" = "スレッドを読む";
+/*Accessibility text for discussion thread last seen date(Posts screen) - {date} last updated thread date*/
+"ACCESSIBILITY.DISCUSSION_LAST_POST_ON" = "{date} の投稿";
+/*Accessibility hint for discussion thread(Posts screen)*/
+"ACCESSIBILITY.DISCUSSION_THREAD_HINT" = "スレッドを見るにはダブルタップしてください。";
+/*Accessibility hint for sort button(Posts Screen)*/
+"ACCESSIBILITY.DISCUSSION_SORT_BY" = "{sort_by} で並べ替え";
+/*Accessibility hint for filter button(Posts Screen)*/
+"ACCESSIBILITY.DISCUSSION_FILTER_BY" = "{filter_by} でフィルタリング";
+/*Accessibility label for user profile in left drawer*/
+"ACCESSIBILITY.LEFT_DRAWER.PROFILE_LABEL" = "現在 {user_name}, {user_email} でログイン中";
+/*Accessibility hint for user profile in left drawer*/
+"ACCESSIBILITY.LEFT_DRAWER.PROFILE_HINT" = "あなたのプロフィールを開くにはダブルタップしてください。";
+/*Accessibility text for close button on whats new screen*/
+"ACCESSIBILITY.WHATSNEW.CLOSE_LABEL"="閉じる";
+/*Accessibility label for header on new screen*/
+"ACCESSIBILITY.WHATSNEW.HEADER_LABEL"="バージョン {app_version} 新機能";
+/*Accessibility text for course share button on course dashboard*/
+"ACCESSIBILITY.SHARE_A_COURSE"="講座をシェア";
+/*Accessibility text for close button*/
+"ACCESSIBILITY.CLOSE_LABEL"="Close";
+/*Accessibility text for profile button*/
+"ACCESSIBILITY.PROFILE_LABEL"="Profile";
+/* Title of user profile section for user accomplishments (like badges) */
+"ACCOMPLISHMENTS.TITLE" = "業績";
+/* Default text template when user shares an accomplishment */
+"ACCOMPLISHMENTS.SHARE_TEXT" = "{platform_name} でバッジを獲得しました！こちらで確認してください";
+/* Add a comment button title and place holder used in discussion comment text view */
+"ADD_A_COMMENT"="コメントを書く";
+/* Add a response button title used in discussion's responses screen */
+"ADD_A_RESPONSE"="返信を書く";
+/* Add comment button title used in discussion's Add a comment */
+"ADD_COMMENT"="コメントを書く";
+/* Add post button title used in discussion's Create a new post */
+"ADD_POST"="投稿する";
+/* Add response button title used in discussion's Add a response */
+"ADD_RESPONSE"="返信を書く";
+/* Add your post button title used in discussion's add a post textview */
+"ADD_YOUR_POST"="投稿する";
+/*Agreement text*/
+"AGREEMENT.TEXT"="you agree to the {eula} and {tos} and you acknowledge that {platform_name} and each Member process your personal data in accordance with the  {privacy_policy}.";
+/*Agreement text prefix for user on signin screen*/
+"AGREEMENT.TEXT_PREFIX_SIGNIN"="By signing-in to this app, ";
+/*Agreement text prefix for user on signup screen*/
+"AGREEMENT.TEXT_PREFIX_SIGNUP"="By creating an account, ";
+/*Link Text for End Use License Agreement*/
+"AGREEMENT.LINK_TEXT_EULA"="{platform_name} End User License Agreement";
+/*Link Text for End Use License Agreement*/
+"AGREEMENT.LINK_TEXT_TOS"="{platform_name} Terms of Service and Honor Code";
+/*Link Text for End Use License Agreement*/
+"AGREEMENT.LINK_TEXT_PRIVACY_POLICY"="Privacy Policy";
+/* Alert dialog button allowing user to chosing to allow downloads on cellular */
+"ALLOW"="許可";
+/* Filtering option to show all discussion posts */
+"ALL_POSTS"="すべての投稿";
+/*Subtitle for bulk download view when in downloading state */
+"ALL_DOWNLOADING_VIDEOS_SUB_TITLE" = "{remaining_videos_count} Remaining, {remaining_videos_size}MB total";
+/*Title for bulk download view when in downloaded state */
+"ALL_VIDEOS_DOWNLOADED_TITLE" = "All Videos Downloaded";
+/* Message shown when there are no announcements for a course */
+"ANNOUNCEMENT_UNAVAILABLE"="現在この講座からのお知らせはありません。";
+/* Label indicating the response answer in Discussion Add comment screen */
+"ANSWER"="解答";
+/* Navigation title for a Question Post which has endorsed answers */
+"ANSWERED_QUESTION"="質問に答える";
+/* Accessibility label for rating control of app review. */
+"APP_REVIEW.RATING_CONTROL_ACCESSIBILITY_LABEL" = "Rating コントロール";
+/* Accessibility hint for rating control of app review. */
+"APP_REVIEW.RATING_CONTROL_ACCESSIBILITY_HINT" = "値を変更するにはダブルタップしてホールド";
+/* Alert title for positive app review */
+"APP_REVIEW.RATE_THE_APP" = "アプリを評価する";
+/* Positive review message */
+"APP_REVIEW.POSITIVE_REVIEW_MESSAGE" = "アプリストアで簡単なレビューを書いて、他の人に伝えよう";
+/* Send feedback message for negative app review */
+"APP_REVIEW.SEND_FEEDBACK_TITLE" = "フィードバックを送りますか？";
+/* Help us improve message for negative app review */
+"APP_REVIEW.HELP_US_IMPROVE" = "改善できるようご協力ください！";
+/* Maybe later message for positive/negative app review */
+"APP_REVIEW.MAYBE_LATER" = "後で";
+/* Send feedback message for negative app review */
+"APP_REVIEW.SEND_FEEDBACK" = "フィードバックを送る";
+/* Question for rating view */
+"APP_REVIEW.RATE_THE_APP_QUESTION" = "アプリを評価してください";
+/* Submit button for rating view */
+"APP_REVIEW.SUBMIT" = "提出";
+/* App Review message email title */
+"APP_REVIEW.MESSAGE_SUBJECT" = "カスタマーレビュー";
+/*Asteric for marking fields required*/
+"ASTERIC" = "*";
+/* This error message will be shown if user tried to login with third party (facebook/google) and server returns 400 status code*/
+"AUTH_PROVIDER_ERROR" = "This {auth_provider} account is not linked with any {platform_name} account. Please register.";
+/*Subtitle for bulk download view when in new, partial or downloaded state - {count} is single video*/
+/*Subtitle for bulk download view when in new, partial or downloaded state - {count} is number of videos*/
+"BULK_DOWNLOAD_VIDEOS_SUB_TITLE##{other}" = "{count} Videos, {videos_size}MB total";
+/* Prefix used with Staff of Community TA on the posts screen */
+"BY_AUTHOR" = "{author_name}";
+/* Prefix used with Staff of Community TA on the posts screen */
+"BY_AUTHOR_LOWER_CASE" = "{author_name}";
+/* Course completion title */
+"CERTIFICATES.COURSE_COMPLETION_TITLE"="おめでとうございます！";
+/* Course completion subtitle */
+"CERTIFICATES.COURSE_COMPLETION_SUBTITLE"="あなたは合格しました。";
+/* Get certificate button text. */
+"CERTIFICATES.GET_CERTIFICATE"="修了証を見る";
+/* Text to share on FB & Twitter when sharing a course cert */
+"CERTIFICATES.SHARE_TEXT"="私は {platform_name} で修了証を獲得しました！こちらで確認してください：";
+/* Title bar when viewing an actual certificate */
+"CERTIFICATES.VIEW_CERT_TITLE"="修了証";
+/* Title of course announcements section */
+"COURSE_ANNOUNCEMENTS"="お知らせ";
+/* Title of course handouts section */
+"COURSE_HANDOUTS"="ハンドアウト";
+/* Title of resources tab in course dashboardTabBar view */
+"RESOURSES"="Resources";
+/* Title of course important dates screen */
+"COURSEDATES.COURSE_IMPORTANT_DATES_TITLE"="Important Dates";
+/* Button text for cancelling any action */
+"CANCEL"="キャンセル";
+/* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */
+"CELLULAR_DOWNLOAD_ENABLED_MESSAGE"="Wi-Fi 接続が利用できない場合、通話回線を使って動画をダウンロードできるようにします。データ通信料が課金されるかもしれません。";
+/* Title of alert explaining charges will apply since the "Wi-fi only" switch was turned off */
+"CELLULAR_DOWNLOAD_ENABLED_TITLE"="通話回線でのダウンロードを許可";
+/* Error message shown when there is a problem loading a video */
+"CHECK_CONNECTION"="動画の読込に失敗しました。\nインターネット接続を確認してください。";
+/* Generic action button label when the user chooses a thing */
+"CHOOSE" = "選ぶ";
+/* Title of dropdown from which the user can select topics on New Post Screen */
+"CHOOSE_A_TOPIC" = "トピックを選ぶ…";
+/* Prompt text shown after user chooses to begin registering with an external service like Facebook or Google. {service} will be replaced with a service name like Google or Facebook. */
+"COMPLETE_REGISTRATION_INFO" = "{service} でサインインできました。 {platform_name} を使い始めるにはもう少し情報が必要です。";
+/* Prompt text shown after user chooses to begin registering with an external service like Facebook or Google */
+"COMPLETE_REGISTRATION_PROMPT" = "登録完了";
+/* Title of alert when confirming deletion of a video */
+"CONFIRM_DELETE_TITLE"="削除の確認";
+/* Text of alert when confirming video deletion */
+/* Text of alert when confirming video deletion */
+"CONFIRM_DELETE_MESSAGE##{other}"="この動画を本当に消去しますか？";
+/* Text of push notification announcing a new course announcement */
+"COURSE_ANNOUNCEMENT_NOTIFICATION_BODY"="新しいお知らせ： {course_name}";
+/* Alert dialog button text */
+"CLOSE"="閉じる";
+/* Discussion response comment - {count} is a number of comments */
+/* Discussion response comment - {count} is a number of comments */
+"COMMENT##{other}"="コメント {count} 件";
+/* Discussion comments */
+"COMMENTS"="コメント";
+/* Text displayed when comments are disabled for a Response */
+"COMMENTS_CLOSED" = "コメント受付終了";
+/* Discussion comment (Posts screen) - {count} is a number of comments */
+/* Discussion comment (Posts screen) - {count} is a number of comments */
+"COMMENTS_TO_RESPONSE##{other}"="コメント {count} 件";
+/* Label for posts pinned by Community TA(s)" */
+"COMMUNITY_TA"="コミュニティTA";
+/* Label indicating the amount of time a course will take */
+"COURSE_DETAIL.EFFORT"="エフォート：";
+/* Label indicating when a course ends. */
+"COURSE_DETAIL.END_DATE"="終了日：";
+/* Button title allowing user to enroll in a course */
+"COURSE_DETAIL.ENROLL_NOW" = "登録しよう";
+/* Button title allowing user to view a course from the course's catalog detail page */
+"COURSE_DETAIL.VIEW_COURSE" = "講座を見る";
+/* Button title describing that the course is invitation only */
+"COURSE_DETAIL.INVITATION_ONLY" = "招待制";
+/* Message shown when there is no course content */
+"COURSEWARE_UNAVAILABLE"="現在受講できる講座コンテンツはありません。";
+/* Message shown when there is no course video */
+"COURSE_VIDEO_UNAVAILABLE"="この講座は動画がありません。";
+/* Message shown when attempting to display content not available on the app */
+"COURSE_CONTENT_UNKNOWN" = "この内容はモバイルでは使えません。\n\n他の内容を見るか、ウェブ上でこの内容をご覧ください。";
+/* Message shown when course content is gated */
+"COURSE_CONTENT_GATED"= "Not available on Mobile";
+/* Message shown when there is no course dates */
+"COURSEDATES.COURSE_DATE_UNAVAILABLE"="講座の日時は現在不明です。";
+/* Label for date when course starts */
+"COURSE.STARTING" = "Starting {start_date}";
+/* Label for date when course end */
+"COURSE.ENDING" = "Ending {end_date}";
+/* Label indicated that a course has ended */
+"COURSE.ENDED"="Ended {end_date}";
+/* Course audit will expires on date*/
+"COURSE.AUDIT.EXPIRES_ON" = "Course access expires on {expiry_date}";
+/* Course audit will expires in {time_duration}*/
+"COURSE.AUDIT.EXPIRES_IN" = "Course access expires in {time_duration}";
+/* Course audit expired n days ago*/
+"COURSE.AUDIT.EXPIRED_DAYS_AGO" = "Course access expired {days} days ago";
+/* Course audit expired in less than 24 hours*/
+"COURSE.AUDIT.EXPIRED_AGO" = "Course access expired {time_duaration}";
+/* Course audit expired on date*/
+"COURSE.AUDIT.EXPIRED_ON" = "Course access expired on {expiry_date}";
+/* Course audit expiry in n number of days*/
+"COURSE.AUDIT.DAYS" = "{days} days";
+/* 1 hour remaining in course audit expiry*/
+/* More than 1 hours remaining in course audit expiry*/
+"COURSE_AUDIT_REMAINING_HOURS##{other}" = "{hours} hours";
+/* 1 minutes remaining in course audit expiry*/
+/* More than 1 minutes remaining in course audit expiry*/
+"COURSE_AUDIT_REMAINING_MINUTES##{other}" = "{minutes} minutes";
+/* 1 second remaining in course audit expiry*/
+/* More than 1 seconds remaining in course audit expiry*/
+"COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} seconds";
+/*Error meessage on course content screen if course audit expires*/
+"COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Your access to this course has expired";
+/* Title text for the Announcements section within the course dashboard */
+"DASHBOARD.COURSE_ANNOUNCEMENTS"="お知らせ";
+/* Text describing the Announcements section within the course dashboard */
+"DASHBOARD.COURSE_ANNOUNCEMENTS_DETAIL"="最新ニュースを見る";
+/* Title text for the Courseware section of the course dashboard */
+"DASHBOARD.COURSE_COURSEWARE"="講座";
+/* Text describing the Courseware section within the course dashboard */
+"DASHBOARD.COURSE_COURSE_DETAIL"="講座コンテンツや課題を見る";
+/* Title text for the videos section of the course dashboard */
+"DASHBOARD.COURSE_Videos"="動画";
+/* Text describing the Videos section within the course dashboard */
+"DASHBOARD.COURSE_Videos_DETAIL"="動画を見る";
+/* Title text for the Discussions section of the course dashboard */
+"DASHBOARD.COURSE_DISCUSSION"="ディスカッション";
+/* Text describing the Discussions section within the course dashboard */
+"DASHBOARD.COURSE_DISCUSSION_DETAIL"="ディスカッションに参加する";
+/* Title text for the Handouts section of the course dashboard  */
+"DASHBOARD.COURSE_HANDOUTS"="ハンドアウト";
+/* Text describing the Handouts section within the course dashboard */
+"DASHBOARD.COURSE_HANDOUTS_DETAIL"="重要な講座情報を探す";
+/* Title text for the Important dates section of the course dashboard  */
+"DASHBOARD.COURSE_IMPORTANT_DATES"="Dates";
+/* Text describing the Important dates section of the course dashboard  */
+"DASHBOARD.COURSE_IMPORTANT_DATES_DETAIL"="締切を確認して確実に進める";
+/*Text for browse by subject label on subject discovery */
+"DISCOVERY.BROWSE_BY_SUBJECT" = "Browse By Subject";
+/*Placeholder text for subjects searchbar*/
+"DISCOVERY.SUBJECT_SEARCH_BAR_PLACEHOLDER" = "Search Subject";
+/*Label text for view all subjects cell*/
+"DISCOVERY.VIEW_ALL_SUBJECTS" = "View All Subjects";
+/* Text describing the course due date for same day*/
+"COURSE_DUE_DATE_SAME_DAY"="due today at {due_date} {time_zone}";
+/* Text describing the course due date*/
+"COURSE_DUE_DATE"="due {due_date}";
+/* Option to show all different types of course content. Constrasts with 'Show Videos Only'. */
+"COURSE_MODE_FULL"="講座全体を見る";
+/* Label to describe the button that allows choosing between Video only mode and All Course Content mode */
+"COURSE_MODE_PICKER_DESCRIPTION" = "モード選択";
+/* Text displayed when Can't find one of your courses is tapped on My Courses screen */
+"COURSE_NOT_LISTED" = "すべての講座をモバイルでご利用いただけるよう作業中です。もしお好みの講座が見つからなくても、日々新しい講座を追加していますので、近日中に再度チェックしてみてください。";
+/* Message shown on a course when it hasn't started yet.*/
+"COURSE_NOT_STARTED"="この講座はまだ開始していません。";
+/* Message shown on a course when it hasn't started yet. {date} will be a localized date string */
+"COURSE_WILL_START_AT"="この講座はまだ開始していません。{date} 以降、動画をご覧いただけます。";
+/* Create a new post button title used in discussions' posts screen */
+"CREATE_A_NEW_POST"="新規投稿を作成する";
+/* Button text to initiate or confirm deletion */
+"DELETE"="削除";
+/* Discussion used in the segmented control Creating a new post */
+"DISCUSSION"="ディスカッション";
+/* Discussion comment overlay message when new comment added */
+"DISCUSSION_COMMENT_POSTED" = "あなたのコメントが追加されました。";
+/* Title of button to allow user to follow a discussion post */
+"DISCUSSION_FOLLOW"="フォロー";
+/* Title of action to report a discussion post/response/comment to the course staff */
+"DISCUSSION_REPORT"="報告";
+/* Discussion response overlay message when new response added */
+"DISCUSSION_THREAD_POSTED" = "あなたの返信が追加されました。";
+/* Title of the navigation bar when entering the course discussion */
+"DISCUSSION_TOPICS"="ディスカッショントピック";
+/* Title of button to allow user to unfollow a discussion post */
+"DISCUSSION_UNFOLLOW"="フォロー解除";
+/* Title of action to unreport a discussion post/response/comment to the course staff */
+"DISCUSSION_UNREPORT"="未報告";
+/* Discussion comments count (Posts screen) - {count} is a number of comments */
+"DISCUSSIONS.REPLIES_COUNT"="返信 {count} 件";
+/*Discussion posts screen last post date - {date} last updated thread date*/
+"DISCUSSIONS.LAST_POST" = "最新の投稿：{date}";
+/* Alert dialog button for allowing/disallowing downloads on cellular data */
+"DO_NOT_ALLOW"="許可しない";
+/* Description about for button to download videos. For example, "Download 1 video" */
+/* Description about for button to download videos. For example, "Download 3 videos" */
+"DOWNLOAD_MANY_VIDEOS##{other}" = "{video_count} 件の動画をダウンロード";
+/* Button text for confirming download */
+"DOWNLOAD" = "ダウンロード";
+/* Label indicating that a video or videos have been downloaded */
+"DOWNLOADED" = "ダウンロード済";
+/* Description about downloaded videos. For example, "Downloaded 1 video" */
+/* Description about downloaded videos. For example, "Downloaded 3 videos" */
+"DOWNLOADED_MANY_VIDEOS##{other}" = "{video_count} 件の動画をダウンロード";
+/* Label indicating that a video or videos are downloading */
+"DOWNLOADING" = "ダウンロード中";
+/* Title of video downloads screen */
+"DOWNLOADS"="ダウンロード";
+/* Overlay message after user chooses to download a video */
+"DOWNLOADING_1_VIDEO"="1件の動画をダウンロード中";
+/*Title for bulk download view when in downloading state */
+"DOWNLOADING_VIDEOS_TITLE" = "Downloading Videos...";
+/*Title for bulk download view when in new or partial state */
+"DOWNLOAD_TO_DEVICE_TITLE" = "Download to Device";
+/*Discover in left drawer(used for courses and programs discovery)*/
+"DISCOVER"="Discovery";
+/*Title for the programs in tabbar and navigation bar*/
+"PROGRAMS"="Programs";
+/*Title for the degrees in navigation bar*/
+"DEGREES"="Degrees";
+/*Debug option title in tabbar */
+"DEBUG"="Debug";
+/* Error message shown when email address is not properly formatted */
+"ERROR_MESSAGE.INVALID_EMAIL_FORMAT"="Please make sure your e-mail address is formatted correctly and try again.";
+/* Alert message shown when user tries to send an email, but email isn't setup */
+"EMAIL_ACCOUNT_NOT_SET_UP_MESSAGE"="お使いの電子メールソフトが設定されていないようです。";
+/* Alert dialog title shown when user tries to send an email, but email isn't setup */
+"EMAIL_ACCOUNT_NOT_SET_UP_TITLE"="メールを送ることができません";
+/* Placeholder text for email address entry field */
+"EMAIL_ADDRESS_PROMPT"="メールアドレス";
+/* Text displayed when no results are found in the search */
+"EMPTY_RESULTSET" = "\"{query_string}\" が見つかりません。他の単語またはディスカッションカテゴリーをお試しください。";
+/* Prompt shown to users on the course list encouraging them to find new courses */
+"ENROLLMENT_LIST.FIND_COURSES_PROMPT" = "新しいチャレンジを探していますか？";
+/* Button title opening course catalog */
+"ENROLLMENT_LIST.FIND_COURSES" = "講座を探す";
+/* Error message when user is not enrolled to any course and course discovery is also disabled.*/
+"ENROLLMENT_LIST.NO_ENROLLMENT" = "あなたはまだどの講座にも受講登録をしていないようです。";
+/* Prompt indicating user needs to enter an email address */
+"ENTER_EMAIL"="Please enter your username or e-mail address and try again.";
+/* Prompt indicating user needs to enter a password */
+"ENTER_PASSWORD"="パスワードを入力して再試行してください。";
+/* Text used when the post is visible to everyone */
+"EVERYONE"="みなさん";
+/* Message when user attempts to register an account using an external service like Facebook or Google, but they already have an account linked to that service */
+"EXTERNAL_REGISTRATION_BECAME_LOGIN" = "あなたは {service} アカウントで既に {platform_name} アカウントを作成済です。そのアカウントでログイン中です。";
+/* Endorsed text */
+"ENDORSED" = "いいね！";
+/* Facebook login method */
+"FACEBOOK"="Facebook";
+/* Overlay message shown when facebook login fails because the user's account isn't linked */
+"FAILED_TO_LOAD_TOPICS"="トピックの読込ができませんでした。";
+/* Title of find courses screen */
+"FIND_COURSES"="講座を探す";
+/* No available courses on find courses section */
+"FIND_COURSES_NO_AVAILABLE_COURSES"="No available courses";
+/* Overlay message shown when enrolling in a course fails because the user is already in the course */
+"FIND_COURSES_ALREADY_ENROLLED_MESSAGE"="あなたはこの講座を登録済みです。";
+/* Overlay message shown when enrolling in a course fails */
+"FIND_COURSES_ENROLLMENT_ERROR_DESCRIPTION"="新規受講登録中にエラーが生じました。";
+/* AlertView message shown when enrolling in a course fails */
+"FIND_COURSES_UNABLE_TO_ENROLL_ERROR_DESCRIPTION"="We are unable to enroll you in this course at this time using the {platform_name} mobile application. Please try again on your web browser";
+/* Title of overlay message shown when enrolling in a course fails */
+"FIND_COURSES_ENROLLMENT_ERROR_TITLE"="登録エラー";
+/* Title of overlay message shown when enrolling in a course succeeds */
+"FIND_COURSES_ENROLLMENT_SUCCESSFUL_MESSAGE"="あなたはこの講座に登録中です。";
+/* Title of overlay message shown when enrolling in a course succeeds */
+"FIND_COURSES_OFFLINE_MESSAGE"="オフラインモードです。講座を探すにはインターネットに接続してください。";
+/* Title of overlay message shown when sign in fails */
+"FLOATING_ERROR_LOGIN_TITLE"="サインイン失敗";
+/* Title of overlay message shown when reset password fails */
+"FLOATING_ERROR_TITLE"="パスワード変更失敗";
+/* Adds a `:` after a label, used in form. Eg. "{First Name}: Bob" */
+"FORM_LABEL"="{label}:";
+/* Google login method */
+"GOOGLE"="Google";
+/* Overlay message shown when third party login fails because the user's account isn't linked. {service} is a third party login service like "Facebook". {platform_name} is the name of the service like "edX". {destination_name} is the name of service's web destination like "edx.org" */
+"SERVICE_ACCOUNT_NOT_ASSOCIATED_MESSAGE"="あなたの {service} アカウントが {destination_name} 上の {platform_name} アカウントと連動しているか確認してください。";
+/* Title of overlay message shown when login through an external service fails because the user's account isn't linked. For example, "Google account not associated with edX account" */
+"SERVICE_ACCOUNT_NOT_ASSOCIATED_TITLE"=" {platform_name} アカウントと連動していない {service} アカウント";
+/* Indicator for course content that is marked as having a graded component */
+"GRADED" = "採点済";
+/* Warning shown to indicate that the user is in a section of graded content. */
+"GRADED_CONTENT_WARNING" = "このような採点対象のセクションは、モバイルでフルサポート対応するまでは、ウェブブラウザ上で行うことをおススメします。";
+/* Message shown when there are no handouts for a course */
+"HANDOUTS_UNAVAILABLE"="現在のところ、この講座のハンドアウトはありません。";
+/* Overlay error shown when logging in with an invalid email address */
+"INVALID_EMAIL_MESSAGE"="メールアドレスが正しいか確認して再試行してください。";
+/* Overlay error shown when logging in with an invalid username or password */
+"INVALID_USERNAME_PASSWORD"="Please make sure that your username or e-mail address and password are correct and try again.";
+/* Alert dialog text asking whether it's okay to download large videos */
+"LARGE_DOWNLOAD_MESSAGE"="あなたが選択した動画は1GB以上です。本当にダウンロードしますか？";
+/* Alert dialog title when asking whether it's okay to download large videos */
+"LARGE_DOWNLOAD_TITLE"="大きいサイズのダウンロード";
+/* Title for Course Item that was last accessed */
+"LAST_ACCESSED" = "最新アクセス";
+/* Prompt leading user to create account screen */
+"LOGIN_SPLASH_SIGN_UP"="登録申込をして学習を始める";
+/* Prompt leading user to sign in screen */
+"LOGIN_SPLASH_SIGN_IN"="アカウントをお持ちですか？サインインしてください。";
+/* Button title to log out the current user */
+"LOGOUT"="ログアウト";
+/* Option to sort discussion post list by most activity */
+"MOST_ACTIVITY"="コメント数";
+/* Option to sort discussion post list by most votes */
+"MOST_VOTES"="投票数";
+/* Screen title showing a user's courses */
+"COURSES"="Courses";
+/* Screen title showing a user's settings */
+"MY_SETTINGS"="設定";
+/* Marked as answer for endorsed responses */
+"MARKED_ANSWER" = "ベストアンサー";
+/* Overlay error shown when attempting an action without an internet connection */
+"NETWORK_NOT_AVAILABLE_MESSAGE"="インターネットに接続されていません。";
+/* Alert dialog error shown when attempting an action without an internet connection */
+"NETWORK_NOT_AVAILABLE_MESSAGE_TROUBLE"="インターネットに接続されていません。インターネットへの接続設定を確認してください";
+/* Title of alert dialog shown when attempting an action without an internet connection */
+"NETWORK_NOT_AVAILABLE_TITLE"="接続エラー";
+/* Button title for moving to the next block in the course */
+"NEXT" = "次へ";
+/* Button title for moving to the next unit in the course */
+"NEXT_UNIT" = "次のユニットへ";
+/* Message shown when tapping on enroll courses when in app course enrollment is disabled */
+"NO_ENROLLMENT_INTERSTITIAL_BOTTOM_LABEL" = "当面はウェブサイト上で受講登録ができます。ログイン、受講登録をしたうえで、アプリに戻ってきてください。";
+/* Message shown when tapping on enroll courses when in app course enrollment is disabled */
+"NO_ENROLLMENT_INTERSTITIAL_TOP_LABEL" = "アプリ内で受講登録ができるよう、ただいま作業中です。";
+/* Message shown when no results are found while filtering discussions */
+"NO_RESULTS_FOUND" = "このディスカッション・カテゴリーには投稿がありません。";
+/* Message shown to indicate video transcript support has not yet been implemented */
+"NO_TRANSCRIPT" = "この動画は複写できません。";
+/* Message shown when user attempts to download a video over cellular data, but has chosen to only allow video downloads over wifi */
+"NO_WIFI_MESSAGE" = "現在ダウンロードは Wi-Fi 接続のみを使用する設定になっています。\nWi-Fi ネットワークに接続するか、ダウンロードの設定を変更してください。";
+/* Text displayed when no results are found for following*/
+"NO_FOLLOWING_RESULTS" = "フォロー中の投稿はありません。";
+/* Message shown when no results are found for all posts*/
+"NO_COURSE_RESULTS" = "このディスカッションには投稿がありません。";
+/* Indicates a field that does not apply to the current context */
+"NOT_APPLICABLE" = "該当なし";
+/* Label of switch that toggles push notification support */
+"NOTIFICATIONS_ENABLED" = "通知を許可";
+/*Text for author if post is by anonymous user*/
+"ANONYMOUS" = "匿名";
+/* Label indicating user has on internet connection and is in offline mode */
+"OFFLINE" = "オフライン";
+/* Alert dialog okay button */
+"OK"="OK";
+/* Button title allowing user to open current page in their web browser */
+"OPEN_IN_BROWSER"="Safari で見る";
+/* Button label to bring up course finder */
+"OR_SIGN_IN_WITH"="またはサインイン";
+/* Login screen password field title text */
+"PASSWORD_TITLE_TEXT" = "Password";
+/* Alert dialog button shown when finishing a video to ask if user should continue by watching the next video */
+"PLAYBACK_COMPLETE_CONTINUE"="続ける";
+/* Alert dialog button shown when finishing a video to ask if user should continue by watching the next video (negative option) */
+"PLAYBACK_COMPLETE_CONTINUE_CANCEL"="いいえ";
+/* Alert dialog content when finishing a video to ask if user should continue by watching the next video */
+"PLAYBACK_COMPLETE_MESSAGE"="次の動画を見ますか？";
+/* Alert dialog title when finishing a video to ask if user should continue by watching the next video */
+"PLAYBACK_COMPLETE_TITLE"="動画が終了しました。";
+/* Post screen title in creating a new post */
+"POST" = "新規投稿を作成";
+/* Title for Row on Discussion screen which opens the posts followed by the user */
+"POSTS_IM_FOLLOWING" = "フォロー中の投稿";
+/* Navigation item title for post and responses */
+"DISCUSSION_POST" = "ディスカッション投稿";
+/* Post discussion button title in Create a new post */
+"POST_DISCUSSION"="ディスカッションを投稿";
+/* Post question button title in Create a new post */
+"POST_QUESTION"="質問を投稿";
+/* Button title for moving to the previous block in the course */
+"PREVIOUS" = "前へ";
+/* Button title for moving to the next unit in the course */
+"PREVIOUS_UNIT" = "前のユニットへ";
+/* A10y hint for the change picture button. */
+"PROFILE.CHANGE_PICTURE_ACCESSIBILITY_HINT" = "Double tap to change profile photo";
+/* Change picture button text on edit profile screen. */
+"PROFILE.CHANGE_PICTURE_BUTTON" = "変更";
+/* Text for use a photo already in library for user profile photo alert */
+"PROFILE.CHOOSE_EXISTING" = "写真を選択";
+/* Instruction title text on the photo crop view. */
+"PROFILE.CROP_AND_RESIZE_PICTURE" = "サイズ変更";
+/* 'Current Language' label on top row of edit language in user's profile */
+"PROFILE.CURRENT_LANGUAGE_LABEL" = "現在の言語：";
+/* 'Current Location' label on top row of edit country in user's profile */
+"PROFILE.CURRENT_LOCATION_LABEL" = "現在地：";
+/* Profile edit view title */
+"PROFILE.EDIT_TITLE" = "プロフィールを編集";
+/* Accessibility label for edit profile button */
+"PROFILE.EDIT_ACCESSIBILITY" = "プロフィールを編集";
+/* Accessibility hint for country field in user profile */
+"PROFILE.COUNTRY_ACCESSIBILITY_HINT" = "国";
+/* Accessibility hint for language field in user profile */
+"PROFILE.LANGUAGE_ACCESSIBILITY_HINT" = "希望言語";
+/* Shown when viewing someone else's limied profile. */
+"PROFILE.LEARNER_HAS_LIMITED_PROFILE" = "この {platform_name} 受講者は現在、限定プロフィールを公開しています。";
+/* User has not filled in an "about me" on their profile */
+"PROFILE.NO_BIO" = "「自己紹介」の情報がありません。";
+/* Text in the picture taker alert to delete the existing image */
+"PROFILE.REMOVE_IMAGE" = "削除";
+/* Profile screen text indicating that the user is currently only displaying a limited profile */
+"PROFILE.SHOWING_LIMITED" = "現在、限定プロフィールを公開しています";
+/* Text for take picture for user profile photo alert */
+"PROFILE.TAKE_PICTURE" = "写真を撮る";
+/* Descriptive text for why a limited profile is shown for users under 13, first line */
+"PROFILE.AGE_LIMIT" = "全プロフィールを公開するには13歳以上でなければなりません。";
+/* Error retrieving a profile */
+"PROFILE.UNABLE_TO_GET" = "プロフィールを読み込めませんでした。";
+/* Error message when removing profile picture */
+"PROFILE.UNABLE_TO_REMOVE_PHOTO" = "写真を削除できませんでした。";
+/* Error saving user profile, for field `field_name` */
+"PROFILE.UNABLE_TO_SEND" = "{field_name} をアップデートできませんでした。";
+/* Error message when setting a new profile picture */
+"PROFILE.UNABLE_TO_SET_PHOTO" = "写真をアップデートできませんでした。";
+/*Pipe sign using for formatting in discussion posts*/
+"PIPE_SIGN" = "私は";
+/* Question used in the segmented control Creating a new post */
+"QUESTION"="質問";
+/* Option to sort discussion post list by recent activity */
+"RECENT_ACTIVITY" = "最近のアクティビティ";
+/* Label before Sort and Filter buttons on Posts Screen ( The Colon(:) is part of the string) */
+"REFINE" = "リファイン：";
+/* Button title when responses are closed for a thread */
+"RESPONSES_CLOSED"="返信受付終了";
+/* Create account agreement. Followed by list of agreement names like "End User License Agreement" */
+"REGISTRATION_AGREEMENT_MESSAGE"="アカウントを作成することにより、以下に同意したものとみなします。";
+/* Button text allowing user create an account */
+"REGISTRATION_CREATE_MY_ACCOUNT"="アカウントを作成する";
+/* Text shown while waiting for registration request */
+"REGISTRATION_CREATING_ACCOUNT"="アカウント作成中...";
+/* Error prompt shown during registration to indicate an empty field. {field_name} is the name of a registration field like 'password' */
+"REGISTRATION_FIELD_EMPTY_ERROR"="{field_name} を入力してください。";
+/* Error prompt shown during registration to indicate a field missing a selection. {field_name} is the name of a registration field like 'year of birth' */
+"REGISTRATION_FIELD_EMPTY_SELECT_ERROR"="{field_name} を選択してください。";
+/* Error prompt shown during registration when a field entry is too long. {field_name} is the name of a registration field like 'password'. {count} is a number of characters */
+/* Error prompt shown during registration when a field entry is too long. {field_name} is the name of a registration field like 'password'. {count} is a number of characters */
+"REGISTRATION_FIELD_MAX_LENGTH_ERROR##{other}"="{field_name}  は  {count} 文字を超えることはできません。";
+/* Error prompt shown during registration when a field entry is too short.  {field_name} is the name of a registration field like 'password'. {count} is a number of characters */
+/* Error prompt shown during registration when a field entry is too short.  {field_name} is the name of a registration field like 'password'. {count} is a number of characters */
+"REGISTRATION_FIELD_MIN_LENGTH_ERROR##{other}"="{field_name}  は少なくとも {count} 文字必要です。";
+/* Button text allowing user to hide visible optional registration fields */
+"REGISTRATION_HIDE_OPTIONAL_FIELDS"="オプションのフィールドを非表示";
+/* Button text allowing user to show hidden optional registration fields */
+"REGISTRATION_SHOW_OPTIONAL_FIELDS"="オプションのフィールドを表示";
+/* Heading on registration screen allowing users to sign up using external services like Facebook and Google. Will be followed by text "or sign up with an email". */
+"REGISTRATION_REGISTER_PROMPT"="登録";
+/* Heading on registration screen allowing users to sign up using external services like Facebook and Google. Will be preceded by text "Sign up with" */
+"REGISTRATION_REGISTER_ALTERNATE_PROMPT"="またはメールで登録";
+/*Title of registration error alert*/
+"REGISTRATION_ERROR_ALERT_TITLE"="Registration Error";
+/* Detailed info message for registration error alert*/
+"REGISTRATION_ERROR_ALERT_MESSAGE"="Update the highlighted fields and try again";
+
+/* Alert dialog title prompting user to enter an email address to reset their password */
+"RESET_PASSWORD_TITLE"="パスワード変更";
+/* Alert dialog content prompting user to enter an email address to reset their password */
+"RESET_PASSWORD_POPUP_TEXT"="あなたのアカウントに登録しているメールアドレスを入力してください。パスワード変更手順についてのメールをお送りします。";
+/* Alert dialog title confirming to the user that a reset password was sent to them */
+"RESET_PASSWORD_CONFIRMATION_TITLE"="パスワード変更メールを送信済";
+/* Alert dialog content confirming to the user that a reset password was sent to them */
+"RESET_PASSWORD_CONFIRMATION_MESSAGE"="登録メールアドレスに、パスワード変更手順についてのメールを送信しました。\nもし数分経ってもメールが見つからない場合は、迷惑メールフォルダを確認してください。";
+/* Button that allows user to retry an operation that did not succeed */
+"RETRY" = "再試行";
+/*Offline snackbar button that allows user to reload data*/
+"RELOAD" = "再読込";
+/* Response back title in adding a new response */
+"ADD_A_RESPONSE"="返信を書く";
+/* Discussion response - {count} is a number of responses */
+/* Discussion response - {count} is a number of responses */
+"RESPONSE##{other}"="返信 {count} 件";
+/* Discussion topics search placeholder */
+"SEARCH_ALL_POSTS"="全ての投稿を検索";
+/*Placeholder text for search course textfield*/
+"SEARCH_COURSES_PLACEHOLDER_TEXT"="Search course";
+/*Placeholder text for search program textfield*/
+"SEARCH_PROGRAMS_PLACEHOLDER_TEXT"="Search program";
+/*Placeholder text for search degree textfield*/
+"SEARCH_DEGREES_PLACEHOLDER_TEXT"="Search degree";
+/* Discussion search results  */
+"SEARCH_RESULTS"="検索";
+/* Text shown below the video, in portrait mode */
+"ROTATE_DEVICE"="全画面表示でこの動画を見るには画面を横向きにしてください。";
+/*if filter applied then append this string to error message*/
+"REMOVE_FILTER" = "投稿フィルタを解除";
+/* Label shown when user attempts to view a course section that hasn't been synced  */
+"SECTION_UNAVAILABLE_OFFLINE"="このセクションはオフラインモードで見ることができません。別のセクションのコンテンツをダウンロードした方は、そのセクションに行ってコンテンツをご覧ください。";
+/* Screen title showing a user's settings */
+"SETTINGS"="設定";
+/* Text for a Twitter or Facebook post to a course about page */
+"SHARE_A_COURSE"="私は {platform_name} の講座を受講中です！こちらを見てください：";
+/* Sign in screen title and button initiating login process after user enters credentials like username and password */
+"SIGN_IN_TEXT"="サインイン";
+/* Message shown while user waits for response to a sign in request */
+"SIGN_IN_BUTTON_TEXT_ON_SIGN_IN"="サインイン中";
+/*  Accessibility text prefix for  Facebook and Google Buttons*/
+"SIGN_IN_PROMPT"="Sign in with";
+/*Sign up screen title and button initiating sign up process on the main screen */
+"REGISTER_TEXT"="登録";
+/* Indicates a date in the near future */
+"SOON"="すぐに";
+/* Label for posts pinned by Staff */
+"STAFF"="スタッフ";
+/* Info message text on the startup screen */
+"STARTUP.INFO_MESSAGE_TEXT"="Courses from the world's best universities in your pocket.";
+/*Log In button title on the startup screen*/
+"STARTUP.LOGIN_TEXT"="Log In";
+/*Create your Account button title on the startup screen*/
+"STARTUP.CREATE_YOUR_ACCOUNT_TEXT"="Create your Account";
+/* Explore Subjects button text on the first screen */
+"STARTUP_EXPLORE_SUBJECTS"="該当分野を探す";
+/* Button allowing user to submit feedback about the app via email */
+"SUBMIT_FEEDBACK.OPTION_TITLE" = "フィードバックを送る";
+/* Support message email title */
+"SUBMIT_FEEDBACK.MESSAGE_SUBJECT" = "利用者フィードバック";
+/* Marker in feedback email meant to separate feedback from prepopulated device information */
+"SUBMIT_FEEDBACK.MARKER" = "---- この行より上にフィードバックを入力してください ----";
+/* Line in submit feedback email that supplies OS version information. For example, "iOS Version: 9.2" */
+"SUBMIT_FEEDBACK.OS_VERSION" = "iOS バージョン: {version}";
+/* Line in submit feedback email that supplies app version information. For example, "App Version: 2.2 (2.2.23)" */
+"SUBMIT_FEEDBACK.APP_VERSION" = "アプリバージョン： {version} ({build})";
+/* Line in submit feedback email that supplies device model information. For example, "Device Model: iPhone" */
+"SUBMIT_FEEDBACK.DEVICE_MODEL" = "デバイス：{model}";
+/* Text that indicates the visibility of the post */
+"POST_VISIBILITY"="この投稿は {cohort} のみ見ることができます。";
+/* Text that indicates the visibility of the post to everyone */
+"POST_VISIBILITY_EVERYONE" = "この投稿は誰でも見ることができます。";
+/*Add parenthesis around text*/
+"PARENTHESIS" = "({text})";
+/* Alert dialog title shown when network request takes too long to complete */
+"TIMEOUT_ALERT_TITLE"="時間切れ";
+/* Alert dialog content shown when network request takes too long to complete */
+"TIMEOUT_CHECK_INTERNET_CONNECTION"="インターネット接続を確認してください。ページの読込に時間がかかり過ぎています。";
+/* Title as place holder in Create a new post */
+"TITLE"="件名";
+/* Topic as button title in Create a new post */
+"TOPIC"="トピック：{topic}";
+/* Back bar button topics */
+"TOPICS"="トピック";
+/* Button text allowing user to reset their password */
+"TROUBLE_IN_LOGIN_BUTTON"="パスワードをお忘れですか？";
+/* Error shown when video download fails */
+"UNABLE_TO_DOWNLOAD"="ダウンロードできませんでした。" ;
+/* Error shown when the course content could not for an unknown reason. */
+"UNABLE_TO_LOAD_COURSE_CONTENT"="講座コンテンツを読み込めませんでした。後ほど再試行してください。";
+/* Filtering option to show unanswered discussion posts */
+"UNANSWERED"="未回答";
+/* Navigation title for a Question Post which has no endorsed answers */
+"UNANSWERED_QUESTION" = "未回答の質問";
+/* Filtering option to show unread discussion posts*/
+"UNREAD"="未読";
+/* Placeholder title for course content with no title */
+"UNTITLED"="名称未設定";
+/* Title text for login field */
+"USERNAME_TITLE_TEXT" = "Username or e-mail address";
+/*Error message when operation failed with unknow error*/
+"UNKNOWN_ERROR" = "完了していません。";
+/* Screen title showing a user's account */
+"USER_ACCOUNT"="Account";
+/* Button title for profile view in account*/
+"USER_ACCOUNT.PROFILE"= "Profile";
+/* Text shown to display the current version number. Environment is a server name like "prod", "dev", stage" and may be empty. For example "Version 1.2.3 Prod" */
+"VERSION_DISPLAY" = "バージョン {number} {environment}";
+/* Error shown when video download fails */
+"VIDEO_CONTENT_NOT_AVAILABLE"="この動画は現在見ることができません。後ほど再試行してください。";
+/* Message shown instead of a video when attempting to watch a video that is only availabe on the web */
+"VIDEO_ONLY_ON_WEB" = "この動画は現在ウェブ上にしかありません。ウェブブラウザ上で見るにはタップしてください。";
+/* Alert dialog content shown when user attempts to view a video that hasn't been synced  */
+"VIDEO_NOT_AVAILABLE"="この動画はオフラインモードでは見れません。ダウンロード済の動画を選択してください。";
+/* Shows in the video setting sub-table which item is selected */
+"VIDEO_SETTING_SELECTED" = "✓ %@";
+/* Button action to open app on YouTube */
+"VIDEO.VIEW_ON_YOUTUBE" = "YouTubeで動画を見る";
+/* Message shown for videos that can only be played external the app via YouTube. */
+"VIDEO.ONLY_ON_YOUTUBE" = "この動画はYouTubeのみで見ることができます。";
+/* Button text for showing an associated item */
+"VIEW" = "見る";
+/* Button linking to course announcements */
+"VIEW_HANDOUTS" = "講座のハンドアウトを見る";
+/* Discussion vote - {count} is a number of votes */
+/* Discussion vote - {count} is a number of votes */
+"VOTE##{other}"="投票 {count} 件";
+/*Title of update button on fullscreen error and SnackBar*/
+"VERSION_UPGRADE_UPDATE" = "アップデート";
+/*Title of dismiss button on SnackBar*/
+"VERSION_UPGRADE.DISMISS" = "閉じる";
+/*Deprecated version detail message*/
+"VERSION_UPGRADE.DEPRECATED_MESSAGE" = "このアプリには新バージョンがあります。";
+/*Outdated version detail message*/
+"VERSION_UPGRADE.OUT_DATED_MESSAGE" = "お使いのアプリのバージョンはサポートが終了しています。";
+/*Outdated version alert message for login screen*/
+"VERSION_UPGRADE_OUT_DATED_LOGIN_MESSAGE" = "お使いのアプリのバージョンはサポートが終了しています。最新バージョンにアップデートしてログインしてください。";
+/*New version available without deadline message*/
+"VERSION_UPGRADE.NEW_VERSION_AVAILABLE" = "このアプリには新バージョンがあります。";
+/*Video player remaining time default value*/
+"VIDEO_PLAYER_DEFAULT_REMAINING_TIME" = "0:00/0:00";
+/* Overlay shown after a network request has started, telling the user to wait for the response */
+"WAITING_FOR_RESPONSE"="お待ちください…";
+/* Header of 'whats new screen'*/
+"WHATS_NEW.HEADER_TEXT"="バージョン {app_version} 新機能";
+/*Whats new screen done button title*/
+"WHATS_NEW.DONE"="完了";
+/*Title for wifi only switch at Settings screen*/
+"WIFI_ONLY_TITLE" = "Wi-Fi 使用ダウンロード";
+/*Detail message for wifi only switch at Settings screen*/
+"WIFI_ONLY_DETAIL_MESSAGE" = "Wi-Fi がオンになっているときだけダウンロード";
+/* Alert dialog button title to confirm an action */
+"YES"="はい";

--- a/Source/ja.lproj/MobileAppEula.htm
+++ b/Source/ja.lproj/MobileAppEula.htm
@@ -1,0 +1,985 @@
+<html>
+
+<head>
+<meta name=Title content="">
+<meta name=Keywords content="">
+<meta http-equiv=Content-Type content="text/html; charset=utf-8">
+<meta name=ProgId content=Word.Document>
+<meta name=Generator content="Microsoft Word 14">
+<meta name=Originator content="Microsoft Word 14">
+<link rel=File-List href="MobileAppEula_files/filelist.xml">
+<!--[if gte mso 9]><xml>
+ <o:DocumentProperties>
+  <o:Author>Microsoft Office User</o:Author>
+  <o:LastAuthor>Salman Nawaz</o:LastAuthor>
+  <o:Revision>2</o:Revision>
+  <o:TotalTime>1</o:TotalTime>
+  <o:Created>2018-05-04T08:58:00Z</o:Created>
+  <o:LastSaved>2018-05-04T08:58:00Z</o:LastSaved>
+  <o:Pages>1</o:Pages>
+  <o:Words>1834</o:Words>
+  <o:Characters>10454</o:Characters>
+  <o:Lines>87</o:Lines>
+  <o:Paragraphs>24</o:Paragraphs>
+  <o:CharactersWithSpaces>12264</o:CharactersWithSpaces>
+  <o:Version>14.0</o:Version>
+ </o:DocumentProperties>
+ <o:OfficeDocumentSettings>
+  <o:AllowPNG/>
+ </o:OfficeDocumentSettings>
+</xml><![endif]-->
+<link rel=themeData href="MobileAppEula_files/themedata.xml">
+<!--[if gte mso 9]><xml>
+ <w:WordDocument>
+  <w:SpellingState>Clean</w:SpellingState>
+  <w:GrammarState>Clean</w:GrammarState>
+  <w:TrackMoves/>
+  <w:TrackFormatting/>
+  <w:PunctuationKerning/>
+  <w:ValidateAgainstSchemas/>
+  <w:SaveIfXMLInvalid>false</w:SaveIfXMLInvalid>
+  <w:IgnoreMixedContent>false</w:IgnoreMixedContent>
+  <w:AlwaysShowPlaceholderText>false</w:AlwaysShowPlaceholderText>
+  <w:DoNotPromoteQF/>
+  <w:LidThemeOther>EN-US</w:LidThemeOther>
+  <w:LidThemeAsian>ZH-CN</w:LidThemeAsian>
+  <w:LidThemeComplexScript>AR-SA</w:LidThemeComplexScript>
+  <w:Compatibility>
+   <w:BreakWrappedTables/>
+   <w:SnapToGridInCell/>
+   <w:ApplyBreakingRules/>
+   <w:WrapTextWithPunct/>
+   <w:UseAsianBreakRules/>
+   <w:DontGrowAutofit/>
+   <w:SplitPgBreakAndParaMark/>
+   <w:EnableOpenTypeKerning/>
+   <w:DontFlipMirrorIndents/>
+   <w:OverrideTableStyleHps/>
+   <w:UseFELayout/>
+  </w:Compatibility>
+  <m:mathPr>
+   <m:mathFont m:val="Cambria Math"/>
+   <m:brkBin m:val="before"/>
+   <m:brkBinSub m:val="&#45;-"/>
+   <m:smallFrac m:val="off"/>
+   <m:dispDef/>
+   <m:lMargin m:val="0"/>
+   <m:rMargin m:val="0"/>
+   <m:defJc m:val="centerGroup"/>
+   <m:wrapIndent m:val="1440"/>
+   <m:intLim m:val="subSup"/>
+   <m:naryLim m:val="undOvr"/>
+  </m:mathPr></w:WordDocument>
+</xml><![endif]--><!--[if gte mso 9]><xml>
+ <w:LatentStyles DefLockedState="false" DefUnhideWhenUsed="true"
+  DefSemiHidden="true" DefQFormat="false" DefPriority="99"
+  LatentStyleCount="276">
+  <w:LsdException Locked="false" Priority="0" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Normal"/>
+  <w:LsdException Locked="false" Priority="9" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="heading 1"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 2"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 3"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 4"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 5"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 6"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 7"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 8"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 9"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 1"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 2"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 3"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 4"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 5"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 6"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 7"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 8"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 9"/>
+  <w:LsdException Locked="false" Priority="35" QFormat="true" Name="caption"/>
+  <w:LsdException Locked="false" Priority="10" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Title"/>
+  <w:LsdException Locked="false" Priority="1" Name="Default Paragraph Font"/>
+  <w:LsdException Locked="false" Priority="11" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Subtitle"/>
+  <w:LsdException Locked="false" Priority="22" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Strong"/>
+  <w:LsdException Locked="false" Priority="20" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Emphasis"/>
+  <w:LsdException Locked="false" Priority="39" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Table Grid"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 1"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 2"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 3"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 4"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 5"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 6"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 7"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 8"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 9"/>
+  <w:LsdException Locked="false" UnhideWhenUsed="false" Name="Placeholder Text"/>
+  <w:LsdException Locked="false" Priority="1" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="No Spacing"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 1"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 1"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 1"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 1"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 1"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 1"/>
+  <w:LsdException Locked="false" UnhideWhenUsed="false" Name="Revision"/>
+  <w:LsdException Locked="false" Priority="34" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="List Paragraph"/>
+  <w:LsdException Locked="false" Priority="29" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Quote"/>
+  <w:LsdException Locked="false" Priority="30" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Intense Quote"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 1"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 1"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 1"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 1"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 1"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 1"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 1"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 1"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 2"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 2"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 2"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 2"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 2"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 2"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 2"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 2"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 2"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 2"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 2"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 2"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 2"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 2"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 3"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 3"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 3"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 3"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 3"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 3"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 3"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 3"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 3"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 3"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 3"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 3"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 3"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 3"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 4"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 4"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 4"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 4"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 4"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 4"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 4"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 4"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 4"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 4"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 4"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 4"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 4"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 4"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 5"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 5"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 5"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 5"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 5"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 5"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 5"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 5"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 5"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 5"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 5"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 5"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 5"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 5"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 6"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 6"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 6"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 6"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 6"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 6"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 6"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 6"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 6"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 6"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 6"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 6"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 6"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 6"/>
+  <w:LsdException Locked="false" Priority="19" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Subtle Emphasis"/>
+  <w:LsdException Locked="false" Priority="21" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Intense Emphasis"/>
+  <w:LsdException Locked="false" Priority="31" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Subtle Reference"/>
+  <w:LsdException Locked="false" Priority="32" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Intense Reference"/>
+  <w:LsdException Locked="false" Priority="33" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Book Title"/>
+  <w:LsdException Locked="false" Priority="37" Name="Bibliography"/>
+  <w:LsdException Locked="false" Priority="39" QFormat="true" Name="TOC Heading"/>
+ </w:LatentStyles>
+</xml><![endif]-->
+<style>
+<!--
+ /* Font Definitions */
+@font-face
+	{font-family:Arial;
+	panose-1:2 11 6 4 2 2 2 2 2 4;
+	mso-font-charset:0;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:-536859905 -1073711037 9 0 511 0;}
+@font-face
+	{font-family:"Courier New";
+	panose-1:2 7 3 9 2 2 5 2 4 4;
+	mso-font-charset:0;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:-536859905 -1073711037 9 0 511 0;}
+@font-face
+	{font-family:Wingdings;
+	panose-1:5 0 0 0 0 0 0 0 0 0;
+	mso-font-charset:2;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:0 268435456 0 0 -2147483648 0;}
+@font-face
+	{font-family:Wingdings;
+	panose-1:5 0 0 0 0 0 0 0 0 0;
+	mso-font-charset:2;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:0 268435456 0 0 -2147483648 0;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;
+	mso-font-charset:0;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:-520092929 1073786111 9 0 415 0;}
+@font-face
+	{font-family:DengXian;
+	mso-font-alt:等线;
+	mso-font-charset:134;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:-1610612033 953122042 22 0 262159 0;}
+ /* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-parent:"";
+	margin:0cm;
+	margin-bottom:.0001pt;
+	mso-pagination:widow-orphan;
+
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:DengXian;
+	mso-fareast-theme-font:minor-fareast;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:Arial;
+	mso-bidi-theme-font:minor-bidi;
+	mso-fareast-language:ZH-CN;}
+a:link, span.MsoHyperlink
+	{mso-style-priority:99;
+	color:blue;
+	text-decoration:underline;
+	text-underline:single;}
+a:visited, span.MsoHyperlinkFollowed
+	{mso-style-noshow:yes;
+	mso-style-priority:99;
+	color:#954F72;
+	mso-themecolor:followedhyperlink;
+	text-decoration:underline;
+	text-underline:single;}
+p.MsoAcetate, li.MsoAcetate, div.MsoAcetate
+	{mso-style-noshow:yes;
+	mso-style-priority:99;
+	mso-style-link:"Balloon Text Char";
+	margin:0cm;
+	margin-bottom:.0001pt;
+	mso-pagination:widow-orphan;
+
+	font-family:"Times New Roman";
+	mso-fareast-font-family:DengXian;
+	mso-fareast-theme-font:minor-fareast;
+	mso-fareast-language:ZH-CN;}
+p.MsoListParagraph, li.MsoListParagraph, div.MsoListParagraph
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:0cm;
+	margin-left:36.0pt;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	mso-pagination:widow-orphan;
+
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:DengXian;
+	mso-fareast-theme-font:minor-fareast;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:Arial;
+	mso-bidi-theme-font:minor-bidi;
+	mso-fareast-language:ZH-CN;}
+p.MsoListParagraphCxSpFirst, li.MsoListParagraphCxSpFirst, div.MsoListParagraphCxSpFirst
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-type:export-only;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:0cm;
+	margin-left:36.0pt;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	mso-pagination:widow-orphan;
+
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:DengXian;
+	mso-fareast-theme-font:minor-fareast;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:Arial;
+	mso-bidi-theme-font:minor-bidi;
+	mso-fareast-language:ZH-CN;}
+p.MsoListParagraphCxSpMiddle, li.MsoListParagraphCxSpMiddle, div.MsoListParagraphCxSpMiddle
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-type:export-only;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:0cm;
+	margin-left:36.0pt;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	mso-pagination:widow-orphan;
+
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:DengXian;
+	mso-fareast-theme-font:minor-fareast;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:Arial;
+	mso-bidi-theme-font:minor-bidi;
+	mso-fareast-language:ZH-CN;}
+p.MsoListParagraphCxSpLast, li.MsoListParagraphCxSpLast, div.MsoListParagraphCxSpLast
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-type:export-only;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:0cm;
+	margin-left:36.0pt;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	mso-pagination:widow-orphan;
+
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:DengXian;
+	mso-fareast-theme-font:minor-fareast;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:Arial;
+	mso-bidi-theme-font:minor-bidi;
+	mso-fareast-language:ZH-CN;}
+span.UnresolvedMention
+	{mso-style-name:"Unresolved Mention";
+	mso-style-priority:99;
+	mso-style-unhide:no;
+	color:gray;
+	background:#E6E6E6;}
+span.BalloonTextChar
+	{mso-style-name:"Balloon Text Char";
+	mso-style-noshow:yes;
+	mso-style-priority:99;
+	mso-style-unhide:no;
+	mso-style-locked:yes;
+	mso-style-link:"Balloon Text";
+	mso-ansi-
+	mso-bidi-
+	font-family:"Times New Roman";
+	mso-ascii-font-family:"Times New Roman";
+	mso-hansi-font-family:"Times New Roman";
+	mso-bidi-font-family:"Times New Roman";}
+span.SpellE
+	{mso-style-name:"";
+	mso-spl-e:yes;}
+span.GramE
+	{mso-style-name:"";
+	mso-gram-e:yes;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	mso-default-props:yes;
+	font-family:Calibri;
+	mso-ascii-font-family:Calibri;
+	mso-ascii-theme-font:minor-latin;
+	mso-fareast-font-family:DengXian;
+	mso-fareast-theme-font:minor-fareast;
+	mso-hansi-font-family:Calibri;
+	mso-hansi-theme-font:minor-latin;
+	mso-bidi-font-family:Arial;
+	mso-bidi-theme-font:minor-bidi;
+	mso-fareast-language:ZH-CN;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:72.0pt 72.0pt 72.0pt 72.0pt;
+	mso-header-margin:36.0pt;
+	mso-footer-margin:36.0pt;
+	mso-paper-source:0;}
+div.WordSection1
+	{page:WordSection1;}
+ /* List Definitions */
+@list l0
+	{mso-list-id:1760831832;
+	mso-list-type:hybrid;
+	mso-list-template-ids:2056441942 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l0:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	margin-left:38.65pt;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l0:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	margin-left:74.65pt;
+	text-indent:-18.0pt;
+	font-family:"Courier New";}
+@list l0:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	margin-left:110.65pt;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l0:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	margin-left:146.65pt;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l0:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	margin-left:182.65pt;
+	text-indent:-18.0pt;
+	font-family:"Courier New";}
+@list l0:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	margin-left:218.65pt;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l0:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	margin-left:254.65pt;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l0:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	margin-left:290.65pt;
+	text-indent:-18.0pt;
+	font-family:"Courier New";}
+@list l0:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	margin-left:326.65pt;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+ol
+	{margin-bottom:0cm;}
+ul
+	{margin-bottom:0cm;}
+
+div, p, a, .AppleFont {
+    font: -apple-system-body;
+}
+-->
+</style>
+</head>
+
+<body bgcolor=white lang=EN-US link=blue vlink="#954F72" style='tab-interval:
+36.0pt'>
+
+<div class=WordSection1>
+
+<p class=MsoNormal><span style='font-family:Arial;mso-fareast-font-family:
+"Times New Roman";color:#222222;background:white'>EDX END USER LICENSE
+AGREEMENT</span><span style='font-family:Arial;mso-fareast-font-family:
+"Times New Roman";color:#222222'><br>
+<br>
+<br>
+<span style='background:white'>THIS END USER LICENSE AGREEMENT (“EULA”) SETS
+FORTH THE TERMS AND CONDITIONS GOVERNING THE USE OF ANY EDX MOBILE APPLICATION DOWNLOADED
+OR OTHERWISE ACQUIRED BY YOU (THE “APPLICATION”) AS PROVIDED BY EDX INC. (“EDX”).&nbsp;</span><br>
+<br>
+<span style='background:white'>BY INSTALLING AND USING THIS APPLICATION, YOU
+AGREE TO BE BOUND BY THE TERMS AND CONDITIONS SET FORTH IN THIS EULA. YOUR USE
+OF THE APPLICATION IS SUBJECT TO:<o:p></o:p></span></span></p>
+
+<p class=MsoListParagraphCxSpFirst style='margin-left:38.65pt;mso-add-space:
+auto;text-indent:-18.0pt;mso-list:l0 level1 lfo1'><![if !supportLists]><span
+style='font-family:Symbol;mso-fareast-font-family:Symbol;
+mso-bidi-font-family:Symbol;color:#222222'><span style='mso-list:Ignore'>·<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><a
+href="https://www.edx.org/edx-terms-service"><span style='
+font-family:Arial;mso-fareast-font-family:"Times New Roman";background:white'>TERMS
+OF SERVICE AND HONOR CODE</span></a><span style='font-family:
+Arial;mso-fareast-font-family:"Times New Roman";color:#222222;background:white'>,<o:p></o:p></span></p>
+
+<p class=MsoListParagraphCxSpMiddle style='margin-left:38.65pt;mso-add-space:
+auto;text-indent:-18.0pt;mso-list:l0 level1 lfo1'><![if !supportLists]><span
+style='font-family:Symbol;mso-fareast-font-family:Symbol;
+mso-bidi-font-family:Symbol;color:#222222'><span style='mso-list:Ignore'>·<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><a
+href="https://www.edx.org/edx-privacy-policy"><span style='
+font-family:Arial;mso-fareast-font-family:"Times New Roman";background:white'>PRIVACY
+POLICY</span></a><span style='font-family:Arial;mso-fareast-font-family:
+"Times New Roman";color:#222222;background:white'>, AND<o:p></o:p></span></p>
+
+<p class=MsoListParagraphCxSpLast style='margin-left:38.65pt;mso-add-space:
+auto;text-indent:-18.0pt;mso-list:l0 level1 lfo1'><![if !supportLists]><span
+style='font-family:Symbol;mso-fareast-font-family:Symbol;
+mso-bidi-font-family:Symbol;color:#222222'><span style='mso-list:Ignore'>·<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white'>ALL OTHER AGREEMENTS AND POLICIES APPLICABLE TO
+YOU AT THE </span><a href="https://www.edx.org/"><span style='
+font-family:Arial;mso-fareast-font-family:"Times New Roman";background:white'>EDX
+WEBSITE</span></a><span style='font-family:Arial;mso-fareast-font-family:
+"Times New Roman";color:#222222;background:white'>.&nbsp; <o:p></o:p></span></p>
+
+<p class=MsoNormal><span style='font-family:Arial;mso-fareast-font-family:
+"Times New Roman";color:#222222;background:white'><o:p>&nbsp;</o:p></span></p>
+
+<p class=MsoNormal><span style='font-family:Arial;mso-fareast-font-family:
+"Times New Roman";color:#222222;background:white'>YOU ACKNOWLEDGE THAT THIS
+EULA IS ENTERED INTO BETWEEN YOU AND EDX. IF YOU DO NOT UNDERSTAND OR DO NOT
+WISH TO ACCEPT OR BE BOUND BY THE TERMS OF THIS EULA, DO NOT USE THIS
+APPLICATION.</span><span style='font-family:Arial;mso-fareast-font-family:
+"Times New Roman";color:#222222'><br>
+<br>
+<span style='background:white'>AS USED IN THIS EULA, “YOU” OR “YOUR” REFERS TO
+THE PERSON OR ENTITY WHO DOWNLOADS AND USES THE APPLICATION.&nbsp;
+ADDITIONALLY, EDX AND YOU ARE REFERRED TO COLLECTIVELY AS THE “PARTIES” AND
+INDIVIDUALLY AS A “PARTY.”</span><br>
+<br>
+<span style='background:white'>1.&nbsp; OWNERSHIP OF THE APPLICATION.&nbsp; All
+right, title, and interest in and to the Application and all improvements,
+additions, updates, supplements, derivatives and other modifications thereto are
+and shall remain the exclusive property of <span class=SpellE>edX</span> and/or
+its licensors. <span style="mso-spacerun:yes"> </span>You agree not to,
+directly or indirectly, disclose, sell or otherwise transfer or exploit the Application
+to any other person or entity or allow any other person or entity to use the Application
+without the prior written consent of <span class=SpellE>edX</span>, which may
+be withheld in <span class=SpellE>edX’s</span> sole discretion. You further
+agree not to challenge or assist with or participate in any challenge, directly
+or indirectly, or <span class=SpellE>edX’s</span> ownership of the Application or
+any right title or interest therein or any portion thereof. </span><br>
+<br>
+<span style='background:white'>2.&nbsp; GRANT OF LICENSE.&nbsp; <span
+class=SpellE>EdX</span> grants <span class=GramE>You</span> a personal,
+limited, non-exclusive, non-transferable, revocable license to install and use
+the Application in object code form on a single mobile device in accordance
+with the terms and conditions of this EULA. The Application is licensed, not
+sold, to <span class=GramE>You</span> by <span class=SpellE>edX</span>, and <span
+class=SpellE>edX</span> reserves all rights in the Application not expressly
+granted to You. <span class=SpellE>EdX</span> may do any of the following at
+any time, with or without notice or cause, and without any liability to <span
+class=GramE>You</span>: (a) change, suspend, or terminate any features or
+functionality on the Application; (b) impose limits on certain features or
+functionality on the Application; (c) terminate this EULA. <o:p></o:p></span></span></p>
+
+<p class=MsoNormal><span style='font-family:Arial;mso-fareast-font-family:
+"Times New Roman";color:#222222;background:white'><o:p>&nbsp;</o:p></span></p>
+
+<p class=MsoNormal><span style='font-family:Arial;mso-fareast-font-family:
+"Times New Roman";color:#222222;background:white'>Upon such termination or
+expiration, <span class=GramE>You</span> shall no longer be permitted to use
+the Application and shall immediately delete or destroy all copies of the
+Application from Your mobile device including all of its component parts.
+Modification, suspension, or termination of the Application or this EULA shall
+not entitle <span class=GramE>You</span> to any refund, credit, or other
+compensation from <span class=SpellE>edX</span> under this EULA or any other
+agreement or from any third party.<span style="mso-spacerun:yes">  </span>Without
+prejudice to any other rights, <span class=SpellE>edX</span> may terminate this
+EULA if <span class=GramE>You</span> fail to comply with the terms and
+conditions of the EULA.&nbsp; In such event, <span class=GramE>You</span> must
+immediately remove the Application from Your mobile device including all of its
+component parts</span><span style='font-family:Arial;
+mso-fareast-font-family:"Times New Roman";color:#222222'><br>
+<br>
+<span style='background:white'>3.&nbsp; <span class=GramE>RESTRICTIONS ON USE
+OF APPLICATION.</span><span style="mso-spacerun:yes">  </span>The License
+granted to <span class=GramE>You</span> may not be sublicensed, commercially
+distributed, or shared with any third party without the prior written consent
+of <span class=SpellE>edX</span>.&nbsp; Except as otherwise expressly granted
+hereunder, You shall not:&nbsp; (<span class=SpellE>i</span>) copy, distribute,
+reproduce, rent, lend, loan, or sublicense any portion of the Application; (ii)
+translate, adapt, modify, alter, or combine the Application with other
+applications or software, materials, or prepare derivative works based in whole
+or in part, on the Application; (iii) use the Application in a computer-based
+services business; (iv) following the initial download, transmit the
+Application over a network, by telephone, or electronically using any means; or
+(v) reverse engineer, decompile, disassemble, or otherwise reduce the
+Application or any of its subcomponents to a human-perceivable form.</span><br>
+<br>
+<span style='background:white'>4.&nbsp; EQUITABLE REMEDIES AND
+ENFORCEMENT.&nbsp; You acknowledge and agree that Your breach of any of the
+obligations set forth in Sections <span class=GramE>A(</span>1), A(2), A(3), and
+A(8) of this EULA shall cause <span class=SpellE>edX</span> irreparable injury
+and shall entitle <span class=SpellE>edX</span> to equitable relief or
+remedy.&nbsp; The pursuit or securing of any such equitable relief shall not
+prohibit or limit <span class=SpellE>edX</span> from seeking or obtaining any
+other remedy provided under this EULA or by law.&nbsp; If any or all of the
+above covenants or agreements are held to be unenforceable because of the scope
+or duration of such covenant or agreement or the area covered thereby, the
+Parties agree that the court making such determination shall have the power to
+reduce the scope, duration and area of such covenant or agreement to the extent
+that allows the maximum scope, duration and area permitted by applicable
+law.&nbsp; The covenants, agreements and remedies provided herein are in
+addition to, and are not to be construed as a replacement for or limited by,
+the rights and remedies otherwise available to <span class=SpellE>edX</span>
+including, but not limited to, those rights and remedies contained in the
+Uniform Trade Secrets Act, or its state counterparts.</span><br>
+<br>
+<span style='background:white'>5.&nbsp; DISCLAIMER OF WARRANTY.&nbsp; YOU
+EXPRESSLY ACKNOWLEDGE AND AGREE THAT USE OF THE APPLICATION IS AT YOUR SOLE
+RISK AND THAT THE ENTIRE RISK AS TO SATISFACTORY QUALITY, PERFORMANCE, ACCURACY
+AND EFFORT IS WITH YOU. EDX AND ITS LICENSORS, AGENTS, OFFICERS, DIRECTORS,
+EMPLOYEES, SUCCESSORS, ASSIGNS, AFFILIATES, AND MEMBERS PROVIDE THE APPLICATION
+“AS IS WITH ALL FAULTS” WITHOUT WARRANTY OF ANY KIND, AND EDX ON BEHALF OF
+ITSELF AND ITS LICENSORS AND EACH MEMBER HEREBY EXPRESSLY DISCLAIMS ANY EXPRESS
+OR IMPLIED WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, SATISFACTORY QUALITY, AND NON-INFRINGEMENT.&nbsp; EDX DOES NOT WARRANT
+AGAINST INTERFERENCE WITH YOUR ENJOYMENT OF THE APPLICATION, THAT THE FUNCTIONS
+CONTAINED IN THE APPLICATION WILL MEET YOUR REQUIREMENTS, THAT THE APPLICATION
+IS FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS, THAT THE OPERATION OF THE
+APPLICATION WILL BE UNINTERRUPTED OR ERROR-FREE, THAT DEFECTS IN THE
+APPLICATION WILL BE CORRECTED, OR THAT THE FUNCTIONS CONTAINED IN THE
+APPLICATION WILL FUNCTION WITH OTHER SOFTWARE OR HARDWARE, OR WITHIN A
+PARTICULAR SYSTEM.&nbsp; NO ORAL OR WRITTEN INFORMATION OR ADVICE GIVEN BY EDX,
+A MEMBER, OR AN EDX AUTHORIZED REPRESENTATIVE SHALL CREATE A WARRANTY. SHOULD
+THE APPLICATION PROVE DEFECTIVE, YOU ASSUME THE ENTIRE COST OF <span
+class=GramE>ALL NECESSARY</span> SERVICING, REPAIR, OR CORRECTION. SOME
+JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES OR LIMITATIONS
+ON APPLICABLE STATUTORY RIGHTS OF A CONSUMER, SO THE ABOVE EXCLUSION MAY NOT
+APPLY TO YOU.</span><br>
+<br>
+<span style='background:white'>6.&nbsp; LIMITATION OF LIABILITY.&nbsp; TO THE
+MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW AND REGARDLESS OF WHETHER ANY REMEDY
+FAILS OF ITS ESSENTIAL PURPOSE<span class=GramE>,&nbsp; IN</span> NO EVENT
+SHALL EDX OR ITS LICENSORS, AGENTS, OFFICERS, DIRECTORS, EMPLOYEES, SUCCESSORS,
+ASSIGNS, AFFILIATES OR MEMBERS BE LIABLE&nbsp; FOR PERSONAL INJURY, OR ANY
+INCIDENTAL, SPECIAL, INDIRECT, CONSEQUENTIAL, OR PUNITIVE DAMAGES, WHATSOEVER,
+INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF PROFITS, LOST TIME, LOST
+SAVINGS, LOSS OF DATA, DAMAGED DATA, INACCURATE DATA, FAILURE OF
+TELECOMMUNICATION SERVICES, LOST CONFIDENTIAL OR OTHER INFORMATION, OR FOR
+BUSINESS INTERRUPTION OR ANY OTHER COMMERCIAL DAMAGES OR LOSSES ARISING OUT OF
+OR RELATED TO YOUR USE OR INABILITY TO USE THE APPLICATION, HOWEVER CAUSED,
+REGARDLESS OF THE THEORY OF LIABILITY (TORT, CONTRACT OR OTHERWISE) AND EVEN IF
+EDX HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. SOME JURISDICTIONS DO
+NOT ALLOW THE LIMITATION OF LIABILITY FOR PERSONAL INJURY, OR OF INCIDENTAL OR
+CONSEQUENTIAL DAMAGES, SO THIS LIMITATION MAY NOT APPLY TO YOU.&nbsp; THE FOREGOING
+LIMITATIONS WILL APPLY EVEN IF THE ABOVE STATED REMEDY FAILS OF ITS ESSENTIAL
+PURPOSE.</span><br>
+<br>
+<span style='background:white'>7.&nbsp; INDEMNIFICATION.&nbsp; You agree to
+indemnify, hold harmless, and defend <span class=SpellE>edX</span>, its
+licensors, agents, officers, directors, employees, successors, assigns, affiliates,
+and Members, from and against any action, cause, claim, damage, debt, demand or
+liability, including reasonable costs and attorneys’ fees, asserted by any
+person, arising out of or relating to the breach of this EULA.</span><br>
+<br>
+<span style='background:white'>8.&nbsp; EXPORT RESTRICTIONS.&nbsp; You
+acknowledge that the Application is of U.S. origin, and agree to comply with
+all applicable international and national laws that apply to the Application,
+including the U.S. Export Administration Regulations, as well as end-user,
+end-use and country destination restrictions issued by the U.S. and other
+governments.</span><br>
+<br>
+<span style='background:white'>9.&nbsp; GOVERNMENT END USERS.&nbsp; If <span
+class=GramE>You</span> are acquiring the Application on behalf of any unit or
+agency of the United States Government, it is provided to the Government only
+with restricted rights and limited rights.&nbsp; Use, duplication, or
+disclosure by the Government is subject to restrictions set forth in FAR
+Sections 52-227-14 and 52-227-19 or DFARS Section 52.227-7013(C)(1)(ii), as
+applicable.&nbsp; The Application and Application documentation, if any, are
+&quot;Commercial Items,&quot; as that term is defined at 48 C.F.R. \A42.101,
+consisting of &quot;Commercial Computer Application&quot; and &quot;Commercial
+Computer Application Documentation,&quot; as such terms are used in 48 C.F.R.
+\A41 2.21 2 or 48 C.F.R. \A4227.7202, as applicable.</span><br>
+<br>
+<span style='background:white'>10.&nbsp; TERMINATION.&nbsp; Without prejudice
+to any other rights, <span class=SpellE>edX</span> may terminate this EULA if <span
+class=GramE>You</span> fail to comply with the terms and conditions of the EULA.&nbsp;
+In such event, <span class=GramE>You</span> must immediately remove the
+Application from Your mobile device including all of its component parts.</span><br>
+<br>
+<span style='background:white'>11.&nbsp; ENTIRE AGREEMENT.&nbsp; The EULA
+constitutes the entire agreement between the Parties related to the Application
+and supersedes any and all prior and contemporaneous oral or written
+understandings between the Parties relating to the subject matter hereof.</span><br>
+<br>
+<span style='background:white'>12<span class=GramE>.&nbsp; MODIFICATION</span>
+AND WAIVER.&nbsp; <span class=SpellE>EdX</span> reserves the right to modify this
+EULA at any time without advance notice to <span class=GramE>You</span>.&nbsp;</span></span><span
+lang=EN style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white;mso-ansi-language:EN'>Any changes to this EULA
+will be effective immediately for new and current users, with an updated
+effective date. By continuing to use the Application after any changes have
+been made, you signify your agreement on a prospective basis to the modified EULA
+and all of the changes. You should return to this EULA periodically to ensure
+familiarity with the most current version. </span><span style='
+font-family:Arial;mso-fareast-font-family:"Times New Roman";color:#222222;
+background:white'>Any waiver shall be limited to the circumstance or event
+specifically referenced in the written waiver document and shall not be deemed
+a waiver of any other term in this EULA or of the same circumstance or event
+upon any recurrence thereof.</span><span style='font-family:
+Arial;mso-fareast-font-family:"Times New Roman";color:#222222'><br>
+<br>
+<span style='background:white'>13.&nbsp; BINDING EFFECT; VALIDITY.&nbsp; This EULA
+shall be binding upon and inure to the benefit of the Parties’ respective
+successors or assigns. If any part of this </span></span><span lang=EN
+style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white;mso-ansi-language:EN'>EULA </span><span
+style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white'>is determined to be invalid or unenforceable by
+a court of competent jurisdiction or by any other legal constituted body having
+the jurisdiction to make such determination, the remainder of this </span><span
+lang=EN style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white;mso-ansi-language:EN'>EULA </span><span
+style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white'>shall remain in full force and effect.</span><span
+style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222'><br>
+<br>
+<span style='background:white'>14.&nbsp; GOVERNING LAW AND JURISDICTION.&nbsp;
+This </span></span><span lang=EN style='font-family:Arial;
+mso-fareast-font-family:"Times New Roman";color:#222222;background:white;
+mso-ansi-language:EN'>EULA </span><span class=GramE><span style='font-family:Arial;mso-fareast-font-family:"Times New Roman";color:#222222;
+background:white'>shall be deemed to have been made in the Commonwealth of
+Massachusetts and shall be governed by, construed, and</span></span><span
+style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white'> interpreted in accordance with the laws of the
+Commonwealth of Massachusetts.&nbsp;With respect to any dispute, controversy,
+or claim arising out of or relating to this </span><span lang=EN
+style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white;mso-ansi-language:EN'>EULA </span><span
+style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white'>or the relationship between the Parties, the
+Parties agree and consent to jurisdiction of and exclusive venue in the United
+States District Court, District of Massachusetts, <span class=GramE>Boston</span>
+Division or in the Boston Municipal Court.&nbsp;The </span><span class=GramE><span
+lang=EN style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white;mso-ansi-language:EN'>EULA </span><span
+style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white'>shall not be governed by the United Nations
+Convention on Contracts for the International Sale of Goods, the application of
+which is hereby expressly excluded</span></span><span style='
+font-family:Arial;mso-fareast-font-family:"Times New Roman";color:#222222;
+background:white'>.&nbsp;You hereby expressly waive <span class=GramE>Your</span>
+right to trial by jury.</span><span style='font-family:Arial;
+mso-fareast-font-family:"Times New Roman";color:#222222'><br>
+<br>
+<span style='background:white'>15.&nbsp; NO THIRD-PARTY BENEFICIARIES.&nbsp;
+Use of the Application is for <span class=GramE>Your</span> personal
+benefit.&nbsp; This </span></span><span lang=EN style='
+font-family:Arial;mso-fareast-font-family:"Times New Roman";color:#222222;
+background:white;mso-ansi-language:EN'>EULA </span><span style='
+font-family:Arial;mso-fareast-font-family:"Times New Roman";color:#222222;
+background:white'>does not&nbsp;confer any rights to any other person or entity
+as a third-party beneficiary or otherwise.</span><span style='
+font-family:Arial;mso-fareast-font-family:"Times New Roman";color:#222222'><br>
+<br>
+<span style='background:white'>16.&nbsp; HEADINGS.&nbsp; The headings of this </span></span><span
+lang=EN style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white;mso-ansi-language:EN'>EULA </span><span
+style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white'>are for the purpose of reference only and shall
+not in any way limit or affect the meaning or interpretation of any of the
+terms hereof.</span><span style='font-family:Arial;mso-fareast-font-family:
+"Times New Roman";color:#222222'><br>
+<br>
+<span style='background:white'>17.&nbsp; DATE.&nbsp; This </span></span><span
+lang=EN style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white;mso-ansi-language:EN'>EULA </span><span
+style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222;background:white'>was last updated on May 25, 2018.</span><span
+style='font-family:Arial;mso-fareast-font-family:"Times New Roman";
+color:#222222'><br>
+<br>
+<br>
+<br style='mso-special-character:line-break'>
+<![if !supportLineBreakNewLine]><br style='mso-special-character:line-break'>
+<![endif]></span><span style='font-family:"Times New Roman";mso-fareast-font-family:
+"Times New Roman"'><o:p></o:p></span></p>
+
+<p class=MsoNormal><o:p>&nbsp;</o:p></p>
+
+</div>
+
+</body>
+
+</html>

--- a/Source/ja.lproj/PrivacyPolicy.htm
+++ b/Source/ja.lproj/PrivacyPolicy.htm
@@ -1,0 +1,2423 @@
+<html>
+
+<head>
+<meta http-equiv=Content-Type content="text/html; charset=utf-8">
+<meta name=ProgId content=Word.Document>
+<meta name=Generator content="Microsoft Word 14">
+<meta name=Originator content="Microsoft Word 14">
+<link rel=File-List href="PrivacyPolicy_en_files/filelist.xml">
+<link rel=themeData href="PrivacyPolicy_en_files/themedata.xml">
+<!--[if gte mso 9]><xml>
+ <w:WordDocument>
+  <w:SpellingState>Clean</w:SpellingState>
+  <w:GrammarState>Clean</w:GrammarState>
+  <w:TrackMoves/>
+  <w:TrackFormatting/>
+  <w:PunctuationKerning/>
+  <w:ValidateAgainstSchemas/>
+  <w:SaveIfXMLInvalid>false</w:SaveIfXMLInvalid>
+  <w:IgnoreMixedContent>false</w:IgnoreMixedContent>
+  <w:AlwaysShowPlaceholderText>false</w:AlwaysShowPlaceholderText>
+  <w:DoNotPromoteQF/>
+  <w:LidThemeOther>EN-US</w:LidThemeOther>
+  <w:LidThemeAsian>ZH-CN</w:LidThemeAsian>
+  <w:LidThemeComplexScript>AR-SA</w:LidThemeComplexScript>
+  <w:Compatibility>
+   <w:BreakWrappedTables/>
+   <w:SnapToGridInCell/>
+   <w:WrapTextWithPunct/>
+   <w:UseAsianBreakRules/>
+   <w:DontGrowAutofit/>
+   <w:SplitPgBreakAndParaMark/>
+   <w:EnableOpenTypeKerning/>
+   <w:DontFlipMirrorIndents/>
+   <w:OverrideTableStyleHps/>
+  </w:Compatibility>
+  <m:mathPr>
+   <m:mathFont m:val="Cambria Math"/>
+   <m:brkBin m:val="before"/>
+   <m:brkBinSub m:val="&#45;-"/>
+   <m:smallFrac m:val="off"/>
+   <m:dispDef/>
+   <m:lMargin m:val="0"/>
+   <m:rMargin m:val="0"/>
+   <m:defJc m:val="centerGroup"/>
+   <m:wrapIndent m:val="1440"/>
+   <m:intLim m:val="subSup"/>
+   <m:naryLim m:val="undOvr"/>
+  </m:mathPr></w:WordDocument>
+</xml><![endif]--><!--[if gte mso 9]><xml>
+ <w:LatentStyles DefLockedState="false" DefUnhideWhenUsed="true"
+  DefSemiHidden="true" DefQFormat="false" DefPriority="99"
+  LatentStyleCount="276">
+  <w:LsdException Locked="false" Priority="0" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Normal"/>
+  <w:LsdException Locked="false" Priority="9" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="heading 1"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 2"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 3"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 4"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 5"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 6"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 7"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 8"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 9"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 1"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 2"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 3"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 4"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 5"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 6"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 7"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 8"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 9"/>
+  <w:LsdException Locked="false" Priority="35" QFormat="true" Name="caption"/>
+  <w:LsdException Locked="false" Priority="10" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Title"/>
+  <w:LsdException Locked="false" Priority="1" Name="Default Paragraph Font"/>
+  <w:LsdException Locked="false" Priority="11" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Subtitle"/>
+  <w:LsdException Locked="false" Priority="22" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Strong"/>
+  <w:LsdException Locked="false" Priority="20" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Emphasis"/>
+  <w:LsdException Locked="false" Priority="39" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Table Grid"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 1"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 2"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 3"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 4"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 5"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 6"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 7"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 8"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 9"/>
+  <w:LsdException Locked="false" UnhideWhenUsed="false" Name="Placeholder Text"/>
+  <w:LsdException Locked="false" Priority="1" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="No Spacing"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 1"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 1"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 1"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 1"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 1"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 1"/>
+  <w:LsdException Locked="false" UnhideWhenUsed="false" Name="Revision"/>
+  <w:LsdException Locked="false" Priority="34" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="List Paragraph"/>
+  <w:LsdException Locked="false" Priority="29" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Quote"/>
+  <w:LsdException Locked="false" Priority="30" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Intense Quote"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 1"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 1"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 1"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 1"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 1"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 1"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 1"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 1"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 2"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 2"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 2"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 2"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 2"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 2"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 2"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 2"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 2"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 2"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 2"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 2"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 2"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 2"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 3"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 3"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 3"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 3"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 3"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 3"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 3"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 3"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 3"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 3"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 3"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 3"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 3"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 3"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 4"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 4"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 4"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 4"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 4"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 4"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 4"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 4"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 4"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 4"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 4"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 4"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 4"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 4"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 5"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 5"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 5"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 5"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 5"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 5"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 5"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 5"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 5"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 5"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 5"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 5"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 5"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 5"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 6"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 6"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 6"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 6"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 6"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 6"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 6"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 6"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 6"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 6"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 6"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 6"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 6"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 6"/>
+  <w:LsdException Locked="false" Priority="19" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Subtle Emphasis"/>
+  <w:LsdException Locked="false" Priority="21" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Intense Emphasis"/>
+  <w:LsdException Locked="false" Priority="31" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Subtle Reference"/>
+  <w:LsdException Locked="false" Priority="32" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Intense Reference"/>
+  <w:LsdException Locked="false" Priority="33" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Book Title"/>
+  <w:LsdException Locked="false" Priority="37" Name="Bibliography"/>
+  <w:LsdException Locked="false" Priority="39" QFormat="true" Name="TOC Heading"/>
+ </w:LatentStyles>
+</xml><![endif]-->
+<style>
+<!--
+ /* Font Definitions */
+@font-face
+	{font-family:Arial;
+	panose-1:2 11 6 4 2 2 2 2 2 4;
+	mso-font-charset:0;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:3 0 0 0 1 0;}
+@font-face
+	{font-family:"Courier New";
+	panose-1:2 7 3 9 2 2 5 2 4 4;
+	mso-font-charset:0;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:3 0 0 0 1 0;}
+@font-face
+	{font-family:Wingdings;
+	panose-1:5 0 0 0 0 0 0 0 0 0;
+	mso-font-charset:2;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:0 268435456 0 0 -2147483648 0;}
+@font-face
+	{font-family:Wingdings;
+	panose-1:5 0 0 0 0 0 0 0 0 0;
+	mso-font-charset:2;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:0 268435456 0 0 -2147483648 0;}
+ /* Style Definitions */
+p."MsoNormal AppleFont", li."MsoNormal AppleFont", div."MsoNormal AppleFont"
+	{mso-style-unhide:no;
+	mso-style-parent:"";
+	margin:0cm;
+	margin-bottom:.0001pt;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+
+	font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+h1
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:20.0pt;
+	margin-right:0cm;
+	margin-bottom:6.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+	mso-outline-level:1;
+
+	font-family:Arial;
+	mso-font-kerning:0pt;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;
+	font-weight:normal;}
+h2
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:18.0pt;
+	margin-right:0cm;
+	margin-bottom:6.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+	mso-outline-level:2;
+
+	font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;
+	font-weight:normal;}
+h3
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:16.0pt;
+	margin-right:0cm;
+	margin-bottom:4.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+	mso-outline-level:3;
+
+	font-family:Arial;
+	color:#434343;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;
+	font-weight:normal;}
+h4
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:14.0pt;
+	margin-right:0cm;
+	margin-bottom:4.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+	mso-outline-level:4;
+
+	font-family:Arial;
+	color:#666666;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;
+	font-weight:normal;}
+h5
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:12.0pt;
+	margin-right:0cm;
+	margin-bottom:4.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+	mso-outline-level:5;
+
+	font-family:Arial;
+	color:#666666;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;
+	font-weight:normal;}
+h6
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:12.0pt;
+	margin-right:0cm;
+	margin-bottom:4.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+	mso-outline-level:6;
+
+	font-family:Arial;
+	color:#666666;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;
+	font-weight:normal;
+	font-style:italic;
+	mso-bidi-font-style:normal;}
+p.MsoTitle, li.MsoTitle, div.MsoTitle
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:3.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+
+	font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+p.MsoSubtitle, li.MsoSubtitle, div.MsoSubtitle
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:16.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+
+	font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	color:#666666;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+a:link, span.MsoHyperlink
+	{mso-style-priority:99;
+	color:blue;
+	mso-themecolor:hyperlink;
+	text-decoration:underline;
+	text-underline:single;}
+a:visited, span.MsoHyperlinkFollowed
+	{mso-style-noshow:yes;
+	mso-style-priority:99;
+	color:purple;
+	mso-themecolor:followedhyperlink;
+	text-decoration:underline;
+	text-underline:single;}
+p.MsoListParagraph, li.MsoListParagraph, div.MsoListParagraph
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:0cm;
+	margin-left:36.0pt;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+
+	font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+p.MsoListParagraphCxSpFirst, li.MsoListParagraphCxSpFirst, div.MsoListParagraphCxSpFirst
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-type:export-only;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:0cm;
+	margin-left:36.0pt;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+
+	font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+p.MsoListParagraphCxSpMiddle, li.MsoListParagraphCxSpMiddle, div.MsoListParagraphCxSpMiddle
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-type:export-only;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:0cm;
+	margin-left:36.0pt;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+
+	font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+p.MsoListParagraphCxSpLast, li.MsoListParagraphCxSpLast, div.MsoListParagraphCxSpLast
+	{mso-style-priority:34;
+	mso-style-unhide:no;
+	mso-style-qformat:yes;
+	mso-style-type:export-only;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:0cm;
+	margin-left:36.0pt;
+	margin-bottom:.0001pt;
+	mso-add-space:auto;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+
+	font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+span.UnresolvedMention
+	{mso-style-name:"Unresolved Mention";
+	mso-style-noshow:yes;
+	mso-style-priority:99;
+	color:gray;
+	background:#E6E6E6;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	mso-default-props:yes;
+
+	mso-ansi-
+	mso-bidi-
+	font-family:Arial;
+	mso-ascii-font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-hansi-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+.MsoPapDefault
+	{mso-style-type:export-only;
+	line-height:115%;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:72.0pt 72.0pt 72.0pt 72.0pt;
+	mso-header-margin:0cm;
+	mso-footer-margin:36.0pt;
+	mso-page-numbers:1;
+	mso-paper-source:0;}
+div.WordSection1
+	{page:WordSection1;}
+ /* List Definitions */
+@list l0
+	{mso-list-id:296179631;
+	mso-list-type:hybrid;
+	mso-list-template-ids:903648712 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l0:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l0:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l0:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l0:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l0:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l0:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l0:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l0:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l0:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l1
+	{mso-list-id:625428211;
+	mso-list-type:hybrid;
+	mso-list-template-ids:709394912 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l1:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l1:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l1:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l1:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l1:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l1:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l1:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l1:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l1:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l2
+	{mso-list-id:855264675;
+	mso-list-type:hybrid;
+	mso-list-template-ids:2069147862 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l2:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l2:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l2:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l2:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l2:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l2:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l2:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l2:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l2:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l3
+	{mso-list-id:946157629;
+	mso-list-type:hybrid;
+	mso-list-template-ids:-2023688002 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l3:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l3:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l3:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l3:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l3:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l3:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l3:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l3:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l3:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l4
+	{mso-list-id:1197503869;
+	mso-list-type:hybrid;
+	mso-list-template-ids:115746502 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l4:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l4:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l4:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l4:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l4:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l4:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l4:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l4:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l4:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l5
+	{mso-list-id:1332296179;
+	mso-list-type:hybrid;
+	mso-list-template-ids:-756501606 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l5:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l5:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l5:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l5:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l5:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l5:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l5:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l5:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l5:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l6
+	{mso-list-id:1458331043;
+	mso-list-type:hybrid;
+	mso-list-template-ids:-933344802 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l6:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l6:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l6:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l6:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l6:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l6:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l6:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l6:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l6:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l7
+	{mso-list-id:1826584579;
+	mso-list-type:hybrid;
+	mso-list-template-ids:-1429021940 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l7:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l7:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l7:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l7:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l7:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l7:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l7:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l7:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l7:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l8
+	{mso-list-id:1877738044;
+	mso-list-type:hybrid;
+	mso-list-template-ids:-1169157652 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l8:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l8:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l8:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l8:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l8:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l8:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l8:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l8:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l8:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l9
+	{mso-list-id:1977097793;
+	mso-list-type:hybrid;
+	mso-list-template-ids:863167114 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l9:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l9:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l9:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l9:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l9:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l9:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l9:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l9:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l9:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l10
+	{mso-list-id:2019040100;
+	mso-list-type:hybrid;
+	mso-list-template-ids:-50978524 67698689 67698691 67698693 67698689 67698691 67698693 67698689 67698691 67698693;}
+@list l10:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l10:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l10:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l10:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l10:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l10:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+@list l10:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Symbol;}
+@list l10:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:o;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:"Courier New";
+	mso-bidi-font-family:"Courier New";}
+@list l10:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	font-family:Wingdings;}
+ol
+	{margin-bottom:0cm;}
+ul
+	{margin-bottom:0cm;}
+
+div, p, a, .AppleFont {
+    font: -apple-system-body;
+}
+-->
+</style>
+</head>
+
+<body lang=EN-US link=blue vlink=purple style='tab-interval:36.0pt'>
+
+<div class=WordSection1>
+
+<p class="MsoNormal AppleFont" style='margin-right:15.0pt'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='line-height:115%;color:#050505'>NOTICE:
+On May 25, 2018, edX adopted an amended Privacy Policy, providing as follows:</span></b></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'><span
+style="mso-spacerun:yes"> </span></span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+and each </span><span lang=EN><a href="#Member"><span style='
+line-height:115%'>Member</span></a></span><span lang=EN style='
+line-height:115%;color:black;mso-themecolor:text1'> </span><span lang=EN
+style='line-height:115%'>that provides courses through the </span><span
+lang=EN><a href="#EdXSite"><span style='line-height:115%'>edX
+Site</span></a></span><span lang=EN style='line-height:115%;
+color:black;mso-themecolor:text1'> </span><span lang=EN style='
+line-height:115%'>care about the confidentiality and security of your
+information. This Privacy Policy applies to information that edX collects
+through the <span style='color:black;mso-themecolor:text1'>edX Site</span> when
+you interact with edX, with Members, with other users, and generally with the
+edX Site.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>Your
+information is received and controlled by edX according to this Privacy Policy
+when you sign up for an edX account or otherwise use the edX Site.</span></p>
+
+<p class="MsoNormal AppleFont" style='margin-left:72.0pt;text-indent:-36.0pt'><span
+lang=EN style='line-height:115%'>★ <span style='mso-tab-count:
+1'>        </span><i style='mso-bidi-font-style:normal'>EdX is solely and
+independently responsible for its own privacy practices. No Member is
+responsible for edX’s privacy practices.</i></span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>If
+you enroll in a course offered by a Member through the edX Site, information
+about you and your activity in the course is received and controlled also by
+that Member as described in this Privacy Policy.</span></p>
+
+<p class="MsoNormal AppleFont" style='margin-left:72.0pt;text-indent:-36.0pt'><span
+lang=EN style='line-height:115%'>★ <span style='mso-tab-count:
+1'>        </span><i style='mso-bidi-font-style:normal'>Each Member is solely
+and independently responsible for its own privacy practices. No Member is
+responsible for another Member’s privacy practices. Also, edX is not
+responsible for any Member’s privacy practices.</i></span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>If
+you do not accept the terms of this Privacy Policy, then please do not access,
+browse, or register for the edX Site or enroll in any courses. If you choose
+not to provide certain information required to provide you with various
+products and services offered on the edX Site, then you may not be able to
+establish a user account or obtain those products or services.</span></p>
+
+<div style='border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm'>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='line-height:115%;background:white;mso-highlight:white'>Any version of
+this Privacy Policy in a language other than English is provided for
+convenience and you understand and agree that the English language version will
+control if there is any conflict.</span><span lang=EN style='
+line-height:115%'> </span></p>
+
+</div>
+
+<p class="MsoNormal AppleFont"><b style='mso-bidi-font-weight:normal'><span lang=EN
+style='line-height:115%'>This Privacy Policy is organized as
+follows:</span></b></p>
+
+<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN><a href="#InfoThatEdxCollects"><span style='
+line-height:115%'>Information that edX collects from you</span></a></span><span
+lang=EN style='line-height:115%;color:black;mso-themecolor:
+text1'> </span><span lang=EN style='line-height:115%'>(including
+</span><span lang=EN><a href="#PersonalInformation"><span style='line-height:115%'>Personal Information</span></a></span><span lang=EN
+style='line-height:115%'>)</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol;'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN><a href="#CookiesTrackingTechnologies"><span style='
+line-height:115%'>Cookies and Tracking Technologies on the edX Site</span></a></span><u><span
+lang=EN style='line-height:115%;color:#1155CC'></span></u></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol;'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN><a href="#HowYourInformationIsUsed"><span style='
+line-height:115%'>How your information is used</span></a></span><span lang=EN
+style='line-height:115%;color:#1155CC'></span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol;'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN><a href="#HowYourInformationIsShared"><span style='
+line-height:115%'>How your information is shared</span></a></span><span
+lang=EN style='line-height:115%;color:#1155CC'></span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol;'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN><a href="#HowToManageYourPersonalInformation"><span style='line-height:115%'>How to manage your Personal Information</span></a></span><span
+lang=EN style='line-height:115%;color:#1155CC'></span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol;'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN><a href="#StorageSecurity"><span style='line-height:
+115%'>Storage &amp; Security</span></a></span><span lang=EN style='line-height:115%;color:#1155CC'></span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol;'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN><a href="#PrivacyPolicyUpdates"><span style='
+line-height:115%'>Privacy Policy updates</span></a></span><span lang=EN
+style='line-height:115%;color:#1155CC'></span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol;'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN><a href="#ContactInfo"><span style='line-height:115%'>Contact
+information</span></a></span><span lang=EN style='line-height:
+115%;color:#1155CC'></span></p>
+
+<p class=MsoListParagraphCxSpLast style='text-indent:-18.0pt;mso-list:l0 level1 lfo1'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol;'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN><a href="#Glossary"><span style='line-height:115%'>Glossary</span></a></span><span
+lang=EN style='line-height:115%;color:#1155CC'></span></p>
+
+<p class="MsoNormal AppleFont"><a name=InfoThatEdxCollects><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='line-height:115%'>INFORMATION
+THAT EDX COLLECTS FROM YOU (INCLUDING PERSONAL INFORMATION)</span></b></a><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'></span></b></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+directly collects information when you:</span></p>
+
+<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l1 level1 lfo2'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>sign up for an edX user
+account and create an edX user profile;</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l1 level1 lfo2'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>enroll and participate in
+online courses;</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l1 level1 lfo2'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>purchase a product or service
+(for example, </span><span lang=EN><a href="#VerifiedCertificate"><span
+style='line-height:115%'>Verified Certificates</span></a></span><span
+lang=EN style='line-height:115%'>);</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l1 level1 lfo2'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>send email messages to edX
+(including messages to learner support);</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l1 level1 lfo2'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>participate in user surveys;
+and</span></p>
+
+<p class=MsoListParagraphCxSpLast style='text-indent:-18.0pt;mso-list:l1 level1 lfo2'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>participate in public forums,
+webinars, and other interactive experiences on the </span><span lang=EN><a
+href="#EdXSite"><span style='line-height:115%'>edX Site</span></a></span><span
+lang=EN style='line-height:115%'>.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+also indirectly collects usage information about your visit to the edX Site, as
+explained in the section below titled </span><span lang=EN><a
+href="#CookiesTrackingTechnologies"><span style='line-height:
+115%'>Cookies and Tracking Technologies</span></a></span><span lang=EN
+style='line-height:115%'>.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+does not itself collect or store financial account numbers or identification
+issued by a governmental entity, employer, or other authority. Instead, if you
+choose to make a purchase on the edX Site, for example a Verified Certificate,
+you will be directed to edX’s third-party payment processor and edX’s
+third-party ID verification service provider. If you do not wish to submit the
+required authentication or payment information, then you will not be able to
+obtain a certificate via the edX Site.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+requires your </span><span lang=EN><a href="#PersonalInformation"><span
+style='line-height:115%'>Personal Information</span></a></span><span
+lang=EN style='line-height:115%;color:black;mso-themecolor:
+text1'> </span><span lang=EN style='line-height:115%'>only in
+limited circumstances when you:</span></p>
+
+<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l4 level1 lfo3'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>sign up for an edX user
+account (name, username, email address);</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l4 level1 lfo3'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>purchase a Verified
+Certificate (so that edX’s third-party vendor can authenticate your identity)
+or other product or service (so that edX’s third-party vendor can process
+payment);</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l4 level1 lfo3'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>participate in remote
+proctoring or other course facilitation processes (so that edX’s third-party
+vendor can monitor and assess the integrity of your course activity); or</span></p>
+
+<p class=MsoListParagraphCxSpLast style='text-indent:-18.0pt;mso-list:l4 level1 lfo3'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>earn a Verified Certificate
+(the certificate will have your name on it).</span></p>
+
+<p class="MsoNormal AppleFont"><a name=ToTheExtentThatEdXAssociateInfo><b style='mso-bidi-font-weight:
+normal'><i style='mso-bidi-font-style:normal'><span lang=EN style='line-height:115%'>To the extent that edX associates </span></i></b></a><b
+style='mso-bidi-font-weight:normal'><i style='mso-bidi-font-style:normal'><span
+lang=EN style='line-height:115%'>the information that edX
+collects directly or indirectly with an individual (for example, you), the
+association is based on Personal Information in your account profile.</span></i></b></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>You
+may voluntarily choose to share additional Personal Information on the edX
+Site, for example:</span></p>
+
+<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l7 level1 lfo4'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>in your edX account profile
+(and you may display a limited or full profile to other edX Site users);</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l7 level1 lfo4'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>in applying for financial
+assistance; or</span></p>
+
+<p class=MsoListParagraphCxSpLast style='text-indent:-18.0pt;mso-list:l7 level1 lfo4'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>when participating in a
+course, forum, webinar, or other interactive experience on the edX Site (noting
+that in some cases, this information is </span><span lang=EN><a
+href="#WithServiceProviders"><span style='line-height:115%'>shared
+with a third party</span></a></span><span lang=EN style='
+line-height:115%'> that provides tools or other assistance for the edX Site or
+a course).</span></p>
+
+<p class="MsoNormal AppleFont"><i style='mso-bidi-font-style:normal'><span lang=EN
+style='line-height:115%'>EdX encourages you to use discretion
+before voluntarily sharing additional Personal Information on the edX Site. (If
+you later choose to delete your edX account, </span></i><span lang=EN><a
+href="#DeleteAccount"><i style='mso-bidi-font-style:normal'><span
+style='line-height:115%'>deletion of your Personal Information</span></i></a></span><i
+style='mso-bidi-font-style:normal'><span lang=EN style='
+line-height:115%;color:black;mso-themecolor:text1'> </span></i><i
+style='mso-bidi-font-style:normal'><span lang=EN style='
+line-height:115%'>will be subject to the process and limits outlined below.)</span></i></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN><a href="#Member"><span style='
+line-height:115%'>Members</span></a></span><span lang=EN style='
+line-height:115%;color:black;mso-themecolor:text1'> </span><span lang=EN
+style='line-height:115%'>do not receive your Personal
+Information unless and until you enroll in a course. If you enroll in a course,
+the Member that offers the course will receive Personal Information from your
+edX account profile plus the information that edX collects about your activity
+and performance in the course in which you enrolled.</span></p>
+
+<p class="MsoNormal AppleFont"><a name=CookiesTrackingTechnologies><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='line-height:115%'>COOKIES AND
+TRACKING TECHNOLOGIES ON THE EDX SITE</span></b></a></p>
+
+<span style='mso-bookmark:CookiesTrackingTechnologies'></span>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>Like
+many companies, edX uses </span><span lang=EN><a href="#Cookies"><span
+style='line-height:115%'>Cookies</span></a></span><span
+lang=EN style='line-height:115%;color:black;mso-themecolor:
+text1'> </span><span lang=EN style='line-height:115%'>and
+other common </span><span lang=EN><a href="#TrackingTechnologies"><span
+style='line-height:115%'>Tracking Technologies</span></a></span><span
+lang=EN style='line-height:115%;color:black;mso-themecolor:
+text1'> </span><span lang=EN style='line-height:115%'>on the </span><span
+lang=EN><a href="#EdXSite"><span style='line-height:115%'>edX
+Site</span></a></span><span lang=EN style='line-height:115%;
+color:black;mso-themecolor:text1'> </span><span lang=EN style='
+line-height:115%'>and in email communications to help edX better understand
+your use and needs of the edX Site, current and future edX-related products and
+services, and how edX and Members can improve. For example:</span></p>
+
+<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l10 level1 lfo5'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>based on your cookie
+settings, edX tracks information indicating, among other things, which pages of
+the edX Site were visited, the order in which they were visited, when they were
+visited, and which hyperlinks and other user interface controls were used;</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l10 level1 lfo5'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>edX may log the IP address,
+operating system, and browser software (including mobile use and device type
+when you use edX native mobile apps) you used when accessing the edX Site, and
+edX may be able to determine from an IP address your Internet Service Provider
+and the geographic location of your point of connectivity; and</span></p>
+
+<p class=MsoListParagraphCxSpLast style='text-indent:-18.0pt;mso-list:l10 level1 lfo5'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>edX may track and collect
+information from emails that edX sends to you, for example whether you opened
+the email or clicked on any links from the email.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+also partners with third parties to help us track and understand your activity
+on the edX Site, how you interact with edX’s social media, and how you find or
+may be referred to the edX Site. Individual Members may separately use Tracking
+Technologies within their courses and email communications to understand your
+activity within a course and how you find or may be referred to a course on the
+edX Site.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+and Members use Cookies and other Tracking Technologies for the following
+purposes:</span></p>
+
+<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l3 level1 lfo6'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>when necessary for system
+administration, security, and integrity to ensure the edX Site works properly
+for you. Without these technologies, the edX Site may not function correctly;</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l3 level1 lfo6'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>to enable analytics,
+performance and functionality, to help edX and Members gather information about
+how visitors use the edX Site and monitor edX Site performance, and to enhance
+your experience by recognizing and remembering whether you have visited the edX
+Site before and may have any personal preferences; and</span></p>
+
+<p class=MsoListParagraphCxSpLast style='text-indent:-18.0pt;mso-list:l3 level1 lfo6'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>to support marketing by
+enabling edX and Members to deliver content relevant to your interests on the
+edX Site and third-party sites based on how you interact with edX or Member
+advertisements or content. EdX and Members use “first-party” cookies, which
+means cookies served by edX or an individual Member, and also “third-party”
+cookies, which means cookies served by third parties that help edX and Members
+track this information.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>You
+have some options for managing Cookies and other Tracking Technologies. These
+include:</span></p>
+
+<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l8 level1 lfo7'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><u><span
+lang=EN style='line-height:115%'>Modifying your browser
+settings</span></u><span lang=EN style='line-height:115%'>:
+You should be able to control how and whether your web browser accepts Cookies
+by adjusting its privacy and security settings. The “help” feature of the menu
+bar on most browsers will tell you how to stop accepting new Cookies, how to
+receive notification of new Cookies, and how to disable existing Cookies. If
+you reject edX’s Cookies, many functions and conveniences of the edX Site may
+not work properly.</span></p>
+
+<p class=MsoListParagraphCxSpLast style='text-indent:-18.0pt;mso-list:l8 level1 lfo7'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><u><span
+lang=EN style='line-height:115%'>Opting-out of certain
+third-party tracking and advertising</span></u><span lang=EN style='line-height:115%'>: Some of the third parties used by edX or a Member
+for Cookies and Tracking Technologies offer the ability to opt-out from their
+tracking by following processes described on their websites. A list of some
+such third parties is maintained and available at the </span><span lang=EN><a
+href="https://support.edx.org/hc/en-us"><span style='
+line-height:115%'>edX learner Help Center</span></a></span><span lang=EN
+style='line-height:115%'> and includes, for some, links to
+applicable opt-out processes. Neither edX nor any Member is responsible for the
+effectiveness of any third-party opt-out options.</span></p>
+
+<p class="MsoNormal AppleFont"><a name=HowYourInformationIsUsed><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='line-height:115%'>HOW YOUR
+INFORMATION IS USED</span></b></a></p>
+
+<span style='mso-bookmark:HowYourInformationIsUsed'></span>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+and </span><span lang=EN><a href="#Member"><span style='
+line-height:115%'>Members</span></a></span><span lang=EN style='
+line-height:115%;color:black;mso-themecolor:text1'> </span><span lang=EN
+style='line-height:115%'>use information, including </span><span
+lang=EN><a href="#PersonalInformation"><span style='
+line-height:115%'>Personal Information</span></a></span><span lang=EN
+style='line-height:115%'>, to carry out the following
+purposes:</span></p>
+
+<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l5 level1 lfo8'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>Operate and improve the edX Site</span></b><span lang=EN
+style='line-height:115%'> – This includes creating and
+improving features that support the edX community and enable </span><span
+lang=EN><a href="#EdXSite"><span style='line-height:115%'>edX
+Site</span></a></span><span lang=EN style='line-height:115%;
+color:black;mso-themecolor:text1'> </span><span lang=EN style='
+line-height:115%'>usage at scale. This also includes personalizing the edX
+Site, so your learning experience is tailored to your interests and needs.</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l5 level1 lfo8'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>Create, administer, provide, and teach courses</span></b><span
+lang=EN style='line-height:115%'> – This includes creating and
+improving the delivery of massive open online courses and programs on edX. This
+also includes personalizing courses, so your learning experience is tailored to
+your interests and needs, and assessing your performance and awarding
+certificates.</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l5 level1 lfo8'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>Offer and improve products and services</span></b><span
+lang=EN style='line-height:115%'> – This includes enabling you
+to navigate the edX Site, to enroll and participate in courses and programs on
+the edX Site, to learn effectively in such courses and programs, and to
+purchase or obtain products and services on the edX Site such as Verified
+Certificates.</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l5 level1 lfo8'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>Develop and maintain the security and performance of the edX
+Site</span></b><span lang=EN style='line-height:115%'> – This
+includes tracking edX Site outages and creating software solutions, detecting
+violations of the Honor Code and Terms of Service, and monitoring uses,
+misuses, and potential misuses of the edX Site.</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l5 level1 lfo8'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>Communicate with you </span></b><span lang=EN
+style='line-height:115%'>– This includes answering your course
+and platform questions, notifying you of course and edX Site maintenance and
+updates, marketing to you about course offerings, programs, news, and related products
+and services of edX or edX affiliates, and as permitted under applicable law,
+sending you communications about products or services of selected business
+partners that may be of interest to you.</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l5 level1 lfo8'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>Support scientific research including, for example, in the
+areas of cognitive science and education</span></b><span lang=EN
+style='line-height:115%'> – This includes collaborating to
+enable and conduct research about how learners access and master course
+materials online, with the goal of improving course outcomes.</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l5 level1 lfo8'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>Track edX Site usage against goals and mission</span></b><span
+lang=EN style='line-height:115%'> – This includes performing
+analytics to evaluate access to and performance in courses and course-related
+products and services and to report aggregate usage information (not Personal
+Information) to business partners and external audiences.</span></p>
+
+<p class=MsoListParagraphCxSpLast style='text-indent:-18.0pt;mso-list:l5 level1 lfo8'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>Exercise, enforce, and comply with legal rights and
+obligations</span></b><span lang=EN style='line-height:115%'>
+– This includes responding to subpoenas, court orders, or other legal process;
+and investigating, preventing, or taking action regarding illegal activities,
+suspected fraud, security or technical issues, or to protect the rights,
+property, or safety of edX, Members, or others, and as otherwise required by
+applicable law.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+or a Member may also seek your consent for additional uses of information,
+including Personal Information, and will use it only for the purpose described
+to you. All use of Personal Information is subject to applicable law.</span></p>
+
+<p class="MsoNormal AppleFont" style='margin-bottom:12.0pt'><a
+name=HowYourInformationIsShared><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='line-height:115%'>HOW YOUR INFORMATION IS
+SHARED</span></b></a></p>
+
+<span style='mso-bookmark:HowYourInformationIsShared'></span>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+and </span><span lang=EN><a href="#Member"><span style='
+line-height:115%'>Members</span></a></span><span lang=EN style='
+line-height:115%;color:black;mso-themecolor:text1'> </span><span lang=EN
+style='line-height:115%'>share information, including </span><span
+lang=EN><a href="#PersonalInformation"><span style='
+line-height:115%'>Personal Information</span></a></span><span lang=EN
+style='line-height:115%'>, with third parties for the
+following purposes:</span></p>
+
+<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l6 level1 lfo9'><a
+name=WithServiceProviders><span lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:Symbol;
+mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>With service providers</span></b></a><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='line-height:115%'>, contractors,
+and other third parties that help carry out the uses described above</span></b><span
+lang=EN style='line-height:115%'> – EdX requires third parties
+to: (1) abide by this Privacy Policy and applicable law; (2) handle Personal
+Information in a confidential manner and maintain adequate security; and (3)
+use Personal Information only as needed to fulfill the relevant purpose(s). In
+some cases, the edX Site and individual courses are integrated with third-party
+services or contain links to websites published by third parties, including
+other content providers as well as service providers. These third parties are
+responsible for their own privacy practices, so you should pay attention
+anytime you are redirected to a third-party website and be sure to review its
+privacy policy.</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l6 level1 lfo9'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>With other learners in courses that you take and with other
+visitors to the edX Site, to create an interactive learning environment,
+support class participation, and share course information</span></b><span
+lang=EN style='line-height:115%'> –<b style='mso-bidi-font-weight:
+normal'> </b>This includes sharing comments, coursework, or other information
+or content that you submit to a portion of the </span><span lang=EN><a
+href="#EdXSite"><span style='line-height:115%'>edX Site</span></a></span><span
+lang=EN style='line-height:115%;color:black;mso-themecolor:
+text1'> </span><span lang=EN style='line-height:115%'>designed
+for viewing by other class members or for public communication. This also
+includes providing opportunities for you to communicate with other users who
+may have similar interests or educational goals, for instance, recommending
+specific study partners or connecting potential student mentees and mentors. In
+such cases, edX and each Member that offers a course in which you enrolled may
+use all information collected about you to determine who might be interested in
+communicating with you, but will only provide others your username (for
+clarity, no disclosure of your real name or email address).</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l6 level1 lfo9'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>With employers, government programs, institutions, or other
+enterprises that sponsor your enrollment in a course for training or other
+educational purposes</span></b><span lang=EN style='
+line-height:115%'> – If an entity pays for or otherwise sponsors your </span><span
+lang=EN><a href="#VerifiedCertificate"><span style='
+line-height:115%'>Verified Certificate</span></a></span><span lang=EN
+style='line-height:115%;color:black;mso-themecolor:text1'> </span><span
+lang=EN style='line-height:115%'>or course participation, edX
+will share information with the entity as needed to confirm your enrollment,
+participation, progress, and completion status in that course.</span></p>
+
+<p class=MsoListParagraphCxSpLast style='text-indent:-18.0pt;mso-list:l6 level1 lfo9'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>With affiliates of edX or a Member, or with successors in the
+event of a merger, acquisition, or reorganization, for their use consistent
+with this Privacy Policy.</span></b></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+or a Member may also seek your consent for additional disclosures of
+information, including Personal Information, and will share it only as
+described to you. In addition, edX or a Member may share with the public and
+with third parties, including but not limited to researchers and business
+partners, information and Personal Information that is de-identified or
+aggregated in a manner that does not personally identify you.</span></p>
+
+<p class="MsoNormal AppleFont"><a name=HowToManageYourPersonalInformation><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>HOW TO MANAGE YOUR PERSONAL INFORMATION</span></b></a><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'></span></b></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>You
+can manage your </span><span lang=EN><a href="#PersonalInformation"><span
+style='line-height:115%'>Personal Information</span></a></span><span
+lang=EN style='line-height:115%;color:black;mso-themecolor:
+text1'> </span><span lang=EN style='line-height:115%'>through
+learner features on the </span><span lang=EN><a href="#EdXSite"><span
+style='line-height:115%'>edX Site</span></a></span><span
+lang=EN style='line-height:115%;color:black;mso-themecolor:
+text1'> </span><span lang=EN style='line-height:115%'>and
+requests to the edX learner support team. If your request involves information
+controlled by a Member, edX learner support will notify and coordinate with the
+appropriate Member to address your request. EdX will provide support to the
+extent required by applicable law (for example, learners in the European Union)
+and more broadly when possible, as a courtesy in our sole discretion. EdX will
+notify you in the event that edX is unable to meet a request that is not
+legally required. Similarly, Members will only be obligated to comply with
+requests to the extent legally required, but may choose to comply with other
+requests in their sole discretion.</span></p>
+
+<p class=MsoListParagraph style='text-indent:-18.0pt;mso-list:l9 level1 lfo10'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>Access and correct your Personal Information</span></b></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>Much
+of your Personal Information is available in your edX account. Your name, email
+address, and other identifiable profile information is editable through the
+profile settings in your edX account except as noted below. Your account
+dashboard lists all current and archived courses in which you have enrolled and
+includes links to any </span><span lang=EN><a href="#VerifiedCertificate"><span
+style='line-height:115%'>Verified Certificates</span></a></span><span
+lang=EN style='line-height:115%;color:black;mso-themecolor:
+text1'> </span><span lang=EN style='line-height:115%'>you may
+have earned. The dashboard also contains copies of your answers and other
+participation and performance in courses. Please contact edX learner support to
+access and update this or other information. If your request involves
+information controlled by a Member, edX learner support will notify the
+appropriate Member of your request.</span></p>
+
+<p class="MsoNormal AppleFont" style='text-indent:36.0pt'><b><i style='mso-bidi-font-style:
+normal'><span lang=EN style='line-height:115%'>Exceptions:</span></i></b></p>
+
+<p class="MsoNormal AppleFont" style='margin-left:72.0pt;text-indent:-36.0pt'><span
+lang=EN style='line-height:115%'>★ <span style='mso-tab-count:
+1'>        </span><i style='mso-bidi-font-style:normal'>Usernames cannot ever
+be changed. This is an edX system restriction. Because usernames identify you
+in courses and elsewhere on the edX Site, edX encourages you to use discretion
+in choosing your username. If you want to protect your identity, do not use
+your real name or a name identifiable to you as your username.</i></span></p>
+
+<p class="MsoNormal AppleFont" style='margin-left:72.0pt;text-indent:-36.0pt'><span
+lang=EN style='line-height:115%'>★ <span style='mso-tab-count:
+1'>        </span><i style='mso-bidi-font-style:normal'>EdX does not track or
+index every time or every place on the edX Site when or where a learner may
+volunteer Personal Information, so neither edX nor Members will be able to help
+you locate or manage all such instances. EdX encourages you to use discretion
+before volunteering Personal Information on the edX Site.</i></span></p>
+
+<p class=MsoListParagraph style='text-indent:-18.0pt;mso-list:l9 level1 lfo10'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>Restrict or object to the processing of Personal Information</span></b></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>If
+you want to manage emails and other communications to you, you may update your preferences
+in your edX account dashboard, follow the steps described in links at the
+bottom of email messages, or contact edX learner support. You may object to, or
+request that edX or a Member stop, its use of your Personal Information for
+other purposes by contacting the edX learner support team. If your request
+involves information controlled by a Member, edX learner support will notify
+the appropriate Member of your request. Please note that if you choose to
+restrict edX’s or a Member’s ability to process Personal Information, and the
+processing is otherwise required to provide you with various services and
+products offered on the edX Site, you may not be able to establish an edX user
+account or enroll for a course, and edX or a Member may not be able to provide
+you with those services or products.</span></p>
+
+<p class=MsoListParagraph style='text-indent:-18.0pt;mso-list:l9 level1 lfo10'><a
+name=DeleteAccount><span lang=EN style='
+line-height:115%;font-family:Symbol;mso-fareast-font-family:Symbol;mso-bidi-font-family:
+Symbol'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='line-height:115%'>Delete account and Personal
+Information</span></b></a><b style='mso-bidi-font-weight:normal'><span lang=EN
+style='line-height:115%'></span></b></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>To
+request deletion of your edX account and Personal Information, you should click
+the button labeled “Delete my account” in your edX account settings. Because
+deletion on the edX system is a permanent action and cannot be reversed, edX
+may ask you to complete a process that aims to confirm your authority to manage
+the edX account affected by your request.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>With
+respect to your edX account, edX will <i style='mso-bidi-font-style:normal'>permanently</i>:</span></p>
+
+<p class=MsoListParagraphCxSpFirst style='text-indent:-18.0pt;mso-list:l9 level1 lfo10'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>deactivate your edX account,</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l9 level1 lfo10'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>remove the active profile,</span></p>
+
+<p class="MsoListParagraphCxSpMiddle AppleFont" style='text-indent:-18.0pt;mso-list:l9 level1 lfo10'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>retire your username, and</span></p>
+
+<p class=MsoListParagraphCxSpLast style='text-indent:-18.0pt;mso-list:l9 level1 lfo10'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><span
+lang=EN style='line-height:115%'>remove you from edX email
+lists.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>With
+respect to your Personal Information, edX will <i style='mso-bidi-font-style:
+normal'>permanently</i> delete your edX account profile Personal Information
+from the edX Site.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN><a href="#ToTheExtentThatEdXAssociateInfo"><span
+style='line-height:115%'>As noted above</span></a></span><span
+lang=EN style='line-height:115%'>, to the extent that edX
+associates the information that edX collects directly or indirectly with an
+individual (for example, you), the association is based on Personal Information
+in your edX account profile. By erasing the Personal Information in your edX
+account profile, the remaining information about your activity on the edX Site
+will no longer be associated with you, except as noted below.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>These
+changes will be applied to data stores that are used for operation of the edX
+Site including course administration by Members. If you enrolled in any courses
+on the edX Site, the edX learner support team will share your request with the
+Members that offered those courses.</span></p>
+
+<p class="MsoNormal AppleFont" style='text-indent:36.0pt'><b><i style='mso-bidi-font-style:
+normal'><span lang=EN style='line-height:115%'>Exceptions:</span></i></b></p>
+
+<p class="MsoNormal AppleFont" style='margin-left:72.0pt;text-indent:-36.0pt'><span
+lang=EN style='line-height:115%'>★ <span style='mso-tab-count:
+1'>        </span><i style='mso-bidi-font-style:normal'>Deletion will not apply
+to historical activity logs or archives unless and until these logs and data
+naturally “age-off” the edX system.</i></span></p>
+
+<p class="MsoNormal AppleFont" style='margin-left:72.0pt;text-indent:-36.0pt'><span
+lang=EN style='line-height:115%'>★ <span style='mso-tab-count:
+1'>        </span><i style='mso-bidi-font-style:normal'>EdX does not track or
+index every time or every place on the edX Site when or where a learner may
+volunteer Personal Information, so neither edX nor Members will be able to help
+you locate or manage all such instances. EdX encourages you to use discretion
+before voluntarily sharing your Personal Information on the edX Site.</i></span></p>
+
+<p class="MsoNormal AppleFont" style='margin-left:72.0pt;text-indent:-36.0pt'><span
+lang=EN style='line-height:115%'>★ <span style='mso-tab-count:
+1'>        </span><i style='mso-bidi-font-style:normal'>EdX will archive course
+data (in a manner and to the extent permitted under applicable law) to serve
+its mission to enable scientific research on cognitive science and education.
+These archives are used to produce encrypted research data packages for
+Members, and Personal Information may not be deleted from research data
+packages retained by Members.</i></span></p>
+
+<p class="MsoNormal AppleFont" style='margin-left:72.0pt;text-indent:-36.0pt'><span
+lang=EN style='line-height:115%'>★ <span style='mso-tab-count:
+1'>        </span><i style='mso-bidi-font-style:normal'>EdX and each applicable
+Member cannot always delete records of past interactions and transactions. For
+example, records relating to previous purchases on the edX Site must be
+retained for financial reporting, audit, and compliance reasons.</i></span></p>
+
+<p class="MsoNormal AppleFont" style='margin-left:72.0pt;text-indent:-36.0pt'><span
+lang=EN style='line-height:115%'>★ <span style='mso-tab-count:
+1'>        </span><i style='mso-bidi-font-style:normal'>EdX and each Member
+will retain and use Personal Information as necessary to comply with its legal
+obligations, resolve disputes, enforce its agreements, and as otherwise
+permitted by applicable law.</i></span></p>
+
+<p class=MsoListParagraph style='text-indent:-18.0pt;mso-list:l2 level1 lfo11'><span
+lang=EN style='line-height:115%;font-family:Symbol;mso-fareast-font-family:
+Symbol;mso-bidi-font-family:Symbol'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>Data retention</span></b></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+will retain your Personal Information for as long as your account is active or
+as needed to provide you with services; to maintain a record of your
+transactions for financial reporting, audit, and compliance purposes; and to
+comply with edX’s legal obligations, resolve disputes, enforce its agreements,
+and as otherwise permitted by applicable law. If you enroll in a Member’s
+course, such Member will also retain your Personal Information for as long as
+needed to provide you with services; to maintain a record of your transactions
+for financial reporting, audit, and compliance purposes; and to comply with its
+legal obligations, resolve disputes, enforce its agreements, and as otherwise
+permitted by applicable law. Upon your request that edX deactivate your account
+and delete your information, edX will follow the process described above,
+including without limitation archiving your course data (in a manner and to the
+extent permitted under applicable law) to serve its mission to enable
+scientific research on cognitive science and education. These archives will be
+used to produce encrypted research data packages for Members, and each such
+Member may also keep and use course data for scientific research.</span></p>
+
+<p class="MsoNormal AppleFont"><a name=StorageSecurity><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='line-height:115%'>STORAGE &amp; SECURITY</span></b></a></p>
+
+<span style='mso-bookmark:StorageSecurity'></span>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+stores information, including </span><span lang=EN><a
+href="#PersonalInformation"><span style='line-height:115%'>Personal
+Information</span></a></span><span lang=EN style='line-height:
+115%'>, on its own servers and also on servers of companies that edX hires to
+provide services. Each </span><span lang=EN><a href="#Member"><span
+style='line-height:115%'>Member</span></a></span><span
+lang=EN style='line-height:115%'> also stores information,
+including Personal Information, on its own servers and/or on servers of
+companies that the Member hires to provide services. In each case, information
+may be stored in the United States and in other countries where edX or a Member
+operates, and in countries where edX and each Member’s respective service
+providers operate. If you are in the European Union, Switzerland, or other
+regions with laws governing data collection and use, you acknowledge that edX
+and each Member may transfer, process and store your personal information in
+the United States and other countries, the privacy laws of which may be
+considered less strict than those of your region.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>EdX
+controls its own copy of information collected through the </span><span
+lang=EN><a href="#EdXSite"><span style='line-height:115%'>edX
+Site</span></a></span><span lang=EN style='line-height:115%'>
+and has an information security program designed to protect information in its
+possession or control. This is done through a variety of privacy and security
+policies, processes, and procedures. EdX uses administrative, physical, and
+technical safeguards that reasonably and appropriately protect the confidentiality,
+integrity, and availability of the information that it collects, receives,
+stores, or transmits. Nonetheless, no method of transmission over the Internet,
+or method of electronic storage, is 100% secure; and therefore, edX cannot
+guarantee its absolute security. While edX works hard to ensure the integrity
+and security of its network and systems, edX cannot guarantee that its security
+measures will prevent “hackers” or other unauthorized persons from illegally
+accessing or obtaining information. </span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>If
+edX learns of a security breach involving its copy of your Personal
+Information, edX may attempt to notify you electronically so that you may take
+appropriate protective steps. By using the <span style='color:black;mso-themecolor:
+text1'>edX Site </span>or providing Personal Information to edX, you agree that
+edX can communicate with you electronically regarding security, privacy, and
+administrative issues relating to your use of the edX Site. If a security
+systems breach occurs, edX may post a notice on the edX homepage (www.edx.org)
+or elsewhere on the edX Site and may send an email to you at the email address
+associated with your edX account. Depending on where you are located, you may
+have a legal right to receive notice of a security breach, involving your
+Personal Information, in writing.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>If a
+Member learns of a security breach involving that Member’s copy of your
+Personal Information, the Member may attempt to notify you electronically so
+that you may take appropriate protective steps. By enrolling in a Member’s
+course on <span style='color:black;mso-themecolor:text1'>the edX Site </span>or
+providing Personal Information to the Member, you agree that the Member can
+communicate with you electronically regarding security, privacy, and
+administrative issues relating to your course enrollment and participation. If
+a security systems breach occurs, the affected Member may post a notice on the
+edX site and/or send an email to you at the email address associated with your
+enrollment in the Member’s course on the edX Site. Depending on where you are
+located, you may have a legal right to receive notice of a security breach,
+involving your Personal Information, in writing.</span></p>
+
+<p class="MsoNormal AppleFont" style='margin-bottom:12.0pt'><a name=PrivacyPolicyUpdates><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='
+line-height:115%'>PRIVACY POLICY UPDATES</span></b></a></p>
+
+<span style='mso-bookmark:PrivacyPolicyUpdates'></span>
+
+<p class="MsoNormal AppleFont" style='margin-bottom:12.0pt'><span lang=EN style='line-height:115%'>This Privacy Policy will be reviewed and updated from
+time to time. When changes are made, the Privacy Policy will be labeled as
+&quot;Revised (date),&quot; indicating that you should review the new terms,
+which will be effective immediately upon posting on this page, with an updated
+effective date. By accessing the </span><span lang=EN><a href="#EdXSite"><span
+style='line-height:115%'>edX Site</span></a></span><span
+lang=EN style='line-height:115%'> after any changes have been
+made, you accept the modified Privacy Policy and any changes contained therein.
+In case you miss the notification referenced above, be sure to return to this
+page periodically to ensure familiarity with the most current version of this
+Privacy Policy.</span></p>
+
+<p class="MsoNormal AppleFont"><a name=ContactInfo><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='line-height:115%'>CONTACT INFORMATION</span></b></a></p>
+
+<span style='mso-bookmark:ContactInfo'></span>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='line-height:115%'>If
+you have privacy concerns, have disclosed data you would prefer to keep
+private, or would like to access the Personal Information that edX maintains
+about you, please contact us at </span><span lang=EN><a
+href="mailto:privacy@edx.org"><span style='line-height:115%'>privacy@edx.org</span></a></span><span
+lang=EN style='line-height:115%'>. You may also write to us
+at: ATTN: PRIVACY, edX Inc., 141 Portland Street, Cambridge, MA 02139 USA. If
+your request involves a Member, edX will notify the appropriate Member of your
+request.</span></p>
+
+<p class="MsoNormal AppleFont"><a name=Glossary><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='line-height:115%'>GLOSSARY</span></b></a></p>
+
+<span style='mso-bookmark:Glossary'></span>
+
+<p class="MsoNormal AppleFont"><a name=Cookies><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='line-height:115%'>Cookies</span></b></a><span
+style='mso-bookmark:Cookies'><span lang=EN style='line-height:
+115%'> </span></span><span lang=EN style='line-height:115%'>are
+unique identifiers usually in the form of small data files placed on your
+device that send certain information about your activity on the edX Site or in
+an email communication back to edX or the authorized third party that served
+the cookie. EdX or third parties may also use Flash cookies.</span></p>
+
+<p class="MsoNormal AppleFont"><a name=EdXSite><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='line-height:115%'>EdX Site</span></b></a><span
+style='mso-bookmark:EdXSite'><span lang=EN style='line-height:
+115%'> </span></span><span lang=EN style='line-height:115%'>consists
+of all content and pages located within the edX.org web domain and all edX
+mobile applications.</span></p>
+
+<p class="MsoNormal AppleFont"><a name=Member><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='line-height:115%'>Member</span></b></a><span
+style='mso-bookmark:Member'><span lang=EN style='line-height:
+115%'> </span></span><span lang=EN style='line-height:115%'>is
+each educational institution or other leading global institution or entity that
+provides courses through the edX Site.</span></p>
+
+<p class="MsoNormal AppleFont"><a name=PersonalInformation><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='line-height:115%'>Personal
+Information</span></b></a><span style='mso-bookmark:PersonalInformation'><span
+lang=EN style='line-height:115%'> </span></span><span lang=EN
+style='line-height:115%'>is information that specifically
+identifies you or that, when combined with other information, could be used to
+identify you.</span></p>
+
+<p class="MsoNormal AppleFont"><a name=TrackingTechnologies><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='line-height:115%'>Tracking Technologies</span></b></a><span
+style='mso-bookmark:TrackingTechnologies'><span lang=EN style='
+line-height:115%'> </span></span><span lang=EN style='
+line-height:115%'>are web beacons, clear gifs, pixels, and similar technologies
+that are also unique identifiers used to track your online activity but are not
+stored on your device.</span></p>
+
+<p class="MsoNormal AppleFont"><a name=VerifiedCertificate><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='line-height:115%'>Verified
+Certificate</span></b></a><span style='mso-bookmark:VerifiedCertificate'><span
+lang=EN style='line-height:115%'> </span></span><span lang=EN
+style='line-height:115%'>is a virtual certificate that shows
+that you have successfully completed your edX course or program and verified
+your identity using your webcam and your acceptable form of photo ID.</span></p>
+
+<p class="MsoNormal AppleFont" style='margin-bottom:12.0pt'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='line-height:115%'>Effective Date:</span></b><span
+lang=EN style='line-height:115%'> May 25, 2018</span></p>
+
+</div>
+
+</body>
+
+</html>

--- a/Source/ja.lproj/TermsOfServices.htm
+++ b/Source/ja.lproj/TermsOfServices.htm
@@ -1,0 +1,2565 @@
+<html>
+
+<head>
+<meta http-equiv=Content-Type content="text/html; charset=utf-8">
+<meta name=ProgId content=Word.Document>
+<meta name=Generator content="Microsoft Word 14">
+<meta name=Originator content="Microsoft Word 14">
+<link rel=File-List href="TermsOfServices_en_files/filelist.xml">
+<link rel=themeData href="TermsOfServices_en_files/themedata.xml">
+<!--[if gte mso 9]><xml>
+ <w:WordDocument>
+  <w:SpellingState>Clean</w:SpellingState>
+  <w:GrammarState>Clean</w:GrammarState>
+  <w:TrackMoves/>
+  <w:TrackFormatting/>
+  <w:PunctuationKerning/>
+  <w:ValidateAgainstSchemas/>
+  <w:SaveIfXMLInvalid>false</w:SaveIfXMLInvalid>
+  <w:IgnoreMixedContent>false</w:IgnoreMixedContent>
+  <w:AlwaysShowPlaceholderText>false</w:AlwaysShowPlaceholderText>
+  <w:DoNotPromoteQF/>
+  <w:LidThemeOther>EN-US</w:LidThemeOther>
+  <w:LidThemeAsian>ZH-CN</w:LidThemeAsian>
+  <w:LidThemeComplexScript>AR-SA</w:LidThemeComplexScript>
+  <w:Compatibility>
+   <w:BreakWrappedTables/>
+   <w:SnapToGridInCell/>
+   <w:WrapTextWithPunct/>
+   <w:UseAsianBreakRules/>
+   <w:DontGrowAutofit/>
+   <w:SplitPgBreakAndParaMark/>
+   <w:EnableOpenTypeKerning/>
+   <w:DontFlipMirrorIndents/>
+   <w:OverrideTableStyleHps/>
+  </w:Compatibility>
+  <m:mathPr>
+   <m:mathFont m:val="Cambria Math"/>
+   <m:brkBin m:val="before"/>
+   <m:brkBinSub m:val="&#45;-"/>
+   <m:smallFrac m:val="off"/>
+   <m:dispDef/>
+   <m:lMargin m:val="0"/>
+   <m:rMargin m:val="0"/>
+   <m:defJc m:val="centerGroup"/>
+   <m:wrapIndent m:val="1440"/>
+   <m:intLim m:val="subSup"/>
+   <m:naryLim m:val="undOvr"/>
+  </m:mathPr></w:WordDocument>
+</xml><![endif]--><!--[if gte mso 9]><xml>
+ <w:LatentStyles DefLockedState="false" DefUnhideWhenUsed="true"
+  DefSemiHidden="true" DefQFormat="false" DefPriority="99"
+  LatentStyleCount="276">
+  <w:LsdException Locked="false" Priority="0" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Normal"/>
+  <w:LsdException Locked="false" Priority="9" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="heading 1"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 2"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 3"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 4"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 5"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 6"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 7"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 8"/>
+  <w:LsdException Locked="false" Priority="9" QFormat="true" Name="heading 9"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 1"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 2"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 3"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 4"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 5"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 6"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 7"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 8"/>
+  <w:LsdException Locked="false" Priority="39" Name="toc 9"/>
+  <w:LsdException Locked="false" Priority="35" QFormat="true" Name="caption"/>
+  <w:LsdException Locked="false" Priority="10" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Title"/>
+  <w:LsdException Locked="false" Priority="1" Name="Default Paragraph Font"/>
+  <w:LsdException Locked="false" Priority="11" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Subtitle"/>
+  <w:LsdException Locked="false" Priority="22" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Strong"/>
+  <w:LsdException Locked="false" Priority="20" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Emphasis"/>
+  <w:LsdException Locked="false" Priority="39" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Table Grid"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 1"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 2"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 3"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 4"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 5"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 6"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 7"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 8"/>
+  <w:LsdException Locked="false" SemiHidden="false" UnhideWhenUsed="false"
+   Name="Note Level 9"/>
+  <w:LsdException Locked="false" UnhideWhenUsed="false" Name="Placeholder Text"/>
+  <w:LsdException Locked="false" Priority="1" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="No Spacing"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 1"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 1"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 1"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 1"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 1"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 1"/>
+  <w:LsdException Locked="false" UnhideWhenUsed="false" Name="Revision"/>
+  <w:LsdException Locked="false" Priority="34" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="List Paragraph"/>
+  <w:LsdException Locked="false" Priority="29" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Quote"/>
+  <w:LsdException Locked="false" Priority="30" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Intense Quote"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 1"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 1"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 1"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 1"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 1"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 1"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 1"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 1"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 2"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 2"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 2"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 2"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 2"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 2"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 2"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 2"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 2"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 2"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 2"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 2"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 2"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 2"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 3"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 3"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 3"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 3"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 3"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 3"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 3"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 3"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 3"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 3"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 3"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 3"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 3"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 3"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 4"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 4"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 4"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 4"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 4"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 4"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 4"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 4"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 4"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 4"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 4"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 4"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 4"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 4"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 5"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 5"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 5"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 5"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 5"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 5"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 5"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 5"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 5"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 5"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 5"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 5"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 5"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 5"/>
+  <w:LsdException Locked="false" Priority="60" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Shading Accent 6"/>
+  <w:LsdException Locked="false" Priority="61" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light List Accent 6"/>
+  <w:LsdException Locked="false" Priority="62" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Light Grid Accent 6"/>
+  <w:LsdException Locked="false" Priority="63" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 1 Accent 6"/>
+  <w:LsdException Locked="false" Priority="64" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Shading 2 Accent 6"/>
+  <w:LsdException Locked="false" Priority="65" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 1 Accent 6"/>
+  <w:LsdException Locked="false" Priority="66" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium List 2 Accent 6"/>
+  <w:LsdException Locked="false" Priority="67" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 1 Accent 6"/>
+  <w:LsdException Locked="false" Priority="68" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 2 Accent 6"/>
+  <w:LsdException Locked="false" Priority="69" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Medium Grid 3 Accent 6"/>
+  <w:LsdException Locked="false" Priority="70" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Dark List Accent 6"/>
+  <w:LsdException Locked="false" Priority="71" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Shading Accent 6"/>
+  <w:LsdException Locked="false" Priority="72" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful List Accent 6"/>
+  <w:LsdException Locked="false" Priority="73" SemiHidden="false"
+   UnhideWhenUsed="false" Name="Colorful Grid Accent 6"/>
+  <w:LsdException Locked="false" Priority="19" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Subtle Emphasis"/>
+  <w:LsdException Locked="false" Priority="21" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Intense Emphasis"/>
+  <w:LsdException Locked="false" Priority="31" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Subtle Reference"/>
+  <w:LsdException Locked="false" Priority="32" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Intense Reference"/>
+  <w:LsdException Locked="false" Priority="33" SemiHidden="false"
+   UnhideWhenUsed="false" QFormat="true" Name="Book Title"/>
+  <w:LsdException Locked="false" Priority="37" Name="Bibliography"/>
+  <w:LsdException Locked="false" Priority="39" QFormat="true" Name="TOC Heading"/>
+ </w:LatentStyles>
+</xml><![endif]-->
+<style>
+ /* Font Definitions */
+@font-face
+	{font-family:Arial;
+	panose-1:2 11 6 4 2 2 2 2 2 4;
+	mso-font-charset:0;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:-536859905 -1073711037 9 0 511 0;}
+@font-face
+	{font-family:Arial;
+	panose-1:2 11 6 4 2 2 2 2 2 4;
+	mso-font-charset:0;
+	mso-generic-font-family:auto;
+	mso-font-pitch:variable;
+	mso-font-signature:-536859905 -1073711037 9 0 511 0;}
+@font-face
+	{font-family:"Open Sans";
+	mso-font-alt:Calibri;
+	mso-font-charset:0;
+	mso-generic-font-family:auto;
+	mso-font-pitch:auto;
+	mso-font-signature:0 0 0 0 0 0;}
+ /* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{mso-style-unhide:no;
+	mso-style-parent:"";
+	margin:0cm;
+	margin-bottom:.0001pt;
+	line-height:115%;
+	mso-pagination:widow-orphan;
+
+	font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+h1
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:20.0pt;
+	margin-right:0cm;
+	margin-bottom:6.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+	mso-outline-level:1;
+
+	font-family:Arial;
+	mso-font-kerning:0pt;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;
+	font-weight:normal;}
+h2
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:18.0pt;
+	margin-right:0cm;
+	margin-bottom:6.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+	mso-outline-level:2;
+
+	font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;
+	font-weight:normal;}
+h3
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:16.0pt;
+	margin-right:0cm;
+	margin-bottom:4.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+	mso-outline-level:3;
+
+	font-family:Arial;
+	color:#434343;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;
+	font-weight:normal;}
+h4
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:14.0pt;
+	margin-right:0cm;
+	margin-bottom:4.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+	mso-outline-level:4;
+
+	font-family:Arial;
+	color:#666666;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;
+	font-weight:normal;}
+h5
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:12.0pt;
+	margin-right:0cm;
+	margin-bottom:4.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+	mso-outline-level:5;
+
+	font-family:Arial;
+	color:#666666;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;
+	font-weight:normal;}
+h6
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:12.0pt;
+	margin-right:0cm;
+	margin-bottom:4.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+	mso-outline-level:6;
+
+	font-family:Arial;
+	color:#666666;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;
+	font-weight:normal;
+	font-style:italic;
+	mso-bidi-font-style:normal;}
+p.MsoHeader, li.MsoHeader, div.MsoHeader
+	{mso-style-priority:99;
+	mso-style-link:"Header Char";
+	margin:0cm;
+	margin-bottom:.0001pt;
+	mso-pagination:widow-orphan;
+	tab-stops:center 234.0pt right 468.0pt;
+
+	font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+p.MsoFooter, li.MsoFooter, div.MsoFooter
+	{mso-style-priority:99;
+	mso-style-link:"Footer Char";
+	margin:0cm;
+	margin-bottom:.0001pt;
+	mso-pagination:widow-orphan;
+	tab-stops:center 234.0pt right 468.0pt;
+
+	font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+p.MsoTitle, li.MsoTitle, div.MsoTitle
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:3.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+
+	font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+p.MsoSubtitle, li.MsoSubtitle, div.MsoSubtitle
+	{mso-style-unhide:no;
+	mso-style-next:Normal;
+	margin-top:0cm;
+	margin-right:0cm;
+	margin-bottom:16.0pt;
+	margin-left:0cm;
+	line-height:115%;
+	mso-pagination:widow-orphan lines-together;
+	page-break-after:avoid;
+
+	font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	color:#666666;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+a:link, span.MsoHyperlink
+	{mso-style-priority:99;
+	color:blue;
+	mso-themecolor:hyperlink;
+	text-decoration:underline;
+	text-underline:single;}
+a:visited, span.MsoHyperlinkFollowed
+	{mso-style-noshow:yes;
+	mso-style-priority:99;
+	color:purple;
+	mso-themecolor:followedhyperlink;
+	text-decoration:underline;
+	text-underline:single;}
+span.HeaderChar
+	{mso-style-name:"Header Char";
+	mso-style-priority:99;
+	mso-style-unhide:no;
+	mso-style-locked:yes;
+	mso-style-link:Header;}
+span.FooterChar
+	{mso-style-name:"Footer Char";
+	mso-style-priority:99;
+	mso-style-unhide:no;
+	mso-style-locked:yes;
+	mso-style-link:Footer;}
+span.UnresolvedMention
+	{mso-style-name:"Unresolved Mention";
+	mso-style-noshow:yes;
+	mso-style-priority:99;
+	color:gray;
+	background:#E6E6E6;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	mso-default-props:yes;
+
+	mso-ansi-
+	mso-bidi-
+	font-family:Arial;
+	mso-ascii-font-family:Arial;
+	mso-fareast-font-family:Arial;
+	mso-hansi-font-family:Arial;
+	mso-bidi-font-family:Arial;
+	mso-ansi-language:EN;
+	mso-fareast-language:ZH-CN;}
+.MsoPapDefault
+	{mso-style-type:export-only;
+	line-height:115%;}
+ /* Page Definitions */
+@page
+	{mso-footnote-separator:url(":TermsOfServices_en_files:header.htm") fs;
+	mso-footnote-continuation-separator:url(":TermsOfServices_en_files:header.htm") fcs;
+	mso-endnote-separator:url(":TermsOfServices_en_files:header.htm") es;
+	mso-endnote-continuation-separator:url(":TermsOfServices_en_files:header.htm") ecs;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:72.0pt 72.0pt 72.0pt 72.0pt;
+	mso-header-margin:0cm;
+	mso-footer-margin:36.0pt;
+	mso-page-numbers:1;
+	mso-header:url(":TermsOfServices_en_files:header.htm") h1;
+	mso-paper-source:0;}
+div.WordSection1
+	{page:WordSection1;}
+ /* List Definitions */
+@list l0
+	{mso-list-id:264463523;
+	mso-list-template-ids:197148870;}
+@list l0:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	mso-ansi-
+	mso-bidi-
+	mso-ascii-font-family:"Open Sans";
+	mso-fareast-font-family:"Open Sans";
+	mso-hansi-font-family:"Open Sans";
+	mso-bidi-font-family:"Open Sans";
+	color:#4E4E4E;
+	text-decoration:none;
+	text-underline:none;}
+@list l0:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l0:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l0:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l0:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l0:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l0:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l0:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l0:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l1
+	{mso-list-id:599409750;
+	mso-list-template-ids:-1638003230;}
+@list l1:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	mso-ansi-
+	mso-bidi-
+	mso-ascii-font-family:"Open Sans";
+	mso-fareast-font-family:"Open Sans";
+	mso-hansi-font-family:"Open Sans";
+	mso-bidi-font-family:"Open Sans";
+	color:#4E4E4E;
+	text-decoration:none;
+	text-underline:none;}
+@list l1:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l1:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l1:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l1:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l1:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l1:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l1:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l1:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l2
+	{mso-list-id:1157108096;
+	mso-list-template-ids:133694058;}
+@list l2:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l2:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l2:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l2:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l2:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l2:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l2:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l2:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l2:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l3
+	{mso-list-id:1161964398;
+	mso-list-template-ids:-792570768;}
+@list l3:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	mso-ansi-
+	mso-bidi-
+	mso-ascii-font-family:"Open Sans";
+	mso-fareast-font-family:"Open Sans";
+	mso-hansi-font-family:"Open Sans";
+	mso-bidi-font-family:"Open Sans";
+	color:#4E4E4E;
+	text-decoration:none;
+	text-underline:none;}
+@list l3:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l3:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l3:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l3:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l3:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l3:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l3:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l3:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l4
+	{mso-list-id:1800419136;
+	mso-list-template-ids:-1395874352;}
+@list l4:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	mso-ansi-
+	mso-bidi-
+	mso-ascii-font-family:"Open Sans";
+	mso-fareast-font-family:"Open Sans";
+	mso-hansi-font-family:"Open Sans";
+	mso-bidi-font-family:"Open Sans";
+	color:#4E4E4E;
+	text-decoration:none;
+	text-underline:none;}
+@list l4:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l4:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l4:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l4:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l4:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l4:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l4:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l4:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l5
+	{mso-list-id:1847937646;
+	mso-list-template-ids:1408802950;}
+@list l5:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	mso-ansi-
+	mso-bidi-
+	mso-ascii-font-family:"Open Sans";
+	mso-fareast-font-family:"Open Sans";
+	mso-hansi-font-family:"Open Sans";
+	mso-bidi-font-family:"Open Sans";
+	color:#4E4E4E;
+	text-decoration:none;
+	text-underline:none;}
+@list l5:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l5:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l5:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l5:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l5:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l5:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l5:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l5:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l6
+	{mso-list-id:1940217157;
+	mso-list-template-ids:-281015196;}
+@list l6:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	mso-ansi-
+	mso-bidi-
+	mso-ascii-font-family:"Open Sans";
+	mso-fareast-font-family:"Open Sans";
+	mso-hansi-font-family:"Open Sans";
+	mso-bidi-font-family:"Open Sans";
+	color:#4E4E4E;
+	text-decoration:none;
+	text-underline:none;}
+@list l6:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l6:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l6:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l6:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l6:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l6:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l6:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l6:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l7
+	{mso-list-id:2019313009;
+	mso-list-template-ids:-1977594340;}
+@list l7:level1
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	mso-ansi-
+	mso-bidi-
+	mso-ascii-font-family:"Open Sans";
+	mso-fareast-font-family:"Open Sans";
+	mso-hansi-font-family:"Open Sans";
+	mso-bidi-font-family:"Open Sans";
+	color:#4E4E4E;
+	text-decoration:none;
+	text-underline:none;}
+@list l7:level2
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l7:level3
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l7:level4
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l7:level5
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l7:level6
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l7:level7
+	{mso-level-number-format:bullet;
+	mso-level-text:●;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l7:level8
+	{mso-level-number-format:bullet;
+	mso-level-text:○;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+@list l7:level9
+	{mso-level-number-format:bullet;
+	mso-level-text:■;
+	mso-level-tab-stop:none;
+	mso-level-number-position:left;
+	text-indent:-18.0pt;
+	text-decoration:none;
+	text-underline:none;}
+ol
+	{margin-bottom:0cm;}
+ul
+	{margin-bottom:0cm;}
+
+div, p, a, .AppleFont {
+    font: -apple-system-body;
+}
+</style>
+</head>
+
+<body bgcolor=white lang=EN-US link=blue vlink=purple style='tab-interval:36.0pt'>
+
+<div class=WordSection1>
+
+<div style='border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm'>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>On May 25, 2018,
+edX adopted amended Terms of Service, providing as follows:</span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>Welcome to edX. Please read these Terms of Service
+(&quot;TOS&quot;) and Honor Code prior to registering for an account on edX.org
+or using any portion of the edX website or mobile applications (collectively, the
+&quot;edX Site,&quot; which consists of all content and pages located within
+the edX.org web domain and all edX mobile applications), including accessing
+any course material, chat rooms, or other electronic services. These TOS and
+the </span><span lang=EN><a href="#HonorCode">Honor Code</a><span
+style='color:black;mso-themecolor:text1'> that follows are agreements (the
+&quot;Agreements&quot;) between you and edX Inc. By using the edX Site, you
+accept and agree to be legally bound by the Agreements, whether or not you are
+a registered user. Please also read the </span><a
+href="https://www.edx.org/edx-privacy-policy">Privacy Policy</a><span
+style='color:black;mso-themecolor:text1'> for the edX Site before you use any
+portion of the edX Site. The Privacy Policy describes how your personal data is
+collected and processed when you use the edX Site. If you do not understand or
+do not wish to be bound by the terms of the Agreements or Privacy Policy, you
+should not use the edX Site.</span></span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>EdX reserves the right to modify these TOS at any time
+without advance notice. Any changes to these TOS will be effective immediately
+upon posting on this page, with an updated effective date. By accessing the edX
+Site after any changes have been made, you signify your agreement on a
+prospective basis to the modified TOS and all of the changes. Be sure to return
+to this page periodically to ensure familiarity with the most current version
+of these TOS.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1;background:white;mso-highlight:white'>Any version of these
+TOS in a language other than English is provided for convenience and you
+understand and agree that the English language version will control if there is
+any conflict.</span><span lang=EN style='color:black;mso-themecolor:text1'></span></p>
+
+</div>
+
+<p class="MsoNormal AppleFont"><b style='mso-bidi-font-weight:normal'><span lang=EN
+style='color:black;mso-themecolor:text1'>These TOS are organized as follows:</span></b></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l2 level1 lfo3'><![if !supportLists]><span
+lang=EN style='color:black;mso-themecolor:text1'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN><a href="#RulesForOnlineConduct">Rules for online conduct</a><span
+style='color:black;mso-themecolor:text1'></span></span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l2 level1 lfo3'><![if !supportLists]><span
+lang=EN style='color:black;mso-themecolor:text1'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN><a href="#StrictlyProhibitedItems">Strictly prohibited items</a><span
+style='color:black;mso-themecolor:text1'></span></span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l2 level1 lfo3'><![if !supportLists]><span
+lang=EN style='color:black;mso-themecolor:text1'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN><a href="#UserAccounts">User accounts</a><span style='color:black;
+mso-themecolor:text1'></span></span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l2 level1 lfo3'><![if !supportLists]><span
+lang=EN style='color:black;mso-themecolor:text1'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN><a href="#YourRightToUseContent">Your right to use content on the edX
+Site</a><span style='color:black;mso-themecolor:text1'></span></span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l2 level1 lfo3'><![if !supportLists]><span
+lang=EN style='color:black;mso-themecolor:text1'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN><a href="#UserPostings">User postings</a><span style='color:black;
+mso-themecolor:text1'></span></span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l2 level1 lfo3'><![if !supportLists]><span
+lang=EN style='color:black;mso-themecolor:text1'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN><a href="#CertificatesAndOtherProducts">Certificates and other products
+&amp; services</a><span style='color:black;mso-themecolor:text1'></span></span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l2 level1 lfo3'><![if !supportLists]><span
+lang=EN style='color:black;mso-themecolor:text1'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN><a href="#Trademarks">Trademarks</a><span style='color:black;
+mso-themecolor:text1'></span></span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l2 level1 lfo3'><![if !supportLists]><span
+lang=EN style='color:black;mso-themecolor:text1'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN><a href="#DigitalMillenniumCopyrightAct">Digital Millennium Copyright
+Act</a><span style='color:black;mso-themecolor:text1'></span></span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l2 level1 lfo3'><![if !supportLists]><span
+lang=EN style='color:black;mso-themecolor:text1'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN><a href="#DisclaimersOfWarranty">Disclaimers of Warranty / Limitations
+of Liabilities</a><span style='color:black;mso-themecolor:text1'></span></span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l2 level1 lfo3'><![if !supportLists]><span
+lang=EN style='color:black;mso-themecolor:text1'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN><a href="#Indemnification">Indemnification</a><span style='color:black;
+mso-themecolor:text1'></span></span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l2 level1 lfo3'><![if !supportLists]><span
+lang=EN style='color:black;mso-themecolor:text1'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN><a href="#AdditionalTerms">Additional Terms</a><span style='color:black;
+mso-themecolor:text1'></span></span></p>
+
+<div style='mso-element:para-border-div;border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm'>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><a name=RulesForOnlineConduct><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>RULES FOR ONLINE CONDUCT</span></b></a></p>
+
+<span style='mso-bookmark:RulesForOnlineConduct'></span>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>You agree that you are responsible for your own use of
+the edX Site and for your User Postings. &quot;User Postings&quot; means all
+content submitted, posted, published, or distributed on the edX Site by you or
+other users of the edX Site, including but not limited to all forum posts, wiki
+edits, notes, questions, comments, videos, and file uploads. You agree that you
+will use the edX Site in compliance with these Agreements, and all applicable
+local, state, national and international laws, rules and regulations, including
+copyright laws, any laws regarding the transmission of technical data exported
+from your country of residence, and all United States export control laws.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>As a condition of your use of the edX Site, you will not
+use the edX Site in any manner intended to damage, disable, overburden, or
+impair any edX server or the network(s) connected to any edX server or to
+interfere with any other party's use and enjoyment of the edX Site. You may not
+attempt to gain unauthorized access to the edX Site, other accounts, computer
+systems, or networks connected to any edX server through hacking, password
+mining, or any other means. You may not obtain or attempt to obtain any
+materials or information stored on the edX Site, its servers, or associated
+computers through any means not intentionally made available through the edX
+Site.<span style="mso-spacerun:yes">  </span>If you are a registered user, you
+will not share your password or let anyone else access or compromise your
+account.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>Furthermore, you agree not to scrape, or otherwise
+download in bulk, any edX Site content, including but not limited to a list or
+directory of users on the system, User Postings or user information, online
+textbooks, course materials, or trademarks and logos. You agree not to
+misrepresent or attempt to misrepresent your identity while using the edX Site
+(although you are welcome and encouraged to use an anonymous username in the
+forums and to act in a manner that keeps your identity concealed).</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><a name=StrictlyProhibitedItems><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>STRICTLY PROHIBITED ITEMS</span></b></a><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'> </span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>THE FOLLOWING ITEMS ARE STRICTLY PROHIBITED ON THE EDX
+SITE:</span></p>
+
+</div>
+
+<div style='mso-element:para-border-div;border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm;margin-left:
+18.0pt;margin-right:0cm'>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l0 level1 lfo5;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Content that defames, harasses, or threatens others;</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l0 level1 lfo5;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Content that discusses illegal activities with the intent to commit
+them;</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l0 level1 lfo5;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Content that infringes another's intellectual property, including, but
+not limited to, copyrights or trademarks;</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l0 level1 lfo5;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Profane, pornographic, obscene, indecent, or unlawful content;</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l0 level1 lfo5;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Advertising or any form of commercial solicitation;</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l0 level1 lfo5;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Content related to partisan political activities;</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l0 level1 lfo5;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Viruses, trojan horses, worms, time bombs, corrupted files, malware, spyware,
+or any other similar software that may damage the operation of another's
+computer or property; and</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l0 level1 lfo5;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Content that contains intentionally inaccurate information or that is
+posted with the intent of misleading others (this list, collectively, “Strictly
+Prohibited Items”).</span></p>
+
+</div>
+
+<div style='mso-element:para-border-div;border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm'>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>You may not submit, post, publish, share, or otherwise
+distribute any of the above Strictly Prohibited Items on or via the edX Site.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><a name=UserAccounts><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>USER ACCOUNTS</span></b></a><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'></span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>In order to create a user account, you must provide your
+full name, an email address, your country or region of residence, a public
+username, and a user password. You agree that you will never divulge or share
+access or access information for your user account with any third party for any
+reason. In setting up your user account, you may be prompted to enter
+additional optional information (e.g., your year of birth). You represent that
+all information provided by you is accurate and current. You agree to maintain
+and update your information to keep it accurate and current.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>We care about the confidentiality and security of your
+personal information. Please see the </span><span lang=EN><a
+href="https://www.edx.org/edx-privacy-policy">Privacy Policy</a><span
+style='color:black;mso-themecolor:text1'> for more information about the
+collection and use of data on the edX Site.</span></span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><a name=YourRightToUseContent><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>YOUR RIGHT TO USE CONTENT ON THE EDX SITE</span></b></a><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'></span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>Unless indicated as being in the public domain, the
+content on the edX Site is protected by United States and foreign copyright
+laws. Unless otherwise expressly stated on the edX Site, the texts, exams,
+video, images, and other instructional materials provided with the courses
+offered on the edX Site are for your personal use in connection with those
+courses only. We aim to make much of the edX course content available under
+more open license terms that will help create a vibrant ecosystem of contributors
+and further edX's goal of making education accessible and affordable to the
+world.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>Certain reference documents, digital textbooks, articles,
+and other information on the edX Site are used with the permission of third
+parties, and use of that information is subject to certain rules and
+conditions, which will be posted along with the information. By using the edX
+Site, you agree to abide by all such rules and conditions.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>You agree to retain all copyright and other notices on
+any content you obtain from the edX Site. All rights in the edX Site and its
+content, if not expressly granted, are reserved.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>Use for
+Personalization and Pedagogical Improvements</span></b><span lang=EN
+style='color:black;mso-themecolor:text1'>.<span style="mso-spacerun:yes"> 
+</span>Our goal is to provide current and future visitors to the edX Site with
+the best possible educational experience. To further this goal, we sometimes
+present different users with different versions of course materials and
+software. We do this to personalize the experience to the individual learner
+(to assess the learner’s level of ability and learning style, and present
+materials best suited to the learner), to improve our understanding of the
+learning process, and to evaluate and improve the effectiveness of our course
+materials, payment models, platform features, and offerings. We may publish or
+otherwise publicize results from this process, but, unless otherwise permitted
+under the </span><span lang=EN><a href="https://www.edx.org/edx-privacy-policy">Privacy
+Policy</a><span style='color:black;mso-themecolor:text1'>, those publications
+or public disclosures will not include your personal information.</span></span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><a name=UserPostings><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>USER POSTINGS</span></b></a><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'></span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>User Postings
+Representations and Warranties</span></b><span lang=EN style='color:black;
+mso-themecolor:text1'>.<span style="mso-spacerun:yes">  </span>By submitting or
+distributing your User Postings, you affirm, represent, and warrant (1) that
+you have the necessary rights, licenses, consents, and/or permissions to
+reproduce and publish the User Postings and to authorize edX and its users to
+reproduce, modify, publish, and otherwise use and distribute your User Postings
+in a manner consistent with the licenses granted by you below, and (2) that
+neither your submission of your User Postings nor the exercise of the licenses
+granted below will infringe or violate the rights of any third party. You, and
+not edX, are solely responsible for your User Postings and the consequences of
+posting or publishing them.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>License Grant to
+edX</span></b><span lang=EN style='color:black;mso-themecolor:text1'>.<span
+style="mso-spacerun:yes">  </span>By submitting or distributing your User
+Postings, you hereby grant to edX a worldwide, non-exclusive, transferable,
+assignable, sub licensable, fully paid-up, royalty-free, perpetual, irrevocable
+right and license to host, transfer, display, perform, reproduce, modify,
+distribute, redistribute, relicense, and otherwise use, make available, and
+exploit your User Postings, in whole or in part, in any form and in any media
+formats and through any media channels (now known or hereafter developed).</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>License Grant to
+edX Users</span></b><span lang=EN style='color:black;mso-themecolor:text1'>.<span
+style="mso-spacerun:yes">  </span>By submitting or distributing your User
+Postings, you hereby grant to each user of the edX Site a non-exclusive license
+to access and use your User Postings in connection with their use of the edX
+Site for their own personal purposes.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><a
+name=CertificatesAndOtherProducts><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='color:black;mso-themecolor:text1'>CERTIFICATES AND OTHER
+PRODUCTS &amp; SERVICES</span></b></a><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='color:black;mso-themecolor:text1'></span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>Generally</span></b><span
+lang=EN style='color:black;mso-themecolor:text1'>.<span
+style="mso-spacerun:yes">  </span>From time to time, edX and the colleges,
+universities, and other institutions providing courses and programs on the edX
+Site (collectively, the &quot;Members&quot;) may offer services and products
+for a fee (for example, course and program certificates). For anything that you
+choose to purchase on the edX Site, you agree to pay all applicable fees when
+due. As described in the </span><span lang=EN><a
+href="https://www.edx.org/edx-privacy-policy">Privacy Policy</a><span
+style='color:black;mso-themecolor:text1'>, the processing of your payment
+information is done by a third-party payment vendor, and you will be routed to
+a secure payment flow controlled by that vendor to complete the payment
+transaction. Once your payment transaction is completed, an edX confirmation
+page will be displayed, and you will receive a confirmation email with your
+name, order number, and the payment amount. Please retain this email for your
+records as this information will be required if you seek a refund from edX, as
+described below.</span></span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>Certificates</span></b><span
+lang=EN style='color:black;mso-themecolor:text1'>.<span
+style="mso-spacerun:yes">  </span>EdX and the Members may offer ID Verified
+Certificates of Achievement for courses (a &quot;Verified Certificate&quot;) or
+certificates for programs (for example, a MicroMasters program certificate) for
+learners who, in the Members’ judgment, have satisfactorily demonstrated
+mastery of the course or program material. Certificates will be issued by edX
+under the name of the underlying Member(s) from where the course or program
+originated, i.e. HarvardX, MITx, etc. The decision whether a certificate will
+be awarded to a given learner will be solely within the discretion of the
+awarding Member.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>Subject to the foregoing, you will be required to pay a
+fee and complete the ID verification process for Verified Certificates. In
+order to authenticate your identity for a Verified Certificate, you will be
+prompted to take a webcam photo of yourself, as well as a photo of an
+acceptable form of photo ID (described below). Although these items are
+collected by edX in accordance with these TOS and the </span><span lang=EN><a
+href="https://www.edx.org/edx-privacy-policy">Privacy Policy</a><span
+style='color:black;mso-themecolor:text1'>, you should be aware that the actual
+authentication of your identity is performed by an edX third-party service
+provider and this information will be used only for the purpose of verifying
+your identity. Acceptable forms of photo ID’s are:</span></span></p>
+
+</div>
+
+<div style='mso-element:para-border-div;border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm;margin-left:
+18.0pt;margin-right:0cm'>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l6 level1 lfo7;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Government or State-issued driver’s license</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l6 level1 lfo7;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Passport</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l6 level1 lfo7;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>National ID card</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l6 level1 lfo7;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>State or Province ID card (including cards issued by motor vehicle
+agencies)</span></p>
+
+</div>
+
+<div style='mso-element:para-border-div;border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm'>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>In order to be accepted by edX, your photo ID must:</span></p>
+
+</div>
+
+<div style='mso-element:para-border-div;border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm;margin-left:
+18.0pt;margin-right:0cm'>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l4 level1 lfo2;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Contain your full name exactly (excluding hyphens, accents, and spaces);</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l4 level1 lfo2;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Contain a relatively current photograph of yourself;</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l4 level1 lfo2;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Be an original document; photocopied documents cannot be accepted; and</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l4 level1 lfo2;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Be current and valid; expired documents cannot be accepted.</span></p>
+
+</div>
+
+<div style='mso-element:para-border-div;border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm'>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>Unfortunately, if you do not possess a photo ID meeting
+the criteria described above, edX is unable to provide you with a Verified
+Certificate at this time.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>Refunds</span></b><span
+lang=EN style='color:black;mso-themecolor:text1'>. Certificates and other
+purchases on the edX Site may be eligible for a refund for a period of time (in
+each case, the “Refund Period”). The applicable Refund Period for some products
+and services are described below. To request a refund for a purchase that you
+made, please email us at </span><span lang=EN><a href="mailto:billing@edx.org">billing@edx.org</a><a
+href="mailto:billing@edx.org"><span style='color:black;mso-themecolor:text1;
+text-decoration:none;text-underline:none'> and </span></a><span
+style='color:black;mso-themecolor:text1'>include your full name and order
+number in your email request. Refunds will be credited to the credit card used
+for the purchase and may take up to two billing cycles to process. If the
+applicable Refund Period for a purchase has passed, but you believe a refund is
+warranted, please email us at </span><a href="mailto:billing@edx.org">billing@edx.org</a><span
+style='color:black;mso-themecolor:text1'>. </span></span></p>
+
+</div>
+
+<div style='mso-element:para-border-div;border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm;margin-left:
+18.0pt;margin-right:0cm'>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l3 level1 lfo1;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='color:black;mso-themecolor:text1'>Verified Certificate Track: </span></b><span
+lang=EN style='color:black;mso-themecolor:text1'>For enrollment in the verified
+certificate track of a course, you have a period of 14 days after your payment
+or 14 days after your course starts (up to 60 days after your payment)
+whichever occurs later, during which you may withdraw or unenroll from the
+course by clicking on the unenroll link on the learner dashboard and request a
+refund by emailing </span><span lang=EN><a href="mailto:billing@edx.org">billing@edx.org</a><span
+style='color:black;mso-themecolor:text1'>. </span></span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l3 level1 lfo1;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='color:black;mso-themecolor:text1'>Professional Education
+Courses: </span></b><span lang=EN style='color:black;mso-themecolor:text1'>For
+enrollment in a Professional Education course, you have a period of 2 days
+after your payment or 2 days after the course starts (up to 60 days after your
+payment) whichever occurs later to unenroll from the course by clicking on the
+unenroll link on the learner dashboard and request a refund by emailing </span><span
+lang=EN><a href="mailto:billing@edx.org">billing@edx.org</a><span
+style='color:black;mso-themecolor:text1'>. </span></span></p>
+
+</div>
+
+<div style='mso-element:para-border-div;border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm'>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>For more information about refund options (for example,
+changing to another course session), you should </span><span lang=EN><a
+href="https://support.edx.org/hc/en-us">visit the edX Help Center</a><span
+style='color:black;mso-themecolor:text1'>. </span></span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>Coupon codes and other course entitlements are subject to
+expiration and any other conditions stated at the time of purchase.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>No Other
+Enrollment</span></b><span lang=EN style='color:black;mso-themecolor:text1'>.<span
+style="mso-spacerun:yes">  </span>You will not be an applicant for admission
+to, or enrolled in, any degree or other credit- or credential-bearing program
+of the Member as a result of registering for or completing a course or program
+provided by such Member through edX. You will not be entitled to use any of the
+resources of the Member beyond the online courses or programs provided on the
+edX Site, nor will you be eligible to receive student privileges or benefits
+provided to students enrolled in degree or other credit- or credential-bearing
+programs of the Member.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><a name=Trademarks><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>TRADEMARKS</span></b></a><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'></span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>Use of edX, MIT,
+Harvard University, and Other Member Names, Trademarks, and Service Marks</span></b><span
+lang=EN style='color:black;mso-themecolor:text1'>.<span
+style="mso-spacerun:yes">  </span>The &quot;edX,&quot; &quot;MIT,&quot; and
+&quot;Harvard University&quot; names, logos and seals are trademarks
+(&quot;Trademarks&quot;) of the respective entities. Likewise, the names,
+logos, and seals of the other Members are Trademarks owned by the respective
+Member. You may not use any of these Trademarks, or any variations thereof,
+without the owner's prior written consent. You may not use any of these
+Trademarks, or any variations thereof, for promotional purposes, or in any way
+that deliberately or inadvertently claims, suggests or, in the owner’s sole
+judgment, gives the appearance or impression of a relationship with or
+endorsement by the owner.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>All Trademarks not owned by edX or the Members that
+appear on the edX Site or on or through the services made available on or
+through the edX Site, if any, are the property of their respective owners.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>Nothing contained on the edX Site should be construed as
+granting, by implication, estoppel, or otherwise, any license or right to use
+any Trademark displayed on the edX Site without the written permission of the
+owner of the applicable Trademark.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><a
+name=DigitalMillenniumCopyrightAct><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='color:black;mso-themecolor:text1'>DIGITAL MILLENNIUM COPYRIGHT
+ACT</span></b></a><b style='mso-bidi-font-weight:normal'><span lang=EN
+style='color:black;mso-themecolor:text1'></span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>Copyright owners who believe their material has been infringed
+on the edX Site should contact edX's designated copyright agent at
+dmca-agent@edx.org or at edX Inc., 141 Portland St., Cambridge, MA 02139,
+Attention: edX DMCA Agent/General Counsel.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>Notification must include:</span></p>
+
+</div>
+
+<div style='mso-element:para-border-div;border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm;margin-left:
+18.0pt;margin-right:0cm'>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l1 level1 lfo6;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Identification of the copyrighted work, or, in the case of multiple
+works at the same location, a representative list of such works at that site.</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l1 level1 lfo6;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Identification of the material that is claimed to be infringing or to be
+the subject of infringing activity. You must include sufficient information for
+us to locate the material (e.g., URL, IP address, computer name).</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l1 level1 lfo6;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Information for us to be able to contact the complaining party (e.g.,
+email address, phone number).</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l1 level1 lfo6;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>A statement that the complaining party believes that the use of the
+material has not been authorized by the copyright owner or an authorized agent.</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:18.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l1 level1 lfo6;border:none;mso-border-bottom-alt:
+none windowtext 0cm;padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>A statement that the information in the notification is accurate and
+that the complaining party is authorized to act on behalf of the copyright
+owner.</span></p>
+
+</div>
+
+<div style='mso-element:para-border-div;border:none;border-bottom:none windowtext 1.0pt;
+mso-border-bottom-alt:none windowtext 0cm;padding:0cm 0cm 8.0pt 0cm'>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><a name=DisclaimersOfWarranty><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>DISCLAIMERS OF WARRANTY / LIMITATIONS OF LIABILITIES</span></b></a><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'></span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>THE EDX SITE AND
+ANY INFORMATION, CONTENT OR SERVICES MADE AVAILABLE ON OR THROUGH THE EDX SITE
+ARE PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; WITHOUT WARRANTY OF
+ANY KIND (EXPRESS, IMPLIED OR OTHERWISE), INCLUDING, WITHOUT LIMITATION, ANY IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT, EXCEPT INSOFAR AS ANY SUCH IMPLIED WARRANTIES MAY NOT BE
+DISCLAIMED UNDER APPLICABLE LAW.</span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>&nbsp;</span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>EDX AND THE EDX
+PARTICIPANTS (AS HEREINAFTER DEFINED) DO NOT WARRANT THAT THE EDX SITE WILL
+OPERATE IN AN UNINTERRUPTED OR ERROR-FREE MANNER, THAT THE EDX SITE IS FREE OF
+VIRUSES OR OTHER HARMFUL COMPONENTS, OR THAT THE COURSES OR CONTENT PROVIDED
+WILL MEET YOUR NEEDS OR EXPECTATIONS. EDX AND THE EDX PARTICIPANTS ALSO MAKE NO
+WARRANTY ABOUT THE ACCURACY, COMPLETENESS, TIMELINESS, OR QUALITY OF THE EDX
+SITE OR ANY COURSES OR CONTENT, OR THAT ANY PARTICULAR COURSES OR CONTENT WILL
+CONTINUE TO BE MADE AVAILABLE. “EDX PARTICIPANTS” MEANS MIT, HARVARD, THE OTHER
+MEMBERS, THE ENTITIES PROVIDING INFORMATION, CONTENT, OR SERVICES FOR THE EDX
+SITE, THE COURSE INSTRUCTORS, AND THEIR STAFFS.</span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>&nbsp;</span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>USE OF THE EDX
+SITE, AND THE CONTENT AND SERVICES OBTAINED FROM OR THROUGH THE EDX SITE, IS AT
+YOUR OWN RISK. YOUR ACCESS TO OR DOWNLOAD OF INFORMATION, MATERIALS, OR DATA
+THROUGH THE EDX SITE OR ANY REFERENCE SITES IS AT YOUR OWN DISCRETION AND RISK,
+AND YOU WILL BE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR PROPERTY (INCLUDING
+YOUR COMPUTER SYSTEM) OR LOSS OF DATA THAT RESULTS FROM THE DOWNLOAD OR USE OF
+SUCH MATERIAL OR DATA, UNLESS OTHERWISE EXPRESSLY PROVIDED FOR IN THE </span></b><span
+lang=EN><a href="https://www.edx.org/edx-privacy-policy"><b style='mso-bidi-font-weight:
+normal'>PRIVACY POLICY</b></a><b style='mso-bidi-font-weight:normal'><span
+style='color:black;mso-themecolor:text1'>.</span></b></span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>&nbsp;</span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>User Postings
+Disclaimer</span></b><span lang=EN style='color:black;mso-themecolor:text1'>.<span
+style="mso-spacerun:yes">  </span>You understand that when using the edX Site
+you will be exposed to User Postings from a variety of sources and that neither
+edX nor the edX Participants are responsible for the accuracy, usefulness,
+reliability or intellectual property rights of or relating to such User
+Postings. You further understand and acknowledge that you may be exposed to
+User Postings that are inaccurate, offensive, defamatory, indecent or
+objectionable and you agree to waive, and hereby do waive, any legal or
+equitable rights or remedies you have or may have against edX or any of the edX
+Participants with respect thereto. Neither edX nor any of the edX Participants
+endorse any User Postings or any opinion, recommendation or advice expressed
+therein. Neither edX nor any of the edX Participants have any obligation to
+monitor any User Postings or any other user communications through the edX
+Site.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>However, edX reserves the right to review User Postings
+and to exercise its sole discretion to edit or remove, in whole or in part, any
+User Posting at any time and for any reason, or to allow the edX Participants
+to do so. Without limiting the foregoing, upon receiving notice from a user or
+a content owner that a User Posting allegedly does not conform to these TOS,
+edX may investigate the allegation and determine in its sole discretion whether
+to remove the User Posting, which it reserves the right to do at any time and
+without notice.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>Links to Other
+Websites</span></b><span lang=EN style='color:black;mso-themecolor:text1'>.<span
+style="mso-spacerun:yes">  </span>The edX Site may include hyperlinks to
+websites maintained or controlled by others. EdX and the edX Participants are
+not responsible for and do not routinely screen, approve, review or endorse the
+contents of or use of any of the products or services that may be offered at
+these websites. If you decide to access linked third-party websites, you do so
+at your own risk.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>TO THE FULLEST
+EXTENT PERMITTED BY APPLICABLE LAW, YOU AGREE THAT NEITHER EDX NOR ANY OF THE
+EDX PARTICIPANTS WILL BE LIABLE TO YOU FOR ANY LOSS OR DAMAGES, EITHER ACTUAL
+OR CONSEQUENTIAL, ARISING OUT OF OR RELATING TO THESE TERMS OF SERVICE, OR YOUR
+(OR ANY THIRD PARTY'S) USE OF OR INABILITY TO USE THE EDX SITE, OR YOUR
+PLACEMENT OF CONTENT ON THE EDX SITE, OR YOUR RELIANCE UPON INFORMATION
+OBTAINED FROM OR THROUGH THE EDX SITE, WHETHER YOUR CLAIM IS BASED IN CONTRACT,
+TORT, STATUTORY OR OTHER LAW.</span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>&nbsp;</span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>IN PARTICULAR,
+TO THE FULLEST EXTENT PERMITTED BY APPLICABLE LAW, NEITHER EDX NOR ANY OF THE
+EDX PARTICIPANTS WILL HAVE ANY LIABILITY FOR ANY CONSEQUENTIAL, INDIRECT,
+PUNITIVE, SPECIAL, EXEMPLARY, OR INCIDENTAL DAMAGES, WHETHER FORESEEABLE OR
+UNFORESEEABLE AND WHETHER OR NOT EDX OR ANY OF THE EDX PARTICIPANTS HAS BEEN
+NEGLIGENT OR OTHERWISE AT FAULT (INCLUDING, BUT NOT LIMITED TO, CLAIMS FOR
+DEFAMATION, ERRORS, LOSS OF PROFITS, LOSS OF DATA, OR INTERRUPTION IN
+AVAILABILITY OF DATA).</span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>&nbsp;</span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>CERTAIN STATE
+LAWS DO NOT ALLOW LIMITATIONS ON IMPLIED WARRANTIES OR THE EXCLUSION OR
+LIMITATION OF CERTAIN DAMAGES. IF THESE LAWS APPLY TO YOU, SOME OR ALL OF THE
+ABOVE DISCLAIMERS, EXCLUSIONS, OR LIMITATIONS MAY NOT APPLY TO YOU, AND YOU
+MIGHT HAVE ADDITIONAL RIGHTS.</span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>&nbsp;</span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><a name=Indemnification><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>INDEMNIFICATION</span></b></a><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'></span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>You agree to defend, hold harmless, and indemnify edX and
+the edX Participants, and their respective subsidiaries, affiliates, officers,
+faculty, students, fellows, governing board members, agents and employees from
+and against any third-party claims, actions, or demands arising out of,
+resulting from or in any way related to your use of the edX Site, including any
+liability or expense arising from any and all claims, losses, damages (actual
+and consequential), suits, judgments, litigation costs, and attorneys' fees, of
+every kind and nature. In such a case, edX or the applicable edX Participant
+will provide you with written notice of such claim, suit, or action.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><a name=AdditionalTerms><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>ADDITIONAL TERMS</span></b></a><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'></span></b></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>Termination
+Rights; Discontinuation of Courses and Content</span></b><span lang=EN
+style='color:black;mso-themecolor:text1'>.<span style="mso-spacerun:yes"> 
+</span>You agree that edX, in its sole discretion, may terminate your use of
+the edX Site or your participation in it, for any reason or no reason, upon
+notice to you. It is edX's policy to terminate in appropriate circumstances the
+accounts of users of the edX Site who are repeat copyright infringers. EdX and
+the edX Participants reserve the right at any time in their sole discretion to
+cancel, delay, reschedule or alter the format of any course offered through
+edX, or to cease providing any part or all of the edX Site content or related
+services, and you agree that neither edX nor any of the edX Participants will
+have any liability to you for such an action. If you no longer desire to
+participate in the edX Site, you may terminate your participation at any time.
+The rights granted to you hereunder will terminate upon any termination of your
+right to use the edX Site, but the other provisions of the Agreements will
+survive any such termination.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>Entire Agreement</span></b><span
+lang=EN style='color:black;mso-themecolor:text1'>.<span
+style="mso-spacerun:yes">  </span>The Agreements constitute the entire
+agreement between you and edX with respect to your use of the edX Site,
+superseding any prior agreements between you and edX regarding your use of the
+edX Site.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>Waiver and
+Severability</span></b><span lang=EN style='color:black;mso-themecolor:text1'>.<span
+style="mso-spacerun:yes">  </span>The failure of edX to exercise or enforce any
+right or provision of the Agreements shall not constitute a waiver of such
+right or provision. If any provision of the Agreements is found by a court of
+competent jurisdiction to be invalid, the parties nevertheless agree that the
+court should endeavor to give effect to the parties' intentions as reflected in
+the provision and the other provisions of the Agreements shall remain in full
+force and effect.</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='border:none;mso-border-bottom-alt:none windowtext 0cm;
+padding:0cm;mso-padding-alt:0cm 0cm 8.0pt 0cm'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>Choice of
+Law/Forum Selection</span></b><span lang=EN style='color:black;mso-themecolor:
+text1'>.<span style="mso-spacerun:yes">  </span>You agree that the Agreements
+and any claim or dispute arising out of or relating to the Agreements or any
+content or service obtained from or through the edX Site will be governed by
+the laws of the Commonwealth of Massachusetts, excluding its conflicts of law
+provisions. You agree that all such claims and disputes will be heard and
+resolved exclusively in the federal or state courts located in and serving
+Cambridge, Massachusetts, U.S.A. You consent to the personal jurisdiction of
+those courts over you for this purpose, and you waive and agree not to assert
+any objection to such proceedings in those courts (including any defense or
+objection of lack of proper jurisdiction or venue or inconvenience of forum).</span></p>
+
+</div>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='color:black;mso-themecolor:text1'>Effective
+Date: May 25, 2018.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='color:black;mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont"><a name=HonorCode><b style='mso-bidi-font-weight:normal'><span
+lang=EN style='color:black;mso-themecolor:text1'>HONOR CODE</span></b></a><b
+style='mso-bidi-font-weight:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'></span></b></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='color:black;mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont"><b style='mso-bidi-font-weight:normal'><span lang=EN
+style='color:black;mso-themecolor:text1'>Collaboration Policy.<span
+style="mso-spacerun:yes">  </span></span></b><span lang=EN style='color:black;
+mso-themecolor:text1'>By enrolling in a course on edX, you are joining a
+special worldwide community of learners. The aspiration of edX is to provide
+anyone with an internet connection access to courses from the best universities
+and institutions in the world and to provide our learners the best educational
+experience internet technology enables. You are a part of the community that
+will help edX achieve this goal. EdX depends upon your motivation to learn the
+material and to do so with honesty and academic integrity. In order to
+participate in edX, you must agree to the Honor Code below and any additional
+terms specific to a course or program. This Honor Code, and any additional terms,
+will be posted on each course website.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='color:black;mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont"><b style='mso-bidi-font-weight:normal'><span lang=EN
+style='color:black;mso-themecolor:text1'>Honor Code Pledge.<span
+style="mso-spacerun:yes">  </span></span></b><span lang=EN style='color:black;
+mso-themecolor:text1'>By enrolling in an edX course or program, I agree that I
+will:</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l5 level1 lfo8'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Complete all tests and assignments on my own, unless collaboration on an
+assignment is explicitly permitted.</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l5 level1 lfo8'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Maintain only one user account and not let anyone else use my username
+and/or password.</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l5 level1 lfo8'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Not engage in any activity that would dishonestly improve my results, or
+improve or hurt the results of others.</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l5 level1 lfo8'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Not post answers to problems that are being used to assess learner
+performance.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='color:black;mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont"><b style='mso-bidi-font-weight:normal'><span lang=EN
+style='color:black;mso-themecolor:text1'>Violations.<span
+style="mso-spacerun:yes">  </span></span></b><span lang=EN style='color:black;
+mso-themecolor:text1'>If you are found in violation of the Terms of Service or
+Honor Code, you may be subject to one or more of the following actions:</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-left:36.0pt;mso-add-space:auto;
+text-indent:-18.0pt;mso-list:l7 level1 lfo4'><![if !supportLists]><span
+lang=EN style='line-height:115%;font-family:"Open Sans";
+mso-fareast-font-family:"Open Sans";mso-bidi-font-family:"Open Sans";
+color:#4E4E4E'><span style='mso-list:Ignore'>●<span style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+</span></span></span><![endif]><span lang=EN style='color:black;mso-themecolor:
+text1'>Receiving a zero or no credit for an assignment;</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-top:12.0pt;margin-right:0cm;
+margin-bottom:12.0pt;margin-left:36.0pt;mso-add-space:auto;text-indent:-18.0pt;
+mso-list:l7 level1 lfo4'><![if !supportLists]><span lang=EN style='line-height:115%;font-family:"Open Sans";mso-fareast-font-family:"Open Sans";
+mso-bidi-font-family:"Open Sans";color:#4E4E4E'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN style='color:black;mso-themecolor:text1'>Having any certificate earned
+in the course or program withheld or revoked;</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-top:12.0pt;margin-right:0cm;
+margin-bottom:12.0pt;margin-left:36.0pt;mso-add-space:auto;text-indent:-18.0pt;
+mso-list:l7 level1 lfo4'><![if !supportLists]><span lang=EN style='line-height:115%;font-family:"Open Sans";mso-fareast-font-family:"Open Sans";
+mso-bidi-font-family:"Open Sans";color:#4E4E4E'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN style='color:black;mso-themecolor:text1'>Being unenrolled from a course
+or program; or</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-top:12.0pt;margin-right:0cm;
+margin-bottom:12.0pt;margin-left:36.0pt;mso-add-space:auto;text-indent:-18.0pt;
+mso-list:l7 level1 lfo4'><![if !supportLists]><span lang=EN style='line-height:115%;font-family:"Open Sans";mso-fareast-font-family:"Open Sans";
+mso-bidi-font-family:"Open Sans";color:#4E4E4E'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN style='color:black;mso-themecolor:text1'>Termination of your use of the
+edX Site.</span></p>
+
+<p class="NormalParagraph AppleFont" style='margin-top:12.0pt;margin-right:0cm;
+margin-bottom:12.0pt;margin-left:36.0pt;mso-add-space:auto;text-indent:-18.0pt;
+mso-list:l7 level1 lfo4'><![if !supportLists]><span lang=EN style='line-height:115%;font-family:"Open Sans";mso-fareast-font-family:"Open Sans";
+mso-bidi-font-family:"Open Sans";color:#4E4E4E'><span style='mso-list:Ignore'>●<span
+style='font:7.0pt "Times New Roman"'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; </span></span></span><![endif]><span
+lang=EN style='color:black;mso-themecolor:text1'>Additional actions may be
+taken at the sole discretion of edX and edX Member course providers.</span></p>
+
+<p class="MsoNormal AppleFont" style='margin-top:12.0pt;line-height:normal'><span lang=EN
+style='color:black;mso-themecolor:text1'>No refunds will be issued in the case
+of any corrective action for such violations.</span></p>
+
+<p class="MsoNormal AppleFont" style='line-height:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='line-height:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>Honor code violations will be determined at the sole
+discretion of edX Members. You will be notified if a determination has been
+made that you have violated this honor code and you will be informed of the
+corresponding action to be taken as a result of the violation.</span></p>
+
+<p class="MsoNormal AppleFont" style='line-height:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='line-height:normal'><b style='mso-bidi-font-weight:
+normal'><span lang=EN style='color:black;mso-themecolor:text1'>Changing the
+Honor Code.<span style="mso-spacerun:yes">  </span></span></b><span lang=EN
+style='color:black;mso-themecolor:text1'>Please note that we review and may
+make changes to this Honor Code from time to time. Any changes to this Honor
+Code will be effective immediately upon posting on this page, with an updated
+effective date. By accessing the edX Site after any changes have been made, you
+signify your agreement on a prospective basis to the modified Honor Code and
+any changes contained therein. Be sure to return to this page periodically to
+ensure familiarity with the most current version of this Honor Code.</span></p>
+
+<p class="MsoNormal AppleFont" style='line-height:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>&nbsp;</span></p>
+
+<p class="MsoNormal AppleFont" style='line-height:normal'><span lang=EN style='color:black;
+mso-themecolor:text1'>Effective Date: May 25, 2018.</span></p>
+
+<p class="MsoNormal AppleFont"><span lang=EN style='color:black;mso-themecolor:text1'>&nbsp;</span></p>
+
+</div>
+
+</body>
+
+</html>

--- a/Source/ja.lproj/languages.json
+++ b/Source/ja.lproj/languages.json
@@ -1,0 +1,560 @@
+[
+ {
+ "aa": "Afar"
+ },
+ {
+ "ab": "Abkhazian"
+ },
+ {
+ "af": "Afrikaans"
+ },
+ {
+ "ak": "Akan"
+ },
+ {
+ "sq": "Albanian"
+ },
+ {
+ "am": "Amharic"
+ },
+ {
+ "ar": "Arabic"
+ },
+ {
+ "an": "Aragonese"
+ },
+ {
+ "hy": "Armenian"
+ },
+ {
+ "as": "Assamese"
+ },
+ {
+ "av": "Avaric"
+ },
+ {
+ "ae": "Avestan"
+ },
+ {
+ "ay": "Aymara"
+ },
+ {
+ "az": "Azerbaijani"
+ },
+ {
+ "ba": "Bashkir"
+ },
+ {
+ "bm": "Bambara"
+ },
+ {
+ "eu": "Basque"
+ },
+ {
+ "be": "Belarusian"
+ },
+ {
+ "bn": "Bengali"
+ },
+ {
+ "bh": "Bihari languages"
+ },
+ {
+ "bi": "Bislama"
+ },
+ {
+ "bs": "Bosnian"
+ },
+ {
+ "br": "Breton"
+ },
+ {
+ "bg": "Bulgarian"
+ },
+ {
+ "my": "Burmese"
+ },
+ {
+ "ca": "Catalan"
+ },
+ {
+ "ch": "Chamorro"
+ },
+ {
+ "ce": "Chechen"
+ },
+ {
+ "zh": "Chinese"
+ },
+ {
+ "zh_HANS": "Simplified Chinese"
+ },
+ {
+ "zh_HANT": "Traditional Chinese"
+ },
+ {
+ "cu": "Church Slavic"
+ },
+ {
+ "cv": "Chuvash"
+ },
+ {
+ "kw": "Cornish"
+ },
+ {
+ "co": "Corsican"
+ },
+ {
+ "cr": "Cree"
+ },
+ {
+ "cs": "Czech"
+ },
+ {
+ "da": "Danish"
+ },
+ {
+ "dv": "Divehi"
+ },
+ {
+ "nl": "Dutch"
+ },
+ {
+ "dz": "Dzongkha"
+ },
+ {
+ "en": "English"
+ },
+ {
+ "eo": "Esperanto"
+ },
+ {
+ "et": "Estonian"
+ },
+ {
+ "ee": "Ewe"
+ },
+ {
+ "fo": "Faroese"
+ },
+ {
+ "fj": "Fijian"
+ },
+ {
+ "fi": "Finnish"
+ },
+ {
+ "fr": "French"
+ },
+ {
+ "fy": "Western Frisian"
+ },
+ {
+ "ff": "Fulah"
+ },
+ {
+ "ka": "Georgian"
+ },
+ {
+ "de": "German"
+ },
+ {
+ "gd": "Gaelic"
+ },
+ {
+ "ga": "Irish"
+ },
+ {
+ "gl": "Galician"
+ },
+ {
+ "gv": "Manx"
+ },
+ {
+ "el": "Greek"
+ },
+ {
+ "gn": "Guarani"
+ },
+ {
+ "gu": "Gujarati"
+ },
+ {
+ "ht": "Haitian"
+ },
+ {
+ "ha": "Hausa"
+ },
+ {
+ "he": "Hebrew"
+ },
+ {
+ "hz": "Herero"
+ },
+ {
+ "hi": "Hindi"
+ },
+ {
+ "ho": "Hiri Motu"
+ },
+ {
+ "hr": "Croatian"
+ },
+ {
+ "hu": "Hungarian"
+ },
+ {
+ "ig": "Igbo"
+ },
+ {
+ "is": "Icelandic"
+ },
+ {
+ "io": "Ido"
+ },
+ {
+ "ii": "Sichuan Yi"
+ },
+ {
+ "iu": "Inuktitut"
+ },
+ {
+ "ie": "Interlingue"
+ },
+ {
+ "ia": "Interlingua"
+ },
+ {
+ "id": "Indonesian"
+ },
+ {
+ "ik": "Inupiaq"
+ },
+ {
+ "it": "Italian"
+ },
+ {
+ "jv": "Javanese"
+ },
+ {
+ "ja": "Japanese"
+ },
+ {
+ "kl": "Kalaallisut"
+ },
+ {
+ "kn": "Kannada"
+ },
+ {
+ "ks": "Kashmiri"
+ },
+ {
+ "kr": "Kanuri"
+ },
+ {
+ "kk": "Kazakh"
+ },
+ {
+ "km": "Central Khmer"
+ },
+ {
+ "ki": "Kikuyu"
+ },
+ {
+ "rw": "Kinyarwanda"
+ },
+ {
+ "ky": "Kirghiz"
+ },
+ {
+ "kv": "Komi"
+ },
+ {
+ "kg": "Kongo"
+ },
+ {
+ "ko": "Korean"
+ },
+ {
+ "kj": "Kuanyama"
+ },
+ {
+ "ku": "Kurdish"
+ },
+ {
+ "lo": "Lao"
+ },
+ {
+ "la": "Latin"
+ },
+ {
+ "lv": "Latvian"
+ },
+ {
+ "li": "Limburgan"
+ },
+ {
+ "ln": "Lingala"
+ },
+ {
+ "lt": "Lithuanian"
+ },
+ {
+ "lb": "Luxembourgish"
+ },
+ {
+ "lu": "Luba-Katanga"
+ },
+ {
+ "lg": "Ganda"
+ },
+ {
+ "mk": "Macedonian"
+ },
+ {
+ "mh": "Marshallese"
+ },
+ {
+ "ml": "Malayalam"
+ },
+ {
+ "mi": "Maori"
+ },
+ {
+ "mr": "Marathi"
+ },
+ {
+ "ms": "Malay"
+ },
+ {
+ "mg": "Malagasy"
+ },
+ {
+ "mt": "Maltese"
+ },
+ {
+ "mn": "Mongolian"
+ },
+ {
+ "na": "Nauru"
+ },
+ {
+ "nv": "Navajo"
+ },
+ {
+ "nr": "Ndebele, South"
+ },
+ {
+ "nd": "Ndebele, North"
+ },
+ {
+ "ng": "Ndonga"
+ },
+ {
+ "ne": "Nepali"
+ },
+ {
+ "nn": "Norwegian Nynorsk"
+ },
+ {
+ "nb": "Bokmål, Norwegian"
+ },
+ {
+ "no": "Norwegian"
+ },
+ {
+ "ny": "Chichewa"
+ },
+ {
+ "oc": "Occitan"
+ },
+ {
+ "oj": "Ojibwa"
+ },
+ {
+ "or": "Oriya"
+ },
+ {
+ "om": "Oromo"
+ },
+ {
+ "os": "Ossetian"
+ },
+ {
+ "pa": "Panjabi"
+ },
+ {
+ "fa": "Persian"
+ },
+ {
+ "pi": "Pali"
+ },
+ {
+ "pl": "Polish"
+ },
+ {
+ "pt": "Portuguese"
+ },
+ {
+ "ps": "Pushto"
+ },
+ {
+ "qu": "Quechua"
+ },
+ {
+ "rm": "Romansh"
+ },
+ {
+ "ro": "Romanian"
+ },
+ {
+ "rn": "Rundi"
+ },
+ {
+ "ru": "Russian"
+ },
+ {
+ "sg": "Sango"
+ },
+ {
+ "sa": "Sanskrit"
+ },
+ {
+ "si": "Sinhala"
+ },
+ {
+ "sk": "Slovak"
+ },
+ {
+ "sl": "Slovenian"
+ },
+ {
+ "se": "Northern Sami"
+ },
+ {
+ "sm": "Samoan"
+ },
+ {
+ "sn": "Shona"
+ },
+ {
+ "sd": "Sindhi"
+ },
+ {
+ "so": "Somali"
+ },
+ {
+ "st": "Sotho, Southern"
+ },
+ {
+ "es": "Spanish"
+ },
+ {
+ "sc": "Sardinian"
+ },
+ {
+ "sr": "Serbian"
+ },
+ {
+ "ss": "Swati"
+ },
+ {
+ "su": "Sundanese"
+ },
+ {
+ "sw": "Swahili"
+ },
+ {
+ "sv": "Swedish"
+ },
+ {
+ "ty": "Tahitian"
+ },
+ {
+ "ta": "Tamil"
+ },
+ {
+ "tt": "Tatar"
+ },
+ {
+ "te": "Telugu"
+ },
+ {
+ "tg": "Tajik"
+ },
+ {
+ "tl": "Tagalog"
+ },
+ {
+ "th": "Thai"
+ },
+ {
+ "bo": "Tibetan"
+ },
+ {
+ "ti": "Tigrinya"
+ },
+ {
+ "to": "Tonga (Tonga Islands)"
+ },
+ {
+ "tn": "Tswana"
+ },
+ {
+ "ts": "Tsonga"
+ },
+ {
+ "tk": "Turkmen"
+ },
+ {
+ "tr": "Turkish"
+ },
+ {
+ "tw": "Twi"
+ },
+ {
+ "ug": "Uighur"
+ },
+ {
+ "uk": "Ukrainian"
+ },
+ {
+ "ur": "Urdu"
+ },
+ {
+ "uz": "Uzbek"
+ },
+ {
+ "ve": "Venda"
+ },
+ {
+ "vi": "Vietnamese"
+ },
+ {
+ "vo": "Volapük"
+ },
+ {
+ "cy": "Welsh"
+ },
+ {
+ "wa": "Walloon"
+ },
+ {
+ "wo": "Wolof"
+ },
+ {
+ "xh": "Xhosa"
+ },
+ {
+ "yi": "Yiddish"
+ },
+ {
+ "yo": "Yoruba"
+ },
+ {
+ "za": "Zhuang"
+ },
+ {
+ "zu": "Zulu"
+ }
+ ]

--- a/Source/ja.lproj/profiles.json
+++ b/Source/ja.lproj/profiles.json
@@ -1,0 +1,59 @@
+{
+    "fields":[
+        {
+            "name" : "account_privacy",
+            "label" : "他の受講者が見ることができるのは：",
+            "type" : "switch",
+            "data_type" : "boolean",
+            "options" : {
+                "values" : [
+                    { "name" : "全プロフィール", "value" : "all_users" },
+                    { "name" : "限定プロフィール",  "value" : "private" }
+                ]
+            },
+            "instructions" : "限定プロフィールではあなたのユーザー名およびプロフィール写真のみ公開されます。",
+            "accessibility_hint" : "他の人に公開する情報を変更"
+        },
+        {
+            "name" : "year_of_birth",
+            "label" : "誕生年",
+            "type" : "select",
+            "options" : {
+                "range_min" : 1896,
+                "range_max" : 2019,
+                "allows_none" : true,
+                "none_label" : "誕生年なし"
+            },
+            "instructions" : "全プロフィールを公開する場合は誕生年を入力しなければなりません。",
+            "sub_instructions" : "これは公開されません。"
+        },
+        {
+            "name" : "country",
+            "label" : "現在地",
+            "type" : "select",
+            "data_type" : "country",
+            "options" : {
+                "reference" : "countries",
+                "allows_none" : true,
+                "none_label" : "現在地なし"
+            }
+        },
+        {
+            "name" : "language_proficiencies",
+            "label" : "第一言語",
+            "type" : "select",
+            "data_type" : "language",
+            "options" : {
+                "reference" : "languages",
+                "allows_none" : true,
+                "none_label" : "第一言語なし"
+            }
+        },
+        {
+            "name" : "bio",
+            "label" : "自己紹介",
+            "type" : "textarea",
+            "placeholder" : "私が学びたいのは…"
+        }
+    ]
+}

--- a/Source/ja.lproj/whats_new.json
+++ b/Source/ja.lproj/whats_new.json
@@ -1,0 +1,166 @@
+[
+    {
+        "version":"2.18",
+        "messages":[
+            {
+                "platforms":[
+                    "ios",
+                    "android"
+                ],
+                "image":"screen_1",
+                "title":"Program & Degree Discovery",
+                "message":"You can now search edX programs and degrees using the mobile application!"
+            }
+        ]
+    },
+    {
+        "version":"2.16",
+        "messages":[
+            {
+                "platforms":[
+                    "ios",
+                    "android"
+                ],
+                "image":"screen_1",
+                "title":"Programs on Mobile",
+                "message":"You can now view your edX programs on the go!"
+            }
+        ]
+    },
+    {
+        "version":"2.15",
+        "messages":[
+            {
+                "platforms":[
+                    "ios",
+                    "android"
+                ],
+                "image":"screen_1",
+                "title":"Improved Landscape and Rotation Support",
+                "message":"You can now rotate your iPhone or iPad for improved viewing on most areas of the application."
+            },
+            {
+                "platforms":[
+                    "ios",
+                    "android"
+                ],
+                "image":"screen_2",
+                "title":"Show Popular Subjects in Course Discovery",
+                "message":"Browse courses by subject when you are looking for new learning experiences!"
+            }
+        ]
+    },
+    {
+        "version":"2.14",
+        "messages":[
+            {
+                "platforms":[
+                    "ios",
+                    "android"
+                ],
+                "image":"screen_1",
+                "title":"Bulk Download Subsection Videos",
+                "message":"Easily download all videos within a subsection using the new toggle controls."
+            },
+            {
+                "platforms":[
+                    "ios",
+                    "android"
+                ],
+                "image":"screen_2",
+                "title":"Improved Video Streaming Quality",
+                "message":"Video streaming quality will now adapt based on your network. Improve video quality even further by connecting to a WiFi network!"
+            }
+        ]
+    },
+    {
+        "version":"2.13",
+        "messages":[
+            {
+                "platforms":[
+                    "ios",
+                    "android"
+                ],
+                "image":"screen_1",
+                "title":"Improved Navigation",
+                "message":"Quickly access your courses or discover new courses using the new application navigation."
+            },
+            {
+                "platforms":[
+                    "ios",
+                    "android"
+                ],
+                "image":"screen_2",
+                "title":"Bulk Video Download",
+                "message":"Easily download all videos within a course using the new toggle control."
+            }
+        ]
+    },
+    {
+        "version":"2.12",
+        "messages":[
+            {
+                "platforms":[
+                    "ios",
+                    "android"
+                ],
+                "image":"screen_1",
+                "title":"Improved Course Navigation",
+                "message":"Quickly jump to course videos, discussions, and important dates in your course using new in-course navigation."
+            }
+        ]
+    },
+    {
+        "version":"2.11",
+        "messages":[
+            {
+                "platforms":[
+                    "ios",
+                    "android"
+                ],
+                "image":"screen_1",
+                "title":"Updated Navigation",
+                "message":"A simplified main menu makes it easier to access and discover courses."
+            },
+            {
+                "platforms":[
+                    "ios",
+                    "android"
+                ],
+                "image":"screen_2",
+                "title":"Assignment Due Dates",
+                "message":"You can now see due dates for assignments in the course outline."
+            }
+        ]
+    },
+    {
+        "version":"2.10",
+        "messages":[
+            {
+                "platforms":[
+                    "ios",
+                    "android"
+                ],
+                "image":"screen_1",
+                "title":"Videos",
+                "message":"The \"Videos\" tab in each course's menu replaces \"My Videos\" in the main menu. Now you can view all the videos in a course in one place!"
+            },
+            {
+                "platforms":[
+                    "android"
+                ],
+                "image":"screen_2",
+                "title":"Delete Videos",
+                "message":"In the list of downloaded course videos, use a long press to select videos that you want to delete."
+            },
+            {
+                "platforms":[
+                    "ios"
+                ],
+                "image":"screen_2",
+                "title":"Delete Videos",
+                "message":"Swipe left to delete downloaded videos."
+            }
+        ]
+    }
+]

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -1002,6 +1002,15 @@
 		1AFEB1B21BBD52C7004C471D /* JSONFormBuilderTextEditor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONFormBuilderTextEditor.swift; sourceTree = "<group>"; };
 		1AFEB1B51BBD5B95004C471D /* ProfilePictureTaker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfilePictureTaker.swift; sourceTree = "<group>"; };
 		1AFEB1BA1BBD88F3004C471D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = en; path = en.lproj/languages.json; sourceTree = "<group>"; };
+		220570142307E9850026E65A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = ja; path = ja.lproj/subjects.json; sourceTree = "<group>"; };
+		220570152307E9850026E65A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = ja; path = ja.lproj/MobileAppEula.htm; sourceTree = "<group>"; };
+		220570162307E9850026E65A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = ja; path = ja.lproj/PrivacyPolicy.htm; sourceTree = "<group>"; };
+		220570172307E9850026E65A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = ja; path = ja.lproj/TermsOfServices.htm; sourceTree = "<group>"; };
+		220570182307E9850026E65A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		220570192307E9860026E65A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		2205701A2307E9860026E65A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = ja; path = ja.lproj/profiles.json; sourceTree = "<group>"; };
+		2205701B2307E9860026E65A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = ja; path = ja.lproj/languages.json; sourceTree = "<group>"; };
+		2205701C2307E9860026E65A /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = ja; path = ja.lproj/whats_new.json; sourceTree = "<group>"; };
 		2212FD3621D4BE84007409C3 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = "es-419"; path = "es-419.lproj/MobileAppEula.htm"; sourceTree = "<group>"; };
 		2212FD3821D4BE86007409C3 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = en; path = en.lproj/MobileAppEula.htm; sourceTree = "<group>"; };
 		2212FD3A21D4BE92007409C3 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = "es-419"; path = "es-419.lproj/PrivacyPolicy.htm"; sourceTree = "<group>"; };
@@ -4167,6 +4176,7 @@
 				fr,
 				"pt-BR",
 				de,
+				ja,
 			);
 			mainGroup = BECB7B021924C0C3009C77F1;
 			productRefGroup = BECB7B0C1924C0C3009C77F1 /* Products */;
@@ -5253,6 +5263,7 @@
 				2250E9D222DC623B00674093 /* fr */,
 				E006BD1422DF29D100AA5185 /* pt-BR */,
 				E01287E322EEDD2C0093285E /* de */,
+				2205701A2307E9860026E65A /* ja */,
 			);
 			name = profiles.json;
 			sourceTree = "<group>";
@@ -5268,6 +5279,7 @@
 				2250E9D322DC623B00674093 /* fr */,
 				E006BD1522DF29D100AA5185 /* pt-BR */,
 				E01287E422EEDD2C0093285E /* de */,
+				2205701B2307E9860026E65A /* ja */,
 			);
 			name = languages.json;
 			sourceTree = "<group>";
@@ -5283,6 +5295,7 @@
 				2250E9CD22DC623A00674093 /* fr */,
 				E006BD0F22DF29CF00AA5185 /* pt-BR */,
 				E01287DE22EEDD2A0093285E /* de */,
+				220570152307E9850026E65A /* ja */,
 			);
 			name = MobileAppEula.htm;
 			sourceTree = "<group>";
@@ -5298,6 +5311,7 @@
 				2250E9CE22DC623A00674093 /* fr */,
 				E006BD1022DF29CF00AA5185 /* pt-BR */,
 				E01287DF22EEDD2A0093285E /* de */,
+				220570162307E9850026E65A /* ja */,
 			);
 			name = PrivacyPolicy.htm;
 			sourceTree = "<group>";
@@ -5313,6 +5327,7 @@
 				2250E9CF22DC623A00674093 /* fr */,
 				E006BD1122DF29D000AA5185 /* pt-BR */,
 				E01287E022EEDD2B0093285E /* de */,
+				220570172307E9850026E65A /* ja */,
 			);
 			name = TermsOfServices.htm;
 			sourceTree = "<group>";
@@ -5328,6 +5343,7 @@
 				2250E9CC22DC623900674093 /* fr */,
 				E006BD0E22DF29CF00AA5185 /* pt-BR */,
 				E01287DD22EEDD290093285E /* de */,
+				220570142307E9850026E65A /* ja */,
 			);
 			name = subjects.json;
 			sourceTree = "<group>";
@@ -5343,6 +5359,7 @@
 				2250E9D022DC623A00674093 /* fr */,
 				E006BD1222DF29D000AA5185 /* pt-BR */,
 				E01287E122EEDD2B0093285E /* de */,
+				220570182307E9850026E65A /* ja */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -5358,6 +5375,7 @@
 				2250E9D122DC623B00674093 /* fr */,
 				E006BD1322DF29D100AA5185 /* pt-BR */,
 				E01287E222EEDD2C0093285E /* de */,
+				220570192307E9860026E65A /* ja */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -5373,6 +5391,7 @@
 				2250E9D422DC623C00674093 /* fr */,
 				E006BD1622DF29D200AA5185 /* pt-BR */,
 				E01287E522EEDD2C0093285E /* de */,
+				2205701C2307E9860026E65A /* ja */,
 			);
 			name = whats_new.json;
 			sourceTree = "<group>";


### PR DESCRIPTION
### Description

[LEARNER-7356](https://openedx.atlassian.net/browse/LEARNER-7356)

Japanese language support has added. All Resources are downloaded from [Transifex](https://www.transifex.com/open-edx/edx-mobile-apps/content/).  

### Notes
If Japanese translation of any string is missing then the english version of string will be display.  

### How to test this PR
Change the iOS device language to Japanese. To change the language follow the following path:
Settings -> General -> Language & Region -> iPhone Language

- [ ] App should work properly. It does not crash in any case.
- [ ] UI shouldn't appear distorted.
- [ ] Max range of Birth year in profile should be 2019.