### PR TITLE
iOS - Fix Issue with Login Screen for Auto Logout

### DIFF
--- a/Source/OEXRouter.m
+++ b/Source/OEXRouter.m
@@ -122,7 +122,9 @@ OEXRegistrationViewControllerDelegate
 }
 
 - (void)showLoginScreenFromController:(UIViewController*)controller completion:(void(^)(void))completion {
-    [self presentViewController:[self loginViewController] fromController:[[UIApplication sharedApplication] topMostController] completion:completion];
+    if ([[[UIApplication sharedApplication] topMostController] isKindOfClass:[OEXLoginViewController class]] == NO) {
+        [self presentViewController:[self loginViewController] fromController:[[UIApplication sharedApplication] topMostController] completion:completion];
+    }
 }
 
 - (UINavigationController *) loginViewController {


### PR DESCRIPTION
### Description

[LEARNER-LEARNER-7689](https://openedx.atlassian.net/browse/LEARNER-LEARNER-7689)

When the app failed to auto-refresh access_token the NetworkManager+Authenticators.swift logout the learner. Sometimes the logout call happens more than and the sign-in screen shows more than once in the stack.

### How to test this PR
- [x] Show sign-in screen once and ignore the subsequent calls.

