### PR TITLE
iOS - Add option in the video player for going backward & forward

### DIFF
--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -569,7 +569,9 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         playerControls.updateTimeLabel(elapsedTime: backTime, duration: videoDuration)
         seek(to: backTime)
         
-        if let videoId = video?.summary?.videoID, let courseId = video?.course_id, let unitUrl = video?.summary?.unitURL {
+        if let videoId = video?.summary?.videoID,
+            let courseId = video?.course_id,
+            let unitUrl = video?.summary?.unitURL {
             environment.analytics.trackVideoSeek(videoId, requestedDuration:-videoSkipBackwardsDuration, oldTime:oldTime, newTime: currentTime, courseID: courseId, unitURL: unitUrl, skipType: "skip")
         }
     }
@@ -582,7 +584,9 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         playerControls.updateTimeLabel(elapsedTime: forwardTime, duration: videoDuration)
         seek(to: forwardTime)
         
-        if let videoId = video?.summary?.videoID, let courseId = video?.course_id, let unitUrl = video?.summary?.unitURL {
+        if let videoId = video?.summary?.videoID,
+            let courseId = video?.course_id,
+            let unitUrl = video?.summary?.unitURL {
             environment.analytics.trackVideoSeek(videoId, requestedDuration:videoSkipForwardsDuration, oldTime:oldTime, newTime: currentTime, courseID: courseId, unitURL: unitUrl, skipType: "skip")
         }
     }
@@ -612,7 +616,9 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         let elapsedTime: Float64 = videoDuration * Float64(playerControls.durationSliderValue)
         playerControls.updateTimeLabel(elapsedTime: elapsedTime, duration: videoDuration)
         seek(to: elapsedTime)
-        if let videoId = video?.summary?.videoID, let courseId = video?.course_id, let unitUrl = video?.summary?.unitURL {
+        if let videoId = video?.summary?.videoID,
+            let courseId = video?.course_id,
+            let unitUrl = video?.summary?.unitURL {
             environment.analytics.trackVideoSeek(videoId, requestedDuration:currentTime - playerTimeBeforeSeek, oldTime:playerTimeBeforeSeek, newTime: currentTime, courseID: courseId, unitURL: unitUrl, skipType: "slide")
         }
     }

--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -46,8 +46,8 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
     let loadingIndicatorView = UIActivityIndicatorView(style: .white)
     private var lastElapsedTime: TimeInterval = 0
     private var transcriptManager: TranscriptManager?
-    let videoSkipBackwardsDuration: Double = 10
-    let videoSkipForwardsDuration: Double = 15
+    let videoSkipBackwardDuration: Double = 10
+    let videoSkipForwardDuration: Double = 15
     private var playerTimeBeforeSeek:TimeInterval = 0
     private var playerState: PlayerState = .stoped
     private var isObserverAdded: Bool = false
@@ -565,14 +565,14 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         let oldTime = currentTime
         let videoDuration = CMTimeGetSeconds(duration)
         let elapsedTime: Float64 = videoDuration * Float64(playerControls.durationSliderValue)
-        let backTime = elapsedTime > videoSkipBackwardsDuration ? elapsedTime - videoSkipBackwardsDuration : 0.0
+        let backTime = elapsedTime > videoSkipBackwardDuration ? elapsedTime - videoSkipBackwardDuration : 0.0
         playerControls.updateTimeLabel(elapsedTime: backTime, duration: videoDuration)
         seek(to: backTime)
         
         if let videoId = video?.summary?.videoID,
             let courseId = video?.course_id,
             let unitUrl = video?.summary?.unitURL {
-            environment.analytics.trackVideoSeek(videoId, requestedDuration:-videoSkipBackwardsDuration, oldTime:oldTime, newTime: currentTime, courseID: courseId, unitURL: unitUrl, skipType: "skip")
+            environment.analytics.trackVideoSeek(videoId, requestedDuration:-videoSkipBackwardDuration, oldTime:oldTime, newTime: currentTime, courseID: courseId, unitURL: unitUrl, skipType: "skip")
         }
     }
     
@@ -580,14 +580,14 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         let oldTime = currentTime
         let videoDuration = CMTimeGetSeconds(duration)
         let elapsedTime: Float64 = videoDuration * Float64(playerControls.durationSliderValue)
-        let forwardTime = elapsedTime < videoDuration ? elapsedTime + videoSkipForwardsDuration : videoDuration
+        let forwardTime = elapsedTime < videoDuration ? elapsedTime + videoSkipForwardDuration : videoDuration
         playerControls.updateTimeLabel(elapsedTime: forwardTime, duration: videoDuration)
         seek(to: forwardTime)
         
         if let videoId = video?.summary?.videoID,
             let courseId = video?.course_id,
             let unitUrl = video?.summary?.unitURL {
-            environment.analytics.trackVideoSeek(videoId, requestedDuration:videoSkipForwardsDuration, oldTime:oldTime, newTime: currentTime, courseID: courseId, unitURL: unitUrl, skipType: "skip")
+            environment.analytics.trackVideoSeek(videoId, requestedDuration:videoSkipForwardDuration, oldTime:oldTime, newTime: currentTime, courseID: courseId, unitURL: unitUrl, skipType: "skip")
         }
     }
     

