### PR TITLE
User profile improvements 

### DIFF
--- a/Source/JSONFormBuilderTextEditor.swift
+++ b/Source/JSONFormBuilderTextEditor.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+// Server has limit of 300 characters for bio
+private let BioTextMaxLimit = 300
+
 class JSONFormBuilderTextEditorViewController: UIViewController {
     let textView = OEXPlaceholderTextView()
     var text: String { return textView.text }
@@ -64,6 +67,16 @@ extension JSONFormBuilderTextEditorViewController : UITextViewDelegate {
     func textViewShouldEndEditing(_ textView: UITextView) -> Bool {
         textView.resignFirstResponder()
         return true
+    }
+
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        let expectedText = (textView.text as NSString).replacingCharacters(in: range, with: text)
+
+        if expectedText.count > BioTextMaxLimit {
+            let text: NSString = expectedText as NSString
+            textView.text = text.substring(to: BioTextMaxLimit)
+        }
+        return expectedText.count <= BioTextMaxLimit
     }
     
 }

--- a/Source/UserProfileEditViewController.swift
+++ b/Source/UserProfileEditViewController.swift
@@ -54,7 +54,7 @@ extension UserProfile : FormData {
         case .YearOfBirth:
             let newValue = value.flatMap { Int($0) }
             if newValue != birthYear {
-                updateDictionary[key] = newValue as AnyObject?
+                updateDictionary[key] = newValue as AnyObject
             }
             birthYear = newValue
         case .LanguagePreferences:
@@ -70,11 +70,11 @@ extension UserProfile : FormData {
             countryCode = value
         case .Bio:
             if value != bio {
-                updateDictionary[key] = value as AnyObject 
+                updateDictionary[key] = value as AnyObject? ?? "" as AnyObject
             }
             bio = value
         case .AccountPrivacy:
-            setLimitedProfile(newValue: NSString(string: value!).boolValue)
+            setLimitedProfile(newValue: NSString(string: value ?? "").boolValue)
         default: break
             
         }
@@ -167,7 +167,7 @@ class UserProfileEditViewController: UIViewController, UITableViewDelegate, UITa
         
         if let form = JSONFormBuilder(jsonFile: "profiles") {
             JSONFormBuilder.registerCells(tableView: tableView)
-            fields = form.fields!
+            fields = form.fields ?? []
         }
         addBackBarButtonItem()
     }
@@ -222,7 +222,6 @@ class UserProfileEditViewController: UIViewController, UITableViewDelegate, UITa
                     let message = Strings.Profile.unableToSend(fieldName: fieldDescription)
                     self?.showError(message: message)
                     self?.profile.updateDictionary.removeAll()
-
                 }
             }
         }


### PR DESCRIPTION
### Description

[LEARNER-7624](https://openedx.atlassian.net/browse/LEARNER-7624)

Roughly a year ago server has set a limit of `300 characters` for user `bio` text. Mobile apps weren't aware of this change and were letting the user input bio text as much he wants but the server wasn't accepting it and was returning an error.

This PR now limits the user to add bio text to a maximum of 300 characters. If the user pasted the text more than of the limit, the system should automatically trim the text to 300 characters.

### Testing
- [ ] Add bio text from 0 -300 characters. It should work.
- [ ] Add more than 300 characters. The system shouldn't allow the user to add text more than 300 characters.
- [ ] Paste text of more than 300 characters, the first 300 or available characters from 300 should be pasted in the Bio text and rest should be ignored.