### PR TITLE
iOS - Explore new programs

### DIFF
--- a/Source/EnrolledTabBarViewController.swift
+++ b/Source/EnrolledTabBarViewController.swift
@@ -192,9 +192,9 @@ class EnrolledTabBarViewController: UITabBarController, UITabBarControllerDelega
         case .courseDiscovery, .courseDetail, .programDiscovery, .programDiscoveryDetail, .degreeDiscovery, .degreeDiscoveryDetail:
             let isCourseDiscoveryEnabled = environment.config.discovery.course.isEnabled
             let isProgramDiscoveryEnabled = environment.config.discovery.program.isEnabled
-            let isDegreeDiscveryEnabled = environment.config.discovery.degree.isEnabled
+            let isDegreeDiscoveryEnabled = environment.config.discovery.degree.isEnabled
             
-            if (isCourseDiscoveryEnabled && (isProgramDiscoveryEnabled || isDegreeDiscveryEnabled)) {
+            if (isCourseDiscoveryEnabled && (isProgramDiscoveryEnabled || isDegreeDiscoveryEnabled)) {
                 selectedIndex = tabBarViewControllerIndex(with: DiscoveryViewController.self)
             }
             else if isCourseDiscoveryEnabled {

--- a/Source/EnrolledTabBarViewController.swift
+++ b/Source/EnrolledTabBarViewController.swift
@@ -188,6 +188,7 @@ class EnrolledTabBarViewController: UITabBarController, UITabBarControllerDelega
         switch type {
         case .program, .programDetail:
             selectedIndex = tabBarViewControllerIndex(with: ProgramsViewController.self)
+            break
         case .courseDiscovery, .courseDetail, .programDiscovery, .programDiscoveryDetail, .degreeDiscovery, .degreeDiscoveryDetail:
             let isCourseDiscoveryEnabled = environment.config.discovery.course.isEnabled
             let isProgramDiscoveryEnabled = environment.config.discovery.program.isEnabled
@@ -199,6 +200,7 @@ class EnrolledTabBarViewController: UITabBarController, UITabBarControllerDelega
             else if isCourseDiscoveryEnabled {
                 selectedIndex = environment.config.discovery.course.type == .webview ? tabBarViewControllerIndex(with: OEXFindCoursesViewController.self) : tabBarViewControllerIndex(with: CourseCatalogViewController.self)
             }
+            break
         default:
             selectedIndex = 0
             break

--- a/Source/EnrolledTabBarViewController.swift
+++ b/Source/EnrolledTabBarViewController.swift
@@ -199,7 +199,7 @@ class EnrolledTabBarViewController: UITabBarController, UITabBarControllerDelega
                 selectedIndex = tabBarViewControllerIndex(with: DiscoveryViewController.self)
             }
             else if isCourseDiscoveryEnabled {
-                selectedIndex = tabBarViewControllerIndex(with: CourseCatalogViewController.self)
+                selectedIndex = environment.config.discovery.course.type == .webview ? tabBarViewControllerIndex(with: OEXFindCoursesViewController.self) : tabBarViewControllerIndex(with: CourseCatalogViewController.self)
             }
         default:
             selectedIndex = 0

--- a/Source/EnrolledTabBarViewController.swift
+++ b/Source/EnrolledTabBarViewController.swift
@@ -193,9 +193,7 @@ class EnrolledTabBarViewController: UITabBarController, UITabBarControllerDelega
             let isProgramDiscoveryEnabled = environment.config.discovery.program.isEnabled
             let isDegreeDiscveryEnabled = environment.config.discovery.degree.isEnabled
             
-            if (isCourseDiscoveryEnabled && isProgramDiscoveryEnabled && isDegreeDiscveryEnabled) ||
-                (isCourseDiscoveryEnabled && isProgramDiscoveryEnabled) ||
-                (isCourseDiscoveryEnabled && isDegreeDiscveryEnabled) {
+            if (isCourseDiscoveryEnabled && (isProgramDiscoveryEnabled || isDegreeDiscveryEnabled)) {
                 selectedIndex = tabBarViewControllerIndex(with: DiscoveryViewController.self)
             }
             else if isCourseDiscoveryEnabled {

--- a/Source/EnrolledTabBarViewController.swift
+++ b/Source/EnrolledTabBarViewController.swift
@@ -189,7 +189,18 @@ class EnrolledTabBarViewController: UITabBarController, UITabBarControllerDelega
         case .program, .programDetail:
             selectedIndex = tabBarViewControllerIndex(with: ProgramsViewController.self)
         case .courseDiscovery, .courseDetail, .programDiscovery, .programDiscoveryDetail, .degreeDiscovery, .degreeDiscoveryDetail:
-            selectedIndex = tabBarViewControllerIndex(with: DiscoveryViewController.self)
+            let isCourseDiscoveryEnabled = environment.config.discovery.course.isEnabled
+            let isProgramDiscoveryEnabled = environment.config.discovery.program.isEnabled
+            let isDegreeDiscveryEnabled = environment.config.discovery.degree.isEnabled
+            
+            if (isCourseDiscoveryEnabled && isProgramDiscoveryEnabled && isDegreeDiscveryEnabled) ||
+                (isCourseDiscoveryEnabled && isProgramDiscoveryEnabled) ||
+                (isCourseDiscoveryEnabled && isDegreeDiscveryEnabled) {
+                selectedIndex = tabBarViewControllerIndex(with: DiscoveryViewController.self)
+            }
+            else if isCourseDiscoveryEnabled {
+                selectedIndex = tabBarViewControllerIndex(with: CourseCatalogViewController.self)
+            }
         default:
             selectedIndex = 0
             break

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -418,9 +418,7 @@ extension OEXRouter {
         let isProgramDiscoveryEnabled = environment.config.discovery.program.isEnabled
         let isDegreeDiscveryEnabled = environment.config.discovery.degree.isEnabled
         
-        if (isCourseDiscoveryEnabled && isProgramDiscoveryEnabled && isDegreeDiscveryEnabled) ||
-            (isCourseDiscoveryEnabled && isProgramDiscoveryEnabled) ||
-            (isCourseDiscoveryEnabled && isDegreeDiscveryEnabled) {
+        if (isCourseDiscoveryEnabled && (isProgramDiscoveryEnabled || isDegreeDiscveryEnabled)) {
             return DiscoveryViewController(with: environment, bottomBar: bottomBar, searchQuery: searchQuery)
         }
         else if isCourseDiscoveryEnabled {

--- a/Source/WebView/DiscoveryHelper.swift
+++ b/Source/WebView/DiscoveryHelper.swift
@@ -28,6 +28,7 @@ enum WebviewActions: String {
     case enrolledCourseDetail = "enrolled_course_info"
     case enrolledProgramDetail = "enrolled_program_info"
     case programDetail = "program_info"
+    case courseProgram = "course"
 }
 
 class DiscoveryHelper: NSObject {
@@ -161,7 +162,11 @@ extension DiscoveryHelper {
             let type = (controller is DegreesViewController) ? ProgramDiscoveryScreen.degree: ProgramDiscoveryScreen.program
             environment.router?.showProgramDetail(from: controller, with: pathId, bottomBar: bottomBar, type: type)
             break
+        case .courseProgram:
+            environment.router?.showDiscoveryController(from: controller, type: .programDiscovery, isUserLoggedIn: true, pathID: nil)
+            break
         }
+        
         return true
     }
 }


### PR DESCRIPTION
### Description

[LEARNER-7587](https://openedx.atlassian.net/browse/LEARNER-7587)

On ‘My Programs' screen 'Explore New Programs' button was showing error due to the backend’s change of altering the previous URL on the button to mobile-specific URI i.e. `edxapp://course?programs. This PR fixed this issue.

### How to test this PR
- Run the app
- Switch programs tab
- scroll down the view and press the explore program button, the app should navigate to programs discovery view.
