### PR TITLE
Fix video landscape issue on iOS 13

### DIFF
--- a/Source/CutomePlayer/PlayerView.swift
+++ b/Source/CutomePlayer/PlayerView.swift
@@ -10,9 +10,7 @@ import UIKit
 import AVKit
 
 //Apple recommends a convenient way of using AVPlayerLayer in iOS as the backing layer for a UIView, in this way we can update playerLayer constraints
-class PlayerView: UIView {
-    var potraitFrame: CGRect? = nil
-    
+class PlayerView: UIView {    
     var playerLayer: AVPlayerLayer {
         return layer as! AVPlayerLayer
     }

--- a/Source/CutomePlayer/PlayerView.swift
+++ b/Source/CutomePlayer/PlayerView.swift
@@ -11,6 +11,7 @@ import AVKit
 
 //Apple recommends a convenient way of using AVPlayerLayer in iOS as the backing layer for a UIView, in this way we can update playerLayer constraints
 class PlayerView: UIView {
+    var potraitFrame: CGRect? = nil
     
     var playerLayer: AVPlayerLayer {
         return layer as! AVPlayerLayer

--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -281,12 +281,7 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         super.viewWillLayoutSubviews()
         
         if !didRotate && !isLandscape {
-            if let frame = playerView.potraitFrame {
-                playerView.frame = frame
-            } else {
-                playerView.frame = view.frame
-            }
-            setConstraints()
+            playerView.frame = view.frame
         } else {
             didRotate = false
             playerView.frame = movieBackgroundView.bounds

--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -517,8 +517,6 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         if !(view.subviews.contains(playerView)) {
             playerDelegate?.playerWillMoveFromWindow(videoPlayer: self)
             view.addSubview(playerView)
-            view.setNeedsLayout()
-            view.layoutIfNeeded()
             removeGestures()
             controls?.showHideNextPrevious(isHidden: true)
             playerView.snp.remakeConstraints { make in
@@ -716,19 +714,19 @@ extension VideoPlayer {
     
     func rotateMoviePlayer(for orientation: UIInterfaceOrientation, animated: Bool, forceRotate rotate: Bool, completion: (() -> Void)? = nil) {
         var angle: Double = 0
-        var movieFrame: CGRect = CGRect(x: movieBackgroundFrame.maxX, y: movieBackgroundFrame.maxY, width: movieBackgroundFrame.width, height: movieBackgroundFrame.height - 100)
+        var movieFrame: CGRect = CGRect(x: movieBackgroundFrame.maxX, y: movieBackgroundFrame.maxY, width: movieBackgroundFrame.width, height: movieBackgroundFrame.height)
         
         // Used to rotate the view on Fulscreen button click
         // Rotate it forcefully as the orientation is on the UIDeviceOrientation
         if rotate && orientation == .landscapeLeft {
             angle = Double.pi/2
             // MOB-1053
-            movieFrame = CGRect(x: movieBackgroundFrame.maxX, y: movieBackgroundFrame.maxY, width: movieBackgroundFrame.height, height: movieBackgroundFrame.width - 100)
+            movieFrame = CGRect(x: movieBackgroundFrame.maxX, y: movieBackgroundFrame.maxY, width: movieBackgroundFrame.height, height: movieBackgroundFrame.width)
         }
         else if rotate && orientation == .landscapeRight {
             angle = -Double.pi/2
             // MOB-1053
-            movieFrame = CGRect(x: movieBackgroundFrame.maxX, y: movieBackgroundFrame.maxY, width: movieBackgroundFrame.height, height: movieBackgroundFrame.width - 100)
+            movieFrame = CGRect(x: movieBackgroundFrame.maxX, y: movieBackgroundFrame.maxY, width: movieBackgroundFrame.height, height: movieBackgroundFrame.width)
         }
         
         if animated {

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -194,6 +194,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         label.textColor = .lightText
         label.textAlignment = .center
         label.text = Strings.videoPlayerDefaultRemainingTime
+        label.adjustsFontSizeToFitWidth = true
         label.layer.shadowColor = UIColor.black.cgColor
         label.layer.shadowRadius = 1
         label.layer.shadowOffset = CGSize(width: 1.0, height: 1.0)
@@ -365,7 +366,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         }
         
         btnPrevious.snp.makeConstraints { make in
-            make.leading.equalTo(self).offset(StandardVerticalMargin + 20)
+            make.leading.equalTo(self).offset(StandardHorizontalMargin*2)
             make.height.equalTo(previousButtonSize.height)
             make.width.equalTo(previousButtonSize.width)
             make.centerY.equalTo(self.snp.centerY)
@@ -378,15 +379,15 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         btnNext.snp.makeConstraints { make in
             make.height.equalTo(nextButtonSize.height)
             make.width.equalTo(nextButtonSize.width)
-            make.trailing.equalTo(self).inset(StandardVerticalMargin + 20)
+            make.trailing.equalTo(self).inset(StandardHorizontalMargin*2)
             make.centerY.equalTo(self.snp.centerY)
         }
         
         subTitleLabel.snp.makeConstraints { make in
-            make.bottom.equalTo(bottomBar.snp.top).offset(StandardHorizontalMargin*2)
+            make.bottom.equalTo(bottomBar.snp.top).offset(StandardVerticalMargin*4)
             make.centerX.equalTo(snp.centerX)
-            make.leadingMargin.greaterThanOrEqualTo(StandardVerticalMargin*2)
-            make.trailingMargin.lessThanOrEqualTo(StandardVerticalMargin*2)
+            make.leadingMargin.greaterThanOrEqualTo(StandardHorizontalMargin*2)
+            make.trailingMargin.lessThanOrEqualTo(StandardHorizontalMargin*2)
         }
     }
     

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -365,7 +365,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         }
         
         btnPrevious.snp.makeConstraints { make in
-            make.leading.equalTo(self).offset(StandardVerticalMargin)
+            make.leading.equalTo(self).offset(StandardVerticalMargin + 20)
             make.height.equalTo(previousButtonSize.height)
             make.width.equalTo(previousButtonSize.width)
             make.centerY.equalTo(self.snp.centerY)
@@ -378,7 +378,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         btnNext.snp.makeConstraints { make in
             make.height.equalTo(nextButtonSize.height)
             make.width.equalTo(nextButtonSize.width)
-            make.trailing.equalTo(self).inset(StandardVerticalMargin)
+            make.trailing.equalTo(self).inset(StandardVerticalMargin + 20)
             make.centerY.equalTo(self.snp.centerY)
         }
         

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -34,7 +34,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
     private let previousButtonSize = CGSize(width: 42.0, height: 42.0)
     private let rewindButtonSize = CGSize(width: 42.0, height: 42.0)
     private let durationSliderHeight: CGFloat = 34.0
-    private let timeRemainingLabelSize = CGSize(width: 75.0, height: 34.0)
+    private let timeRemainingLabelSize = CGSize(width: 120.0, height: 34.0)
     private let settingButtonSize = CGSize(width: 24.0, height: 24.0)
     private let fullScreenButtonSize = CGSize(width: 20.0, height: 20.0)
     private let tableSettingSize = CGSize(width: 110.0, height: 100.0)


### PR DESCRIPTION
### Description

[LEARNER-7575](https://openedx.atlassian.net/browse/LEARNER-7575)

On iOS 13, the video is not playing properly in the fullscreen mode. The experience is totally broken when the learner goes to fullscreen mode by clicking the fullscreen button. The video is also not covering the whole screen properly when the learner goes to fullscreen by rotating the device to landscape. 

### Notes
There is some issue with iOS version < 12, where the video player does not get back to the original frame after getting back from the landscape view.

### How to test this PR
Play some video on iOS 13, set it to fullscreen, video player should be in full-screen view with landscape orientation.