### PR TITLE
iOS -  Fix the issue in navigation to discussion thread with background push notification.

### DIFF
--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -269,6 +269,8 @@ extension OEXRouter {
         controller.navigationController?.delegate = self
         if let completion = completion {
             controller.navigationController?.pushViewController(viewController: responsesViewController, completion: completion)
+        } else {
+            controller.navigationController?.pushViewController(responsesViewController, animated: true)
         }
     }
     
@@ -308,6 +310,7 @@ extension OEXRouter {
 
     func showDiscussionPosts(from controller: UIViewController, courseID: String, topicID: String) {
         let postsController = PostsViewController(environment: environment, courseID: courseID, topicID: topicID)
+        controller.navigationController?.delegate = self
         controller.navigationController?.pushViewController(postsController, animated: true)
     }
     

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -310,7 +310,6 @@ extension OEXRouter {
 
     func showDiscussionPosts(from controller: UIViewController, courseID: String, topicID: String) {
         let postsController = PostsViewController(environment: environment, courseID: courseID, topicID: topicID)
-        controller.navigationController?.delegate = self
         controller.navigationController?.pushViewController(postsController, animated: true)
     }
     


### PR DESCRIPTION
### Description

[LEARNER-7485](https://openedx.atlassian.net/browse/LEARNER-7485)

In this PR I fixed the issue of app navigation on discussion thread with a deep link or push notification. I also verified the background push notification action for the thread update.

### How to test this PR
 - [ ] The app should open the discussion response screen when tap on the received background notification.