### PR TITLE
Show native alert dialog on FCM push message

### DIFF
--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -40,9 +40,7 @@ typealias DismissCompletion = () -> Void
         let type = link.type
         guard type != .none else { return }
         
-        let application = UIApplication.shared
-        
-        switch application.applicationState {
+        switch UIApplication.shared.applicationState {
         case .active:
             showAlert(with: link)
             break
@@ -54,13 +52,14 @@ typealias DismissCompletion = () -> Void
     
     private func showAlert(with link: PushLink) {
         guard let title = link.title,
-            let message = link.body
+            let message = link.body,
+            let topMostViewController = topMostViewController
             else { return }
-        UIAlertController().showAlert(with: title, message: message, preferredStyle: .alert, cancelButtonTitle: Strings.view, destructiveButtonTitle: Strings.cancel, otherButtonsTitle: nil, tapBlock: { [weak self] (_, _, index) in
-            if index == 0 {
-                self?.navigateToScreen(with: link.type, link: link)
-            }
-        })
+        
+        let controller = UIAlertController().showAlert(withTitle: title, message: message, cancelButtonTitle: Strings.cancel, onViewController: topMostViewController)
+        controller.addButton(withTitle: Strings.view) { [weak self] _ in
+            self?.navigateToScreen(with: link.type, link: link)
+        }
     }
     
     private func showLoginScreen() {

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -38,9 +38,30 @@ typealias DismissCompletion = () -> Void
     func processNotification(with link: PushLink, environment: Environment) {
         self.environment = environment
         let type = link.type
-        guard type != .none else { return }
+        guard type != .none,
+            let title = link.title,
+            let body = link.body
+            else { return }
         
-        navigateToScreen(with: type, link: link)
+        let application = UIApplication.shared
+    
+        switch application.applicationState {
+        case .active:
+            let alert = UIAlertController(title: title, message: body, preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "Ok", style: .default) { [weak self] _ in
+                self?.navigateToScreen(with: type, link: link)
+            }
+            let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { _ in
+                
+            }
+            alert.addAction(okAction)
+            alert.addAction(cancelAction)
+            application.delegate?.window??.rootViewController?.present(alert, animated: true, completion: nil)
+            break
+        default:
+            navigateToScreen(with: type, link: link)
+            break
+        }
     }
     
     private func showLoginScreen() {

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -53,11 +53,11 @@ typealias DismissCompletion = () -> Void
     private func showAlert(with link: PushLink) {
         guard let title = link.title,
             let message = link.body,
-            let topMostViewController = topMostViewController
+            let topController = topMostViewController
             else { return }
         
-        let controller = UIAlertController().showAlert(withTitle: title, message: message, cancelButtonTitle: Strings.cancel, onViewController: topMostViewController)
-        controller.addButton(withTitle: Strings.view) { [weak self] _ in
+        let alertController = UIAlertController().showAlert(withTitle: title, message: message, cancelButtonTitle: Strings.cancel, onViewController: topController)
+        alertController.addButton(withTitle: Strings.view) { [weak self] _ in
             self?.navigateToScreen(with: link.type, link: link)
         }
     }

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -42,7 +42,7 @@ typealias DismissCompletion = () -> Void
         
         switch UIApplication.shared.applicationState {
         case .active:
-            showAlert(with: link)
+            showNotificationAlert(with: link)
             break
         default:
             navigateToScreen(with: type, link: link)
@@ -50,7 +50,7 @@ typealias DismissCompletion = () -> Void
         }
     }
     
-    private func showAlert(with link: PushLink) {
+    private func showNotificationAlert(with link: PushLink) {
         guard let title = link.title,
             let message = link.body,
             let topController = topMostViewController

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -38,30 +38,29 @@ typealias DismissCompletion = () -> Void
     func processNotification(with link: PushLink, environment: Environment) {
         self.environment = environment
         let type = link.type
-        guard type != .none,
-            let title = link.title,
-            let body = link.body
-            else { return }
+        guard type != .none else { return }
         
         let application = UIApplication.shared
-    
+        
         switch application.applicationState {
         case .active:
-            let alert = UIAlertController(title: title, message: body, preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "Ok", style: .default) { [weak self] _ in
-                self?.navigateToScreen(with: type, link: link)
-            }
-            let cancelAction = UIAlertAction(title: "Cancel", style: .cancel) { _ in
-                
-            }
-            alert.addAction(okAction)
-            alert.addAction(cancelAction)
-            application.delegate?.window??.rootViewController?.present(alert, animated: true, completion: nil)
+            showAlert(with: link)
             break
         default:
             navigateToScreen(with: type, link: link)
             break
         }
+    }
+    
+    private func showAlert(with link: PushLink) {
+        guard let title = link.title,
+            let message = link.body
+            else { return }
+        UIAlertController().showAlert(with: title, message: message, preferredStyle: .alert, cancelButtonTitle: Strings.view, destructiveButtonTitle: Strings.cancel, otherButtonsTitle: nil, tapBlock: { [weak self] (_, _, index) in
+            if index == 0 {
+                self?.navigateToScreen(with: link.type, link: link)
+            }
+        })
     }
     
     private func showLoginScreen() {


### PR DESCRIPTION
### Description

[LEARNER-7508](https://openedx.atlassian.net/browse/LEARNER-7508)

When the app is in the foreground and a push notification is received, show a native dialogue with the following specifications.

The dialog will have the title and description along with 2 buttons:

Dismiss: for dismissing the dialog without any action.OK or View: for navigating the learner to the relevant screen according to the received push.

### How to test this PR
The app should show a native dialogue on receiving a push notification while the app is in the foreground state.


![IMG_15DBA4833DC4-1](https://user-images.githubusercontent.com/960241/70778556-61bf7200-1da4-11ea-8525-0988ca26dbb4.jpeg)
