### PR TITLE
Add NSBluetoothAlwaysUsageDescription key to edX-Info.plist file

### DIFF
--- a/Source/edX-Info.plist
+++ b/Source/edX-Info.plist
@@ -80,6 +80,8 @@
 	</dict>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>for bluetooth</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>for bluetooth</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>so user can intract with calendar</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
### Description
This fixes the following error, that is generated, when a new build is uploaded to itunes.

```
ITMS-90683: Missing Purpose String in Info.plist - Your app's code references one or more APIs that 
access sensitive user data. The app's Info.plist file should contain a 
NSBluetoothAlwaysUsageDescription key with a user-facing purpose string explaining clearly and 
completely why your app needs the data. Starting Spring 2019, all apps submitted to the App Store 
that access user data are required to include a purpose string. If you're using external libraries or 
SDKs, they may reference APIs that require a purpose string. While your app might not use these
 APIs, a purpose string is still required. You can contact the developer of the library or SDK and 
request they release a version of their code that doesn't contain the APIs. Learn more 
(https://developer.apple.com/documentation/uikit/core_app/protecting_the_user_s_privacy). 

```

