### PR TITLE
Handle logged out case for Deep link

### DIFF
--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -62,12 +62,11 @@ typealias DismissCompletion = () -> Void
         }
     }
     
-    private func showLoginScreen() {
-        guard let topViewController = topMostViewController,
-            !(topViewController is OEXLoginViewController) else { return }
-        
+    private func showLoginScreen(link: DeepLink) {
         dismiss() { [weak self] in
-            self?.environment?.router?.showLoginScreen(from: nil, completion: nil)
+            self?.environment?.router?.showLoginScreen(completion: {
+                self?.navigateToScreen(with: link.type, link: link)
+            })
         }
     }
     
@@ -496,7 +495,7 @@ typealias DismissCompletion = () -> Void
         }
             
         else if !isUserLoggedin() {
-            showLoginScreen()
+            showLoginScreen(link: link)
             return
         }
         

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -62,7 +62,7 @@ typealias DismissCompletion = () -> Void
         }
     }
     
-    private func showLoginScreen(link: DeepLink) {
+    private func showLoginScreen(with link: DeepLink) {
         dismiss() { [weak self] in
             self?.environment?.router?.showLoginScreen(completion: {
                 self?.navigateToScreen(with: link.type, link: link)
@@ -495,7 +495,7 @@ typealias DismissCompletion = () -> Void
         }
             
         else if !isUserLoggedin() {
-            showLoginScreen(link: link)
+            showLoginScreen(with: link)
             return
         }
         

--- a/Source/OEXRouter.h
+++ b/Source/OEXRouter.h
@@ -51,6 +51,7 @@ extern NSString* OEXSideNavigationChangedStateKey;
 - (void)presentViewController:(UIViewController*)controller fromController:(nullable UIViewController*)fromController completion:(nullable void(^)(void))completion;
 
 #pragma mark Logistration
+- (void) showLoginScreenWithCompletion:(nullable void(^)(void))completion;
 - (void)showLoginScreenFromController:(nullable UIViewController*)controller completion:(nullable void(^)(void))completion;
 - (void)showLoggedOutScreen;
 - (void)showSignUpScreenFromController:(nullable UIViewController*)controller completion:(nullable void(^)(void))completion;

--- a/Source/OEXRouter.m
+++ b/Source/OEXRouter.m
@@ -41,7 +41,7 @@ OEXRegistrationViewControllerDelegate
 @property (strong, nonatomic) SingleChildContainingViewController* containerViewController;
 @property (strong, nonatomic) UIViewController* currentContentController;
 
-@property (strong, nonatomic) void(^registrationCompletion)(void);
+@property (strong, nonatomic) void(^logistrationCompletion)(void);
 
 @end
 
@@ -116,6 +116,11 @@ OEXRegistrationViewControllerDelegate
     [self showEnrolledTabBarView];
 }
 
+- (void) showLoginScreenWithCompletion:(nullable void(^)(void))completion {
+    self.logistrationCompletion = completion;
+    [self presentViewController:[self loginViewController] fromController:[[UIApplication sharedApplication] topMostController] completion:nil];
+}
+
 - (void)showLoginScreenFromController:(UIViewController*)controller completion:(void(^)(void))completion {
     [self presentViewController:[self loginViewController] fromController:[[UIApplication sharedApplication] topMostController] completion:completion];
 }
@@ -130,7 +135,7 @@ OEXRegistrationViewControllerDelegate
 }
 
 - (void)showSignUpScreenFromController:(UIViewController*)controller completion:(void(^)(void))completion {
-    self.registrationCompletion = completion;
+    self.logistrationCompletion = completion;
     OEXRegistrationViewController* registrationController = [[OEXRegistrationViewController alloc] initWithEnvironment:self.environment];
     ForwardingNavigationController *navController = [[ForwardingNavigationController alloc] initWithRootViewController:registrationController];
     registrationController.delegate = self;
@@ -184,15 +189,25 @@ OEXRegistrationViewControllerDelegate
 - (void)registrationViewControllerDidRegister:(OEXRegistrationViewController *)controller completion:(void (^)(void))completion {
     [self showLoggedInContent];
     [controller dismissViewControllerAnimated:YES completion:completion];
-    if (self.registrationCompletion) {
-        self.registrationCompletion();
-        self.registrationCompletion = nil;
+    if (self.logistrationCompletion) {
+        self.logistrationCompletion();
+        self.logistrationCompletion = nil;
     }
 }
 
 - (void)loginViewControllerDidLogin:(OEXLoginViewController *)loginController {
     [self showLoggedInContent];
-    [loginController dismissViewControllerAnimated:YES completion:nil];
+    __block OEXRouter *blockSelf = self;
+    [loginController dismissViewControllerAnimated:YES completion:^{
+        [blockSelf loginCompletion];
+    }];
+}
+
+- (void) loginCompletion {
+    if (self.logistrationCompletion) {
+        self.logistrationCompletion();
+        self.logistrationCompletion = nil;
+    }
 }
 
 #pragma mark Testing


### PR DESCRIPTION
### Description

[LEARNER-7510](https://openedx.atlassian.net/browse/LEARNER-7510)

Opening the app through a deep link that requires an authenticated user, if the leaner was not logged in the app was redirecting the leaner to the login screen. On successful, the app was just showing the enrolled courses screen and was not following the opened deep link.

This PR addresses the mentioned problem and now redirecting the leaner to the relevant screen on a successful login.

### Testing
- [ ] Leaner will redirect to the relevant screen on opening the app through the deep link
- [ ] Leaner will redirect to the relevant screen if the login screen was presented on opening the app through the deep link.