--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -540,12 +540,12 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
             environment.interface?.sendAnalyticsEvents(.pause, withCurrentTime: currentTime, forVideo: video, playMedium: nil)
         }
         else {
-
+            
             guard let video = video else { return }
-
+            
             let playedInterval = environment.interface?.lastPlayedInterval(forVideo: video) ?? 0.0
             let duration = Float(video.summary?.duration ?? 0)
-
+            
             // Ignore the last second of video because sometimes saved played time is 1 second less duration for a watched video
             if duration > 0 && playedInterval + 1 >= duration {
                 // Replay the video

--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -46,8 +46,8 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
     let loadingIndicatorView = UIActivityIndicatorView(style: .white)
     private var lastElapsedTime: TimeInterval = 0
     private var transcriptManager: TranscriptManager?
-    private let videoSkipBackwardsDuration: Double = 10
-    private let videoSkipForwardsDuration: Double = 15
+    let videoSkipBackwardsDuration: Double = 10
+    let videoSkipForwardsDuration: Double = 15
     private var playerTimeBeforeSeek:TimeInterval = 0
     private var playerState: PlayerState = .stoped
     private var isObserverAdded: Bool = false

--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -46,7 +46,8 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
     let loadingIndicatorView = UIActivityIndicatorView(style: .white)
     private var lastElapsedTime: TimeInterval = 0
     private var transcriptManager: TranscriptManager?
-    private let videoSkipBackwardsDuration: Double = 30
+    private let videoSkipBackwardsDuration: Double = 10
+    private let videoSkipForwardsDuration: Double = 15
     private var playerTimeBeforeSeek:TimeInterval = 0
     private var playerState: PlayerState = .stoped
     private var isObserverAdded: Bool = false
@@ -569,7 +570,20 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         seek(to: backTime)
         
         if let videoId = video?.summary?.videoID, let courseId = video?.course_id, let unitUrl = video?.summary?.unitURL {
-            environment.analytics.trackVideoSeekRewind(videoId, requestedDuration:-videoSkipBackwardsDuration, oldTime:oldTime, newTime: currentTime, courseID: courseId, unitURL: unitUrl, skipType: "skip")
+            environment.analytics.trackVideoSeek(videoId, requestedDuration:-videoSkipBackwardsDuration, oldTime:oldTime, newTime: currentTime, courseID: courseId, unitURL: unitUrl, skipType: "skip")
+        }
+    }
+    
+    func seekForwardPressed(playerControls: VideoPlayerControls) {
+        let oldTime = currentTime
+        let videoDuration = CMTimeGetSeconds(duration)
+        let elapsedTime: Float64 = videoDuration * Float64(playerControls.durationSliderValue)
+        let forwardTime = elapsedTime < videoDuration ? elapsedTime + videoSkipForwardsDuration : videoDuration
+        playerControls.updateTimeLabel(elapsedTime: forwardTime, duration: videoDuration)
+        seek(to: forwardTime)
+        
+        if let videoId = video?.summary?.videoID, let courseId = video?.course_id, let unitUrl = video?.summary?.unitURL {
+            environment.analytics.trackVideoSeek(videoId, requestedDuration:videoSkipForwardsDuration, oldTime:oldTime, newTime: currentTime, courseID: courseId, unitURL: unitUrl, skipType: "skip")
         }
     }
     
@@ -599,7 +613,7 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         playerControls.updateTimeLabel(elapsedTime: elapsedTime, duration: videoDuration)
         seek(to: elapsedTime)
         if let videoId = video?.summary?.videoID, let courseId = video?.course_id, let unitUrl = video?.summary?.unitURL {
-            environment.analytics.trackVideoSeekRewind(videoId, requestedDuration:currentTime - playerTimeBeforeSeek, oldTime:playerTimeBeforeSeek, newTime: currentTime, courseID: courseId, unitURL: unitUrl, skipType: "slide")
+            environment.analytics.trackVideoSeek(videoId, requestedDuration:currentTime - playerTimeBeforeSeek, oldTime:playerTimeBeforeSeek, newTime: currentTime, courseID: courseId, unitURL: unitUrl, skipType: "slide")
         }
     }
     

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -127,7 +127,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         button.setImage(UIImage.RewindIcon(), for: .normal)
         button.imageView?.transform = CGAffineTransform(scaleX: -1, y: 1); //Flipped
         button.tintColor = .white
