### PR TITLE
LEARNER-5729, Show loading indicator during applying subject filter

### DIFF
--- a/Source/DiscoveryWebViewHelper.swift
+++ b/Source/DiscoveryWebViewHelper.swift
@@ -381,6 +381,7 @@ extension DiscoveryWebViewHelper: UISearchBarDelegate {
             var params = params else { return }
         set(value: searchText, for: QueryParameterKeys.searchQuery, in: &params)
         if let URL = DiscoveryWebViewHelper.buildQuery(baseURL: baseURL.URLString, params: params) {
+            loadController.state = .Initial
             loadRequest(withURL: URL)
         }
     }

--- a/Source/DiscoveryWebViewHelper.swift
+++ b/Source/DiscoveryWebViewHelper.swift
@@ -331,6 +331,7 @@ extension DiscoveryWebViewHelper: SubjectsViewControllerDelegate, PopularSubject
         set(value: subject.filter, for: QueryParameterKeys.subject, in: &params)
         environment?.analytics.trackSubjectDiscovery(subjectID: subject.filter)
         if let url = DiscoveryWebViewHelper.buildQuery(baseURL: baseURL.URLString, params: params) {
+            loadController.state = .Initial
             loadRequest(withURL: url)
         }
     }


### PR DESCRIPTION
### Description

[LEARNER-5729](https://openedx.atlassian.net/browse/LEARNER-5729)

This PR is to fix the loading indicator during applying the subject filter on the course discovery screen.
I also added a loading indicator on the search results.

### How to test this PR
- Login into the app.
- Switch to discovery tap
- Tap on any subject

Expected Result:
Loading Indicator should show on screen during applying the subject filter.

