### PR TITLE
 Improve Video Player Controls Toggling

### DIFF
--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -443,7 +443,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
             }
             else {
                 if let owner = self {
-                    self?.tableSettings.isHidden = true
+                    owner.tableSettings.isHidden = true
                     owner.bringSubviewToFront(owner.tapButton)
                 }
             }

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -254,6 +254,8 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         addSubview(playPauseButton)
         addSubview(subTitleLabel)
         addSubview(tableSettings)
+
+        sendSubviewToBack(tapButton)
     }
     
     var durationSliderValue: Float {
@@ -359,10 +361,7 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
         }
         
         tapButton.snp.makeConstraints { make in
-            make.leading.equalTo(self)
-            make.trailing.equalTo(self)
-            make.top.equalTo(self)
-            make.bottom.equalTo(bottomBar.snp.top)
+            make.edges.equalTo(self)
         }
         
         btnPrevious.snp.makeConstraints { make in
@@ -437,10 +436,16 @@ class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate {
             self?.btnPrevious.isUserInteractionEnabled = !isHidden
             
             if (!isHidden) {
-                self?.autoHide()
+                if let owner = self {
+                    owner.autoHide()
+                    owner.sendSubviewToBack(owner.tapButton)
+                }
             }
             else {
-                self?.tableSettings.isHidden = true
+                if let owner = self {
+                    self?.tableSettings.isHidden = true
+                    owner.bringSubviewToFront(owner.tapButton)
+                }
             }
             }, completion: { [weak self] _ in
                 self?.updateSubtTitleConstraints()


### PR DESCRIPTION
### Description

[LEARNER-7711](https://openedx.atlassian.net/browse/LEARNER-7711)

The video player has many components like the play/pause button, navigate to next block button, previous block buttons, bottom bar with duration slider, settings button, full screen buttons. These components aren't passing controls to the toggle controls button even when hidden which results in a very limited place to toggle controls button. And also it's a bit tricky for learners where to click to show the controls.

This PR improves the video player controls toggling. 

### Testing
- [ ] All the controls take clicks and should work as expected.
- [ ] Video controls should show on clicking anywhere in the player.