-        button.oex_addAction( {[weak self] action in
+        button.oex_addAction({ [weak self] action in
             guard let weakSelf = self, weakSelf.durationSliderValue < weakSelf.durationSlider.maximumValue - 0.001 else { return }
             weakSelf.delegate?.seekVideo(playerControls: weakSelf, skipDuration: weakSelf.seekForwardDuration, type: .forward)
             weakSelf.seekAnimation(seekLabel: weakSelf.seekForwardLabel, seekType: .forward, animationOffset: 50)
@@ -141,7 +141,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         slider.setThumbImage(UIImage(named: "ic_seek_thumb.png"), for: .normal)
         slider.setMinimumTrackImage(UIImage(named: "ic_progressbar.png"), for: .normal)
         slider.secondaryTrackColor = UIColor(red: 76.0/255.0, green: 135.0/255.0, blue: 130.0/255.0, alpha: 0.9)
-        slider.oex_addAction({[weak self] (action) in
+        slider.oex_addAction({ [weak self] (action) in
             if let weakSelf = self {
                 weakSelf.delegate?.sliderValueChanged(playerControls: weakSelf)
             }

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -670,7 +670,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
             UIView.animate(withDuration: seekAnimationDuration, delay: 0.0, options: UIView.AnimationOptions.curveEaseOut, animations: {
                 seekLabel.alpha = 1.0
                 let offset = seekType == .forward ? animationOffset : -animationOffset
-                seekLabel.frame = CGRect(x: seekLabel.frame.origin.x + offset, y: seekLabel.frame.origin.y, width: seekLabel.frame.size.width, height: seekLabel.frame.size.height)
+                seekLabel.frame = CGRect(x: defaultFrame.origin.x + offset, y: defaultFrame.origin.y, width: defaultFrame.size.width, height: defaultFrame.size.height)
             }) { [weak self] finished in
                 seekLabel.frame = defaultFrame
                 seekLabel.alpha = 0.0

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -116,9 +116,8 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         button.tintColor = .white
         button.oex_addAction({[weak self] (action) in
             guard let weakSelf = self, weakSelf.durationSliderValue > weakSelf.durationSlider.minimumValue else {return}
-                weakSelf.autoHide()
                 weakSelf.delegate?.seekVideo(playerControls: weakSelf, skipDuration: weakSelf.seekBackwardDuration, type: .rewind)
-                weakSelf.seekAnimation(seekLabel: weakSelf.seekRewindLabel, seekType: .rewind, animationFrame: 45)
+                weakSelf.seekAnimation(seekLabel: weakSelf.seekRewindLabel, seekType: .rewind, animationOffset: 45)
             }, for: .touchUpInside)
         return button
     }()
@@ -130,9 +129,8 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         button.tintColor = .white
         button.oex_addAction({[weak self] (action) in
             guard let weakSelf = self, weakSelf.durationSliderValue < weakSelf.durationSlider.maximumValue - 0.001 else {return}
-                weakSelf.autoHide()
                 weakSelf.delegate?.seekVideo(playerControls: weakSelf, skipDuration: weakSelf.seekForwardDuration, type: .forward)
-            weakSelf.seekAnimation(seekLabel: weakSelf.seekForwardLabel, seekType: .forward, animationFrame: 50)
+                weakSelf.seekAnimation(seekLabel: weakSelf.seekForwardLabel, seekType: .forward, animationOffset: 50)
             }, for: .touchUpInside)
         return button
     }()
@@ -663,17 +661,18 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         stopBufferedTimer()
     }
     
-    func seekAnimation(seekLabel: UILabel, seekType: SeekType, animationFrame: CGFloat) {
+    func seekAnimation(seekLabel: UILabel, seekType: SeekType, animationOffset: CGFloat) {
+        autoHide()
         if !isAnimating {
             isAnimating = true
+            let defaultFrame = seekLabel.frame
             seekLabel.text = seekType == .rewind ? String(format: "-%d", Int(seekBackwardDuration)) : String(format: "+%d", Int(seekForwardDuration))
             UIView.animate(withDuration: seekAnimationDuration, delay: 0.0, options: UIView.AnimationOptions.curveEaseOut, animations: {
                 seekLabel.alpha = 1.0
-                let positionX = seekType == .forward ? animationFrame : -animationFrame
-                seekLabel.frame = CGRect(x: seekLabel.frame.origin.x + positionX, y: seekLabel.frame.origin.y, width: seekLabel.frame.size.width, height: seekLabel.frame.size.height)
+                let offset = seekType == .forward ? animationOffset : -animationOffset
+                seekLabel.frame = CGRect(x: seekLabel.frame.origin.x + offset, y: seekLabel.frame.origin.y, width: seekLabel.frame.size.width, height: seekLabel.frame.size.height)
             }) { [weak self] finished in
-                let positionX = seekType == .forward ? -animationFrame : animationFrame
-                    seekLabel.frame = CGRect(x: seekLabel.frame.origin.x + positionX, y: seekLabel.frame.origin.y, width: seekLabel.frame.size.width, height: seekLabel.frame.size.height)
+                seekLabel.frame = defaultFrame
                 seekLabel.alpha = 0.0
                 self?.isAnimating = false
             }

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -46,8 +46,8 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
     private let nextButtonSize = CGSize(width: 42.0, height: 42.0)
     private let seekAnimationDuration = 0.4
     private let seekLabelSize : CGFloat = OEXTextStyle.pointSize(for: OEXTextSize.base)
-    let seekBackwardDuration: Double = 10
-    let seekForwardDuration: Double = 15
+    private let seekBackwardDuration: Double = 10
+    private let seekForwardDuration: Double = 15
     
     var video : OEXHelperVideoDownload? {
         didSet {
@@ -95,7 +95,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         label.backgroundColor = .clear
         label.textColor = .white
         label.alpha = 0.0
-        label.font = self.environment.styles.sansSerif(ofSize: seekLabelSize)
+        label.font = environment.styles.sansSerif(ofSize: seekLabelSize)
         label.layer.shouldRasterize = true
         return label
     }()
@@ -105,7 +105,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         label.backgroundColor = .clear
         label.textColor = .white
         label.alpha = 0.0
-        label.font = self.environment.styles.sansSerif(ofSize: seekLabelSize)
+        label.font = environment.styles.sansSerif(ofSize: seekLabelSize)
         label.layer.shouldRasterize = true
         return label
     }()
@@ -114,23 +114,23 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         let button = CustomPlayerButton()
         button.setImage(UIImage.RewindIcon(), for: .normal)
         button.tintColor = .white
-        button.oex_addAction({[weak self] (action) in
-            guard let weakSelf = self, weakSelf.durationSliderValue > weakSelf.durationSlider.minimumValue else {return}
-                weakSelf.delegate?.seekVideo(playerControls: weakSelf, skipDuration: weakSelf.seekBackwardDuration, type: .rewind)
-                weakSelf.seekAnimation(seekLabel: weakSelf.seekRewindLabel, seekType: .rewind, animationOffset: 45)
+        button.oex_addAction({ [weak self] action in
+            guard let weakSelf = self, weakSelf.durationSliderValue > weakSelf.durationSlider.minimumValue else { return }
+            weakSelf.delegate?.seekVideo(playerControls: weakSelf, skipDuration: weakSelf.seekBackwardDuration, type: .rewind)
+            weakSelf.seekAnimation(seekLabel: weakSelf.seekRewindLabel, seekType: .rewind, animationOffset: 45)
             }, for: .touchUpInside)
         return button
     }()
-
+    
     lazy private var forwardButton: CustomPlayerButton = {
         let button = CustomPlayerButton()
         button.setImage(UIImage.RewindIcon(), for: .normal)
         button.imageView?.transform = CGAffineTransform(scaleX: -1, y: 1); //Flipped
         button.tintColor = .white
-        button.oex_addAction({[weak self] (action) in
-            guard let weakSelf = self, weakSelf.durationSliderValue < weakSelf.durationSlider.maximumValue - 0.001 else {return}
-                weakSelf.delegate?.seekVideo(playerControls: weakSelf, skipDuration: weakSelf.seekForwardDuration, type: .forward)
-                weakSelf.seekAnimation(seekLabel: weakSelf.seekForwardLabel, seekType: .forward, animationOffset: 50)
+        button.oex_addAction( {[weak self] action in
+            guard let weakSelf = self, weakSelf.durationSliderValue < weakSelf.durationSlider.maximumValue - 0.001 else { return }
+            weakSelf.delegate?.seekVideo(playerControls: weakSelf, skipDuration: weakSelf.seekForwardDuration, type: .forward)
+            weakSelf.seekAnimation(seekLabel: weakSelf.seekForwardLabel, seekType: .forward, animationOffset: 50)
             }, for: .touchUpInside)
         return button
     }()
@@ -299,7 +299,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         addSubview(tableSettings)
         addSubview(seekForwardLabel)
         addSubview(seekRewindLabel)
-
+        
         sendSubviewToBack(tapButton)
     }
     
@@ -561,11 +561,11 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
             autoHide()
         }
     }
-
+    
     @objc private func hideControls() {
         hideAndShowControls(isHidden: true)
     }
-
+    
     @objc private func showControls() {
         hideAndShowControls(isHidden: false)
     }
@@ -573,7 +573,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
     private func settingsButtonClicked() {
         NSObject.cancelPreviousPerformRequests(withTarget:self)
         tableSettings.isHidden = !tableSettings.isHidden
-
+        
         if tableSettings.isHidden {
             autoHide()
         }

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -12,6 +12,7 @@ import CoreMedia
 protocol VideoPlayerControlsDelegate: class {
     func playPausePressed(playerControls: VideoPlayerControls, isPlaying: Bool)
     func seekBackwardPressed(playerControls: VideoPlayerControls)
+    func seekForwardPressed(playerControls: VideoPlayerControls)
     func fullscreenPressed(playerControls: VideoPlayerControls)
     func setPlayBackSpeed(playerControls: VideoPlayerControls, speed:OEXVideoSpeed)
     func sliderValueChanged(playerControls: VideoPlayerControls)
@@ -34,7 +35,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
     private let previousButtonSize = CGSize(width: 42.0, height: 42.0)
     private let rewindButtonSize = CGSize(width: 42.0, height: 42.0)
     private let durationSliderHeight: CGFloat = 34.0
-    private let timeRemainingLabelSize = CGSize(width: 120.0, height: 34.0)
+    private let timeRemainingLabelSize = CGSize(width: 80, height: 34.0)
     private let settingButtonSize = CGSize(width: 24.0, height: 24.0)
     private let fullScreenButtonSize = CGSize(width: 20.0, height: 20.0)
     private let tableSettingSize = CGSize(width: 110.0, height: 100.0)
@@ -88,6 +89,19 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         button.oex_addAction({[weak self] (action) in
             if let weakSelf = self {
                 weakSelf.delegate?.seekBackwardPressed(playerControls: weakSelf)
+            }
+            }, for: .touchUpInside)
+        return button
+    }()
+    
+    lazy private var forwardButton: CustomPlayerButton = {
+        let button = CustomPlayerButton()
+        button.setImage(UIImage.RewindIcon(), for: .normal)
+        button.imageView?.transform = CGAffineTransform(scaleX: -1, y: 1); //Flipped
+        button.tintColor = .white
+        button.oex_addAction({[weak self] (action) in
+            if let weakSelf = self {
+                weakSelf.delegate?.seekForwardPressed(playerControls: weakSelf)
             }
             }, for: .touchUpInside)
         return button
@@ -243,7 +257,6 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         addSubview(topBar)
         topBar.addSubview(videoTitleLabel)
         addSubview(bottomBar)
-        bottomBar.addSubview(rewindButton)
         bottomBar.addSubview(durationSlider)
         bottomBar.addSubview(timeRemainingLabel)
         bottomBar.addSubview(btnSettings)
@@ -252,6 +265,8 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         addSubview(btnNext)
         addSubview(btnPrevious)
         addSubview(playPauseButton)
+        addSubview(rewindButton)
+        addSubview(forwardButton)
         addSubview(subTitleLabel)
         addSubview(tableSettings)
 
@@ -317,14 +332,23 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         }
         
         rewindButton.snp.makeConstraints { make in
-            make.leading.equalTo(self).offset(StandardVerticalMargin)
+            make.leading.equalTo(btnPrevious)
+            make.trailing.equalTo(playPauseButton).offset(-StandardHorizontalMargin*3)
             make.height.equalTo(rewindButtonSize.height)
             make.width.equalTo(rewindButtonSize.width)
-            make.centerY.equalTo(bottomBar.snp.centerY)
+            make.centerY.equalTo(self.snp.centerY)
+        }
+        
+        forwardButton.snp.makeConstraints { make in
+            make.leading.equalTo(playPauseButton).offset(StandardHorizontalMargin*3)
+            make.trailing.equalTo(btnNext)
+            make.height.equalTo(rewindButtonSize.height)
+            make.width.equalTo(rewindButtonSize.width)
+            make.centerY.equalTo(self.snp.centerY)
         }
         
         durationSlider.snp.makeConstraints { make in
-            make.leading.equalTo(rewindButton.snp.trailing).offset(StandardVerticalMargin)
+            make.leading.equalTo(self).offset(StandardVerticalMargin)
             make.height.equalTo(durationSliderHeight)
             make.centerY.equalTo(bottomBar.snp.centerY)
         }
@@ -396,6 +420,8 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         btnNext.accessibilityLabel = Strings.next
         rewindButton.accessibilityLabel = Strings.accessibilityRewind
         rewindButton.accessibilityHint = Strings.accessibilityRewindHint
+        forwardButton.accessibilityLabel = Strings.accessibilityForward
+        forwardButton.accessibilityHint = Strings.accessibilityForwardHint
         btnSettings.accessibilityLabel = Strings.accessibilitySettings
         fullScreenButton.accessibilityLabel = Strings.accessibilityFullscreen
         playPauseButton.setAccessibilityLabelsForStateNormal(normalStateLabel: Strings.accessibilityPause, selectedStateLabel: Strings.accessibilityPlay)
@@ -429,6 +455,10 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
             self?.bottomBar.isUserInteractionEnabled = !isHidden
             self?.playPauseButton.alpha = alpha
             self?.playPauseButton.isUserInteractionEnabled = !isHidden
+            self?.rewindButton.alpha = alpha
+            self?.rewindButton.isUserInteractionEnabled = !isHidden
+            self?.forwardButton.alpha = alpha
+            self?.forwardButton.isUserInteractionEnabled = !isHidden
             self?.btnPrevious.alpha = alpha
             self?.btnNext.alpha = alpha
             self?.btnNext.isUserInteractionEnabled = !isHidden

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -45,8 +45,9 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
     private let tableSettingSize = CGSize(width: 110.0, height: 100.0)
     private let nextButtonSize = CGSize(width: 42.0, height: 42.0)
     private let seekAnimationDuration = 0.4
-    let skipBackwardDuration: Double = 10
-    let skipForwardDuration: Double = 15
+    private let seekLabelSize : CGFloat = OEXTextStyle.pointSize(for: OEXTextSize.base)
+    let seekBackwardDuration: Double = 10
+    let seekForwardDuration: Double = 15
     
     var video : OEXHelperVideoDownload? {
         didSet {
@@ -94,7 +95,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         label.backgroundColor = .clear
         label.textColor = .white
         label.alpha = 0.0
-        label.font = self.environment.styles.sansSerif(ofSize: 30)
+        label.font = self.environment.styles.sansSerif(ofSize: seekLabelSize)
         label.layer.shouldRasterize = true
         return label
     }()
@@ -104,7 +105,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         label.backgroundColor = .clear
         label.textColor = .white
         label.alpha = 0.0
-        label.font = self.environment.styles.sansSerif(ofSize: 30)
+        label.font = self.environment.styles.sansSerif(ofSize: seekLabelSize)
         label.layer.shouldRasterize = true
         return label
     }()
@@ -116,9 +117,8 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         button.oex_addAction({[weak self] (action) in
             guard let weakSelf = self, weakSelf.durationSliderValue > weakSelf.durationSlider.minimumValue else {return}
                 weakSelf.autoHide()
-                weakSelf.delegate?.seekVideo(playerControls: weakSelf, skipDuration: weakSelf.skipBackwardDuration, type: .rewind)
-                weakSelf.seekRewindLabel.text = String(format: "-%d", Int(weakSelf.skipBackwardDuration))
-                weakSelf.seekLabelAnimation(seekLabel: weakSelf.seekRewindLabel, seekType: .rewind, animationFrame: 45)
+                weakSelf.delegate?.seekVideo(playerControls: weakSelf, skipDuration: weakSelf.seekBackwardDuration, type: .rewind)
+                weakSelf.seekAnimation(seekLabel: weakSelf.seekRewindLabel, seekType: .rewind, animationFrame: 45)
             }, for: .touchUpInside)
         return button
     }()
@@ -131,9 +131,8 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         button.oex_addAction({[weak self] (action) in
             guard let weakSelf = self, weakSelf.durationSliderValue < weakSelf.durationSlider.maximumValue - 0.001 else {return}
                 weakSelf.autoHide()
-                weakSelf.delegate?.seekVideo(playerControls: weakSelf, skipDuration: weakSelf.skipForwardDuration, type: .forward)
-                weakSelf.seekForwardLabel.text = String(format: "+%d", Int(weakSelf.skipForwardDuration))
-            weakSelf.seekLabelAnimation(seekLabel: weakSelf.seekForwardLabel, seekType: .forward, animationFrame: 50)
+                weakSelf.delegate?.seekVideo(playerControls: weakSelf, skipDuration: weakSelf.seekForwardDuration, type: .forward)
+            weakSelf.seekAnimation(seekLabel: weakSelf.seekForwardLabel, seekType: .forward, animationFrame: 50)
             }, for: .touchUpInside)
         return button
     }()
@@ -664,10 +663,11 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         stopBufferedTimer()
     }
     
-    func seekLabelAnimation(seekLabel: UILabel, seekType: SeekType, animationFrame: CGFloat) {
+    func seekAnimation(seekLabel: UILabel, seekType: SeekType, animationFrame: CGFloat) {
         if !isAnimating {
-            UIView.animate(withDuration: seekAnimationDuration, delay: 0.0, options: UIView.AnimationOptions.curveEaseOut, animations: { [weak self] in
-                self?.isAnimating = true
+            isAnimating = true
+            seekLabel.text = seekType == .rewind ? String(format: "-%d", Int(seekBackwardDuration)) : String(format: "+%d", Int(seekForwardDuration))
+            UIView.animate(withDuration: seekAnimationDuration, delay: 0.0, options: UIView.AnimationOptions.curveEaseOut, animations: {
                 seekLabel.alpha = 1.0
                 let positionX = seekType == .forward ? animationFrame : -animationFrame
                 seekLabel.frame = CGRect(x: seekLabel.frame.origin.x + positionX, y: seekLabel.frame.origin.y, width: seekLabel.frame.size.width, height: seekLabel.frame.size.height)

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -112,7 +112,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
             if let weakSelf = self {
                 weakSelf.autoHide()
                 weakSelf.delegate?.seekBackwardPressed(playerControls: weakSelf)
-                if let duration = weakSelf.videoPlayer?.videoSkipBackwardsDuration {
+                if let duration = weakSelf.videoPlayer?.videoSkipBackwardDuration {
                     weakSelf.seekRewindLabel.text = String(format: "-%d", Int(duration))
                 }
                 weakSelf.seekRewindAnimation()
@@ -130,7 +130,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
             if let weakSelf = self {
                 weakSelf.autoHide()
                 weakSelf.delegate?.seekForwardPressed(playerControls: weakSelf)
-                if let duration = weakSelf.videoPlayer?.videoSkipForwardsDuration {
+                if let duration = weakSelf.videoPlayer?.videoSkipForwardDuration {
                     weakSelf.seekForwardLabel.text = String(format: "+%d", Int(duration))
                 }
                 weakSelf.seekForwardAnimation()

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -41,6 +41,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
     private let fullScreenButtonSize = CGSize(width: 20.0, height: 20.0)
     private let tableSettingSize = CGSize(width: 110.0, height: 100.0)
     private let nextButtonSize = CGSize(width: 42.0, height: 42.0)
+    private let seekAnimationDuration = 0.4
     
     var video : OEXHelperVideoDownload? {
         didSet {
@@ -109,9 +110,10 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         button.tintColor = .white
         button.oex_addAction({[weak self] (action) in
             if let weakSelf = self {
+                weakSelf.autoHide()
                 weakSelf.delegate?.seekBackwardPressed(playerControls: weakSelf)
                 if let duration = weakSelf.videoPlayer?.videoSkipBackwardsDuration {
-                    weakSelf.seekRewindLabel.text = String(format:"-%d", Int(duration))
+                    weakSelf.seekRewindLabel.text = String(format: "-%d", Int(duration))
                 }
                 weakSelf.seekRewindAnimation()
             }
@@ -126,9 +128,10 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         button.tintColor = .white
         button.oex_addAction({[weak self] (action) in
             if let weakSelf = self {
+                weakSelf.autoHide()
                 weakSelf.delegate?.seekForwardPressed(playerControls: weakSelf)
                 if let duration = weakSelf.videoPlayer?.videoSkipForwardsDuration {
-                    weakSelf.seekForwardLabel.text = String(format:"+%d", Int(duration))
+                    weakSelf.seekForwardLabel.text = String(format: "+%d", Int(duration))
                 }
                 weakSelf.seekForwardAnimation()
             }
@@ -666,15 +669,21 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
     
     func seekForwardAnimation() {
         if !isAnimating {
-            UIView.animate(withDuration: 0.7, delay: 0.0, options: UIView.AnimationOptions.curveEaseOut, animations: { [weak self] in
+            UIView.animate(withDuration: seekAnimationDuration, delay: 0.0, options: UIView.AnimationOptions.curveEaseOut, animations: { [weak self] in
                 self?.isAnimating = true
                 self?.seekForwardLabel.alpha = 1.0
-                if let positionX = self?.seekForwardLabel.frame.origin.x, let positionY = self?.seekForwardLabel.frame.origin.y, let width = self?.seekForwardLabel.frame.size.width, let height = self?.seekForwardLabel.frame.size.height {
-                    self?.seekForwardLabel.frame = CGRect(x: positionX + 60, y: positionY, width: width, height: height)
+                if let positionX = self?.seekForwardLabel.frame.origin.x,
+                    let positionY = self?.seekForwardLabel.frame.origin.y,
+                    let width = self?.seekForwardLabel.frame.size.width,
+                    let height = self?.seekForwardLabel.frame.size.height {
+                    self?.seekForwardLabel.frame = CGRect(x: positionX + 50, y: positionY, width: width, height: height)
                 }
             }) { [weak self] finished in
-                if let positionX = self?.seekForwardLabel.frame.origin.x, let positionY = self?.seekForwardLabel.frame.origin.y, let width = self?.seekForwardLabel.frame.size.width, let height = self?.seekForwardLabel.frame.size.height {
-                    self?.seekForwardLabel.frame = CGRect(x: positionX - 60, y: positionY, width: width, height: height)
+                if let positionX = self?.seekForwardLabel.frame.origin.x,
+                    let positionY = self?.seekForwardLabel.frame.origin.y,
+                    let width = self?.seekForwardLabel.frame.size.width,
+                    let height = self?.seekForwardLabel.frame.size.height {
+                    self?.seekForwardLabel.frame = CGRect(x: positionX - 50, y: positionY, width: width, height: height)
                 }
                 self?.seekForwardLabel.alpha = 0.0
                 self?.isAnimating = false
@@ -684,15 +693,15 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
  
     func seekRewindAnimation() {
         if !isAnimating {
-            UIView.animate(withDuration: 0.7, delay: 0.0, options: UIView.AnimationOptions.curveEaseOut, animations: { [weak self] in
+            UIView.animate(withDuration: seekAnimationDuration, delay: 0.0, options: UIView.AnimationOptions.curveEaseOut, animations: { [weak self] in
                 self?.isAnimating = true
                 self?.seekRewindLabel.alpha = 1.0
                 if let positionX = self?.seekRewindLabel.frame.origin.x, let positionY = self?.seekRewindLabel.frame.origin.y, let width = self?.seekRewindLabel.frame.size.width, let height = self?.seekRewindLabel.frame.size.height {
-                    self?.seekRewindLabel.frame = CGRect(x: positionX - 60, y: positionY, width: width, height: height)
+                    self?.seekRewindLabel.frame = CGRect(x: positionX - 45, y: positionY, width: width, height: height)
                 }
             }) { [weak self] finished in
                 if let positionX = self?.seekRewindLabel.frame.origin.x, let positionY = self?.seekRewindLabel.frame.origin.y, let width = self?.seekRewindLabel.frame.size.width, let height = self?.seekRewindLabel.frame.size.height {
-                    self?.seekRewindLabel.frame = CGRect(x: positionX + 60, y: positionY, width: width, height: height)
+                    self?.seekRewindLabel.frame = CGRect(x: positionX + 45, y: positionY, width: width, height: height)
                 }
                 self?.seekRewindLabel.alpha = 0.0
                 self?.isAnimating = false

--- a/Source/CutomePlayer/YoutubeVideoPlayer.swift
+++ b/Source/CutomePlayer/YoutubeVideoPlayer.swift
@@ -104,7 +104,7 @@ class YoutubeVideoPlayer: VideoPlayer {
         }
     }
 
-    override func seek(to time: Double, completion: (() -> Void)? = nil) {
+    override func seek(to time: Double) {
         playerView.seek(toSeconds: Float(time), allowSeekAhead: true)
     }
     

--- a/Source/CutomePlayer/YoutubeVideoPlayer.swift
+++ b/Source/CutomePlayer/YoutubeVideoPlayer.swift
@@ -104,7 +104,7 @@ class YoutubeVideoPlayer: VideoPlayer {
         }
     }
 
-    override func seek(to time: Double) {
+    override func seek(to time: Double, completion: (() -> Void)? = nil) {
         playerView.seek(toSeconds: Float(time), allowSeekAhead: true)
     }
     

--- a/Source/OEXAnalytics.h
+++ b/Source/OEXAnalytics.h
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
                    CourseID:(NSString*)courseId
                     UnitURL:(NSString*)unitUrl;
 
-- (void)trackVideoSeekRewind:(NSString*)videoId
+- (void)trackVideoSeek:(NSString*)videoId
            RequestedDuration:(NSTimeInterval)requestedDuration
                      OldTime:(NSTimeInterval)oldTime
                      NewTime:(NSTimeInterval)newTime

--- a/Source/OEXAnalytics.m
+++ b/Source/OEXAnalytics.m
@@ -271,7 +271,7 @@ static OEXAnalytics* sAnalytics;
     [self trackVideoPlayerEvent:event withInfo:info];
 }
 
-- (void)trackVideoSeekRewind:(NSString*)videoId
+- (void)trackVideoSeek:(NSString*)videoId
            RequestedDuration:(NSTimeInterval)requestedDuration
                      OldTime:(NSTimeInterval)oldTime
                      NewTime:(NSTimeInterval)newTime

--- a/Source/OEXConstants.h
+++ b/Source/OEXConstants.h
@@ -30,14 +30,14 @@ typedef NS_ENUM (NSUInteger, OEXVideoState) {
 
 /**Video player speeds*/
 typedef NS_ENUM(NSUInteger, OEXVideoSpeed) {
+    OEXVideoSpeedDefault, //1.0x
     OEXVideoSpeedXXSlow, // .25x
     OEXVideoSpeedXSlow, // .5x
     OEXVideoSpeedSlow, // .75x
-    OEXVideoSpeedDefault, //1.0x
     OEXVideoSpeedFast, // 1.25x
     OEXVideoSpeedXFast, // 1.5x
     OEXVideoSpeedXXFast, // 1.75x
-    OEXVideoSpeedXXXFast, // 2x
+    OEXVideoSpeedXXXFast // 2x
 };
 
 //Wifi only Key

--- a/Source/OEXInterface.m
+++ b/Source/OEXInterface.m
@@ -236,6 +236,10 @@ static OEXInterface* _sharedInterface = nil;
 }
 
 + (OEXVideoSpeed)getCCSelectedPlaybackSpeed {
+    
+    if(![[NSUserDefaults standardUserDefaults] objectForKey:PERSIST_PLAYBACKSPEED]) {
+        return OEXVideoSpeedDefault;
+    }
     return [[NSUserDefaults standardUserDefaults] integerForKey:PERSIST_PLAYBACKSPEED];
 }
 

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -101,7 +101,11 @@
 /* Accessibility label for Rewind Button in the Video Player */
 "ACCESSIBILITY_REWIND" = "رجوع";
 /* Call to action for Rewind Button in the Video Player */
-"ACCESSIBILITY_REWIND_HINT" = "رجوع بفاصل زمني 30 ثانية";
+"ACCESSIBILITY_REWIND_HINT" = "رجوع بفاصل زمني 10 ثانية";
+/* Accessibility label for Forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD" = "Forward";
+/* Call to action for forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD_HINT" = "Forward by 15 seconds.";
 /* Accessibility label for Seek bar in the Video Player */
 "ACCESSIBILITY_SEEK_BAR" = "شريط التتبّع";
 /* Accessibility label for Settings Button in the Video Player */

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -89,7 +89,11 @@
 /* Accessibility label for Rewind Button in the Video Player */
 "ACCESSIBILITY_REWIND" = "Zurückspulen";
 /* Call to action for Rewind Button in the Video Player */
-"ACCESSIBILITY_REWIND_HINT" = "Um 30 Sekunden zurückspulen.";
+"ACCESSIBILITY_REWIND_HINT" = "Um 10 Sekunden zurückspulen.";
+/* Accessibility label for Forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD" = "Forward";
+/* Call to action for forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD_HINT" = "Forward by 15 seconds.";
 /* Accessibility label for Seek bar in the Video Player */
 "ACCESSIBILITY_SEEK_BAR" = "Suche";
 /* Accessibility label for Settings Button in the Video Player */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -89,7 +89,11 @@
 /* Accessibility label for Rewind Button in the Video Player */
 "ACCESSIBILITY_REWIND" = "Rewind";
 /* Call to action for Rewind Button in the Video Player */
-"ACCESSIBILITY_REWIND_HINT" = "Rewinds by 30 seconds.";
+"ACCESSIBILITY_REWIND_HINT" = "Rewinds by 10 seconds.";
+/* Accessibility label for Forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD" = "Forward";
+/* Call to action for forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD_HINT" = "Forward by 15 seconds.";
 /* Accessibility label for Seek bar in the Video Player */
 "ACCESSIBILITY_SEEK_BAR" = "Seek Bar";
 /* Accessibility label for Settings Button in the Video Player */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -89,7 +89,11 @@
 /* Accessibility label for Rewind Button in the Video Player */
 "ACCESSIBILITY_REWIND" = "Retroceder";
 /* Call to action for Rewind Button in the Video Player */
-"ACCESSIBILITY_REWIND_HINT" = "Retroceder 30 segundos";
+"ACCESSIBILITY_REWIND_HINT" = "Retroceder 10 segundos";
+/* Accessibility label for Forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD" = "Forward";
+/* Call to action for forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD_HINT" = "Forward by 15 seconds.";
 /* Accessibility label for Seek bar in the Video Player */
 "ACCESSIBILITY_SEEK_BAR" = "Barra de búsqueda";
 /* Accessibility label for Settings Button in the Video Player */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -89,7 +89,11 @@
 /* Accessibility label for Rewind Button in the Video Player */
 "ACCESSIBILITY_REWIND" = "Retour arrière";
 /* Call to action for Rewind Button in the Video Player */
-"ACCESSIBILITY_REWIND_HINT" = "Retour arrière de 30 sec.";
+"ACCESSIBILITY_REWIND_HINT" = "Retour arrière de 10 sec.";
+/* Accessibility label for Forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD" = "Forward";
+/* Call to action for forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD_HINT" = "Forward by 15 seconds.";
 /* Accessibility label for Seek bar in the Video Player */
 "ACCESSIBILITY_SEEK_BAR" = "Barre de défilement";
 /* Accessibility label for Settings Button in the Video Player */

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -95,7 +95,11 @@
 /* Accessibility label for Rewind Button in the Video Player */
 "ACCESSIBILITY_REWIND" = "חזור אחורה";
 /* Call to action for Rewind Button in the Video Player */
-"ACCESSIBILITY_REWIND_HINT" = "מחזיר 30 שניות אחרוה.";
+"ACCESSIBILITY_REWIND_HINT" = "מחזיר 10 שניות אחרוה.";
+/* Accessibility label for Forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD" = "Forward";
+/* Call to action for forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD_HINT" = "Forward by 15 seconds.";
 /* Accessibility label for Seek bar in the Video Player */
 "ACCESSIBILITY_SEEK_BAR" = "שורת חיפוש";
 /* Accessibility label for Settings Button in the Video Player */

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -86,7 +86,11 @@
 /* Accessibility label for Rewind Button in the Video Player */
 "ACCESSIBILITY_REWIND" = "巻き戻し";
 /* Call to action for Rewind Button in the Video Player */
-"ACCESSIBILITY_REWIND_HINT" = "30秒巻き戻し";
+"ACCESSIBILITY_REWIND_HINT" = "10秒巻き戻し";
+/* Accessibility label for Forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD" = "Forward";
+/* Call to action for forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD_HINT" = "Forward by 15 seconds.";
 /* Accessibility label for Seek bar in the Video Player */
 "ACCESSIBILITY_SEEK_BAR" = "シークバー";
 /* Accessibility label for Settings Button in the Video Player */

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -89,7 +89,11 @@
 /* Accessibility label for Rewind Button in the Video Player */
 "ACCESSIBILITY_REWIND" = "Voltar o vídeo";
 /* Call to action for Rewind Button in the Video Player */
-"ACCESSIBILITY_REWIND_HINT" = "Volta 30 segundos.";
+"ACCESSIBILITY_REWIND_HINT" = "Volta 10 segundos.";
+/* Accessibility label for Forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD" = "Forward";
+/* Call to action for forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD_HINT" = "Forward by 15 seconds.";
 /* Accessibility label for Seek bar in the Video Player */
 "ACCESSIBILITY_SEEK_BAR" = "Barra de progresso";
 /* Accessibility label for Settings Button in the Video Player */

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -89,7 +89,11 @@
 /* Accessibility label for Rewind Button in the Video Player */
 "ACCESSIBILITY_REWIND" = "Geri sar";
 /* Call to action for Rewind Button in the Video Player */
-"ACCESSIBILITY_REWIND_HINT" = "30 saniye geri sar.";
+"ACCESSIBILITY_REWIND_HINT" = "10 saniye geri sar.";
+/* Accessibility label for Forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD" = "Forward";
+/* Call to action for forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD_HINT" = "Forward by 15 seconds.";
 /* Accessibility label for Seek bar in the Video Player */
 "ACCESSIBILITY_SEEK_BAR" = "Gezinme Çubuğu";
 /* Accessibility label for Settings Button in the Video Player */

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -86,7 +86,11 @@
 /* Accessibility label for Rewind Button in the Video Player */
 "ACCESSIBILITY_REWIND" = "Tua lại";
 /* Call to action for Rewind Button in the Video Player */
-"ACCESSIBILITY_REWIND_HINT" = "Tua lại 30 giây";
+"ACCESSIBILITY_REWIND_HINT" = "Tua lại 10 giây";
+/* Accessibility label for Forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD" = "Forward";
+/* Call to action for forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD_HINT" = "Forward by 15 seconds.";
 /* Accessibility label for Seek bar in the Video Player */
 "ACCESSIBILITY_SEEK_BAR" = "Seek Bar";
 /* Accessibility label for Settings Button in the Video Player */

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -86,7 +86,11 @@
 /* Accessibility label for Rewind Button in the Video Player */
 "ACCESSIBILITY_REWIND" = "后退";
 /* Call to action for Rewind Button in the Video Player */
-"ACCESSIBILITY_REWIND_HINT" = "后退30秒";
+"ACCESSIBILITY_REWIND_HINT" = "后退10秒";
+/* Accessibility label for Forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD" = "Forward";
+/* Call to action for forward Button in the Video Player */
+"ACCESSIBILITY_FORWARD_HINT" = "Forward by 15 seconds.";
 /* Accessibility label for Seek bar in the Video Player */
 "ACCESSIBILITY_SEEK_BAR" = "搜索框";
 /* Accessibility label for Settings Button in the Video Player */

--- a/Test/VideoPlayerTests.swift
+++ b/Test/VideoPlayerTests.swift
@@ -88,15 +88,27 @@ class VideoPlayerTests: XCTestCase {
         }
     }
     
-    // Test the backwarward seek functionality
+    // Test the backward seek functionality
     func testSeekBackword() {
         loadVideoPlayer { videoPlayer in
             XCTAssertEqual(videoPlayer.t_playerCurrentState, .readyToPlay)
             videoPlayer.seek(to: 34.168155555555558)
             videoPlayer.t_controls?.durationSliderValue = 1.01
-            videoPlayer.seekBackwardPressed(playerControls: videoPlayer.t_controls!)
+            videoPlayer.seekVideo(playerControls: videoPlayer.t_controls!, skipDuration: 10, type: .rewind)
             let currentTime = videoPlayer.currentTime
-            XCTAssertGreaterThanOrEqual(currentTime, 3.93)
+            XCTAssertGreaterThanOrEqual(currentTime, 23.93)
+        }
+    }
+    
+    // Test the forward seek functionality
+    func testSeekForword() {
+        loadVideoPlayer { videoPlayer in
+            XCTAssertEqual(videoPlayer.t_playerCurrentState, .readyToPlay)
+            videoPlayer.seek(to: 34.168155555555558)
+            videoPlayer.t_controls?.durationSliderValue = 1.01
+            videoPlayer.seekVideo(playerControls: videoPlayer.t_controls!, skipDuration: 15, type: .forward)
+            let currentTime = videoPlayer.currentTime
+            XCTAssertGreaterThanOrEqual(currentTime, 23.93)
         }
     }
     


### PR DESCRIPTION
### Description

[LEARNER-7688](https://openedx.atlassian.net/browse/LEARNER-7688)

The video player should have video rewind and forward button options. Rewind button would be 10 seconds reverse and the forward button would be 15 seconds skip for video.

### How to test this PR
 - [x] The options should be displayed when the user would tap on a video screen along with the play/pause button, The position of the buttons would be left and right of the play/pause button.

 - [x] Tapping on the forward video button will skip the video for 15 seconds interval. 
 - [x] Tapping on the rewind video button will skip the video for 10 seconds interval.

 - [x] Tapping on the rewind and the forward button will play the text animation for the specific skip interval. On rewind button tapping the “-10“ will be animate and on taping forward button “+15” text will animate. The purpose of this animation text is to show how many intervals the video will be skipped in either direction.

### Screenshot
![IMG_F019EE71E814-1](https://user-images.githubusercontent.com/960241/80481334-aa4e8500-896b-11ea-9f48-60676c6ef94f.jpeg)

