### PR TITLE
Logout when failed to get new access_token against refresh_token

### DIFF
--- a/Source/NSError+JSON.swift
+++ b/Source/NSError+JSON.swift
@@ -31,22 +31,26 @@ extension NSError {
     }
 
     func isAPIError(code: APIErrorCode) -> Bool {
-        guard let errorCode = errorInfo?[ErrorFields.errorCode.rawValue] as? String else { return false }
+        guard let errorInfo = parseError(info: userInfo) else { return false }
+        let errorCode = errorInfo[ErrorFields.errorCode.rawValue] as? String
         return errorCode == code.rawValue
     }
 
     /// error_code can be in the different hierarchy. Like it can be direct or it can be contained in a dictionary under developer_message
-    private var errorInfo: Dictionary<AnyHashable, Any>? {
+    private func parseError(info: Dictionary<AnyHashable, Any>?) -> Dictionary<AnyHashable, Any>? {
         var errorVaule: Any?
 
-        if (userInfo[ErrorFields.errorCode.rawValue] != nil) {
-            errorVaule = userInfo[ErrorFields.errorCode.rawValue]
+        if (info?[ErrorFields.errorCode.rawValue] != nil) {
+            errorVaule = info?[ErrorFields.errorCode.rawValue]
         }
-        else if (userInfo[ErrorFields.error.rawValue] != nil) {
-            errorVaule = userInfo[ErrorFields.error.rawValue]
+        else if (info?[ErrorFields.error.rawValue] != nil) {
+            errorVaule = info?[ErrorFields.error.rawValue]
         }
-        else if (userInfo[ErrorFields.developerMessage.rawValue] != nil) {
-            errorVaule = userInfo[ErrorFields.developerMessage.rawValue]
+        else if (info?[ErrorFields.developerMessage.rawValue] != nil) {
+            errorVaule = info?[ErrorFields.developerMessage.rawValue]
+            if let infoDict = errorVaule as? Dictionary<AnyHashable, Any> {
+                return parseError(info: infoDict)
+            }
         }
 
         return errorInfo(value: errorVaule)

--- a/Source/NetworkManager+Authenticators.swift
+++ b/Source/NetworkManager+Authenticators.swift
@@ -33,7 +33,7 @@ extension NetworkManager {
                 let json = JSON(raw)
                 
                 guard let statusCode = OEXHTTPStatusCode(rawValue: response.statusCode),
-                    let error = NSError(json: json, code: response.statusCode), statusCode == .code401Unauthorised else
+                    let error = NSError(json: json, code: response.statusCode), statusCode.is4xx else
                 {
                     return AuthenticationAction.proceed
                 }


### PR DESCRIPTION
### Description

[LEARNER-7694](https://openedx.atlassian.net/browse/LEARNER-7694)

After the [oauthlib](https://github.com/oauthlib/oauthlib) library upgrades in [BOM-1277](https://openedx.atlassian.net/browse/BOM-1277), our mobile learners are facing the issue of `content isn't loading`.

This issue occurs when the mobile app failed to get access_token against the refresh_token.

Before the oauthlib library upgrade server was returning error `{ "error" : "invalid_grant" }` with status_code 401 when it failed to return an access_token for the provided refresh_token. But after the oauthlib library upgrade server is returning error `{ "error": "invalid_grant" }` with status_code 400. This PR handles `{ "error" : "invalid_grant" }` with `status_code 4xx`.

### Sanbox Config

API_HOST_URL: https://authenticationdebug.sandbox.edx.org
OAUTH_CLIENT_ID: pImgwqAyMsW593dfxKMLwTqthL5YDsZQOr9NAey8

Username: admin
Password: Hamilton

### How to test this PR

1. Login using the above-mentioned credentials.
2. Expires user `access_token` and invalidate `refresh_token` against the expired access_token.
3. Hit any API. The app should logout learner.

 
