### PR TITLE
Register Screen - User can register without password after logging through google

### DIFF
--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -455,6 +455,8 @@
                        requestingUserDetails:NO
                               withCompletion:^(NSString* accessToken, OEXRegisteringUserDetails* details, NSError* error) {
                                   if(accessToken) {
+                                      self.environment.session.thirdPartyAuthProvider = provider.displayName;
+                                      self.environment.session.thirdPartyAuthAccessToken = accessToken;
                                       [OEXAuthentication requestTokenWithProvider:provider externalToken:accessToken completion:handler];
                                   }
                                   else {

--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -455,7 +455,6 @@
                        requestingUserDetails:NO
                               withCompletion:^(NSString* accessToken, OEXRegisteringUserDetails* details, NSError* error) {
                                   if(accessToken) {
-                                      self.environment.session.thirdPartyAuthProvider = provider.displayName;
                                       self.environment.session.thirdPartyAuthAccessToken = accessToken;
                                       [OEXAuthentication requestTokenWithProvider:provider externalToken:accessToken completion:handler];
                                   }

--- a/Source/OEXRegistrationViewController+Swift.swift
+++ b/Source/OEXRegistrationViewController+Swift.swift
@@ -26,7 +26,7 @@ extension OEXRegistrationViewController {
         }
     }
     
-    @objc func register(withParameters parameter:[String:String], success: (()-> ())? = nil) {
+    @objc func register(withParameters parameter:[String:String]) {
         showProgress(true)
         let infoDict :[String: String] = [OEXAnalyticsKeyProvider: self.externalProvider?.backendName ?? ""]
         environment.analytics.trackEvent(OEXAnalytics.registerEvent(name: AnalyticsEventName.UserRegistrationClick.rawValue, displayName: AnalyticsDisplayName.CreateAccount.rawValue), forComponent: nil, withInfo: infoDict)
@@ -38,7 +38,6 @@ extension OEXRegistrationViewController {
                         if response?.statusCode == OEXHTTPStatusCode.code200OK.rawValue {
                             owner.environment.analytics.trackEvent(OEXAnalytics.registerEvent(name: AnalyticsEventName.UserRegistrationSuccess.rawValue, displayName: AnalyticsDisplayName.RegistrationSuccess.rawValue), forComponent: nil, withInfo: infoDict)
                             owner.delegate?.registrationViewControllerDidRegister(owner, completion: nil)
-                            success?()
                         }
                         else if let error = error as NSError?, error.oex_isNoInternetConnectionError {
                             owner.showNoNetworkError()

--- a/Source/OEXRegistrationViewController+Swift.swift
+++ b/Source/OEXRegistrationViewController+Swift.swift
@@ -26,7 +26,7 @@ extension OEXRegistrationViewController {
         }
     }
     
-    @objc func register(withParameters parameter:[String:String]) {
+    @objc func register(withParameters parameter:[String:String], success: (()-> ())? = nil) {
         showProgress(true)
         let infoDict :[String: String] = [OEXAnalyticsKeyProvider: self.externalProvider?.backendName ?? ""]
         environment.analytics.trackEvent(OEXAnalytics.registerEvent(name: AnalyticsEventName.UserRegistrationClick.rawValue, displayName: AnalyticsDisplayName.CreateAccount.rawValue), forComponent: nil, withInfo: infoDict)
@@ -38,6 +38,7 @@ extension OEXRegistrationViewController {
                         if response?.statusCode == OEXHTTPStatusCode.code200OK.rawValue {
                             owner.environment.analytics.trackEvent(OEXAnalytics.registerEvent(name: AnalyticsEventName.UserRegistrationSuccess.rawValue, displayName: AnalyticsDisplayName.RegistrationSuccess.rawValue), forComponent: nil, withInfo: infoDict)
                             owner.delegate?.registrationViewControllerDidRegister(owner, completion: nil)
+                            success?()
                         }
                         else if let error = error as NSError?, error.oex_isNoInternetConnectionError {
                             owner.showNoNetworkError()

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -429,7 +429,6 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
     self.externalAccessToken = accessToken;
     self.externalProvider = provider;
     
-    self.environment.session.thirdPartyAuthProvider = provider.displayName;
     self.environment.session.thirdPartyAuthAccessToken = accessToken;
     
     // Long term, we should update the registration.json description to provide this mapping.

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -253,6 +253,9 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
             if([[fieldController field].name isEqualToString:@"name"]) {
                 [fieldController setValue:fieldController.field.defaultValue];
             }
+            if([[fieldController field].name isEqualToString:@"username"]) {
+                [fieldController setValue:fieldController.field.defaultValue];
+            }
             if([[fieldController field].name isEqualToString:@"email"]) {
                 [fieldController setValue:fieldController.field.defaultValue];
             }

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -37,6 +37,7 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
 /// Contents are id <OEXRegistrationFieldController>
 @property (strong, nonatomic) NSArray* fieldControllers;
 @property (strong, nonatomic) IBOutlet UIScrollView* scrollView;
+@property (strong, nonatomic) NSMutableArray* externalAuthProviders;
 // Used in auth from an external provider
 @property (strong, nonatomic) UIView* currentHeadingView;
 @property (strong, nonatomic) id <OEXExternalAuthProvider> externalProvider;
@@ -109,6 +110,7 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
         weakSelf.registrationDescription = response;
         [weakSelf makeFieldControllers];
         [weakSelf initializeViews];
+        [weakSelf checkIfResumingRegistration];
         [weakSelf refreshFormFields];
     }];
 }
@@ -160,20 +162,20 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
     [tapGesture addTarget:self action:@selector(scrollViewTapped:)];
     [self.scrollView addGestureRecognizer:tapGesture];
     
-    NSMutableArray* providers = [[NSMutableArray alloc] init];
+    self.externalAuthProviders = [[NSMutableArray alloc] init];
     if(self.environment.config.googleConfig.enabled) {
-        [providers addObject:[[OEXGoogleAuthProvider alloc] init]];
+        [self.externalAuthProviders addObject:[[OEXGoogleAuthProvider alloc] init]];
     }
     if(self.environment.config.facebookConfig.enabled) {
-        [providers addObject:[[OEXFacebookAuthProvider alloc] init]];
+        [self.externalAuthProviders addObject:[[OEXFacebookAuthProvider alloc] init]];
     }
     
     if(self.environment.config.microsoftConfig.enabled) {
-        [providers addObject:[[OEXMicrosoftAuthProvider alloc] init]];
+        [self.externalAuthProviders addObject:[[OEXMicrosoftAuthProvider alloc] init]];
     }
     
-    if(providers.count > 0) {
-        OEXExternalRegistrationOptionsView* headingView = [[OEXExternalRegistrationOptionsView alloc] initWithFrame:self.view.bounds providers:providers];
+    if(self.externalAuthProviders.count > 0) {
+        OEXExternalRegistrationOptionsView* headingView = [[OEXExternalRegistrationOptionsView alloc] initWithFrame:self.view.bounds providers:self.externalAuthProviders];
         headingView.delegate = self;
         [self useHeadingView:headingView];
     }
@@ -226,8 +228,35 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
     return self.externalProvider != nil && [field.name isEqualToString:@"password"];
 }
 
+- (void)checkIfResumingRegistration {
+    NSArray* fields = self.registrationDescription.registrationFormFields;
+    for (OEXRegistrationFormField* formField in fields) {
+        if ([formField.name isEqualToString:@"social_auth_provider"]) {
+            for (id <OEXExternalAuthProvider> provider in self.externalAuthProviders) {
+                if ([formField.defaultValue isEqualToString:provider.displayName]) {
+                    NSString *access_token = [[NSUserDefaults standardUserDefaults] stringForKey:@"access_token"];
+                    self.externalAccessToken = access_token;
+                    self.externalProvider = provider;
+                    
+                    UIView* headingView = [[OEXUsingExternalAuthHeadingView alloc] initWithFrame:self.view.bounds serviceName:provider.displayName];
+                               [self useHeadingView:headingView];
+                    break;
+                }
+            }
+        }
+    }
+}
+
 - (void)refreshFormFields {
     for(id <OEXRegistrationFieldController>fieldController in self.fieldControllers) {
+        if (([fieldController.field.defaultValue isEqualToString:@""] == NO) ) {
+            if([[fieldController field].name isEqualToString:@"name"]) {
+                [fieldController setValue:fieldController.field.defaultValue];
+            }
+            if([[fieldController field].name isEqualToString:@"email"]) {
+                [fieldController setValue:fieldController.field.defaultValue];
+            }
+        }
         // Add view to scroll view if field is not optional and it is not agreement field.
         UIView* view = fieldController.view;
         if(fieldController.field.isRequired && ![self shouldFilterField:fieldController.field]) {
@@ -397,6 +426,10 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
 - (void)receivedFields:(OEXRegisteringUserDetails*)profile fromProvider:(id <OEXExternalAuthProvider>)provider withAccessToken:(NSString*)accessToken {
     self.externalAccessToken = accessToken;
     self.externalProvider = provider;
+    
+    [[NSUserDefaults standardUserDefaults] setObject:accessToken forKey:@"access_token"];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    
     // Long term, we should update the registration.json description to provide this mapping.
     // We will need to do this if we ever transition to fetching that from the server
     for(id <OEXRegistrationFieldController> controller in self.fieldControllers) {

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -429,6 +429,7 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
     self.externalAccessToken = accessToken;
     self.externalProvider = provider;
     
+    self.environment.session.thirdPartyAuthProvider = provider.displayName;
     self.environment.session.thirdPartyAuthAccessToken = accessToken;
     
     // Long term, we should update the registration.json description to provide this mapping.
@@ -487,7 +488,6 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
         [parameters setSafeObject:self.externalAccessToken forKey: @"access_token"];
         [parameters setSafeObject:self.externalProvider.backendName forKey:@"provider"];
         [parameters setSafeObject:self.environment.config.oauthClientID forKey:@"client_id"];
-        self.environment.session.thirdPartyAuthAccessToken = nil;
     }
     
     [self registerWithParameters:parameters];

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -487,11 +487,10 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
         [parameters setSafeObject:self.externalAccessToken forKey: @"access_token"];
         [parameters setSafeObject:self.externalProvider.backendName forKey:@"provider"];
         [parameters setSafeObject:self.environment.config.oauthClientID forKey:@"client_id"];
-    }
-
-    [self registerWithParameters:parameters success:^{
         self.environment.session.thirdPartyAuthAccessToken = nil;
-    }];
+    }
+    
+    [self registerWithParameters:parameters];
 }
 
 - (void) showInputErrorAlert {
@@ -580,7 +579,7 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
 }
 
 - (void)t_registerWithParameters:(NSDictionary*)parameters {
-    [self registerWithParameters:parameters success:nil];
+    [self registerWithParameters:parameters];
 }
 
 @end

--- a/Source/OEXSession.h
+++ b/Source/OEXSession.h
@@ -36,7 +36,6 @@ extern NSString* const OEXSessionEndedNotification;
 /// access_token is saved to resume the third party registration flow.
 /// Registration flow would resume from that point and matching access_token with the one returned by server.
 /// When registration is sucssessful, this token is removed.
-@property (nonatomic, strong, nullable) NSString* thirdPartyAuthProvider;
 @property (nonatomic, strong, nullable) NSString* thirdPartyAuthAccessToken;
 
 - (void)loadTokenFromStore;

--- a/Source/OEXSession.h
+++ b/Source/OEXSession.h
@@ -36,6 +36,7 @@ extern NSString* const OEXSessionEndedNotification;
 /// access_token is saved to resume the third party registration flow.
 /// Registration flow would resume from that point and matching access_token with the one returned by server.
 /// When registration is sucssessful, this token is removed.
+@property (nonatomic, strong, nullable) NSString* thirdPartyAuthProvider;
 @property (nonatomic, strong, nullable) NSString* thirdPartyAuthAccessToken;
 
 - (void)loadTokenFromStore;

--- a/Source/OEXSession.h
+++ b/Source/OEXSession.h
@@ -33,8 +33,8 @@ extern NSString* const OEXSessionEndedNotification;
 @property (readonly, nonatomic, strong, nullable) OEXUserDetails* currentUser;
 
 /// This field holds in-memory external auth token when user starts external registration flow such as Google
-/// accessToken is stored so if user dismisses the controller and opens the controller again,
-/// registration flow would resume from that point and matching access_token with he one returned by server.
+/// access_token is saved to resume the third party registration flow.
+/// Registration flow would resume from that point and matching access_token with the one returned by server.
 /// When registration is sucssessful, this token is removed.
 @property (nonatomic, strong, nullable) NSString* thirdPartyAuthAccessToken;
 

--- a/Source/OEXSession.h
+++ b/Source/OEXSession.h
@@ -32,6 +32,12 @@ extern NSString* const OEXSessionEndedNotification;
 @property (readonly, nonatomic, strong, nullable) OEXAccessToken* token;
 @property (readonly, nonatomic, strong, nullable) OEXUserDetails* currentUser;
 
+/// This field holds in-memory external auth token when user starts external registration flow such as Google
+/// accessToken is stored so if user dismisses the controller and opens the controller again,
+/// registration flow would resume from that point and matching access_token with he one returned by server.
+/// When registration is sucssessful, this token is removed.
+@property (nonatomic, strong, nullable) NSString* thirdPartyAuthAccessToken;
+
 - (void)loadTokenFromStore;
 - (void)saveAccessToken:(OEXAccessToken*)token userDetails:(OEXUserDetails*)userDetails;
 - (void)closeAndClearSession;

--- a/Source/OEXSession.m
+++ b/Source/OEXSession.m
@@ -69,7 +69,6 @@ static NSString* OEXSessionClearedCache = @"OEXSessionClearedCache";
     if(token != nil && userDetails != nil) {
         [[NSNotificationCenter defaultCenter] postNotificationName:OEXSessionStartedNotification object:nil userInfo:@{OEXSessionStartedUserDetailsKey : userDetails}];
     }
-    self.thirdPartyAuthProvider = nil;
     self.thirdPartyAuthAccessToken = nil;
 }
 

--- a/Source/OEXSession.m
+++ b/Source/OEXSession.m
@@ -69,6 +69,8 @@ static NSString* OEXSessionClearedCache = @"OEXSessionClearedCache";
     if(token != nil && userDetails != nil) {
         [[NSNotificationCenter defaultCenter] postNotificationName:OEXSessionStartedNotification object:nil userInfo:@{OEXSessionStartedUserDetailsKey : userDetails}];
     }
+    self.thirdPartyAuthProvider = nil;
+    self.thirdPartyAuthAccessToken = nil;
 }
 
 - (void)loadTokenFromStore {


### PR DESCRIPTION
### Description

[LEARNER-7653](https://openedx.atlassian.net/browse/LEARNER-7653)

This PR adds option to Registration flow to check if user is already in registration flow, then continue the registration flow.

### How to test this PR
**Case 1**
- [ ] Open Registration Screen
- [ ] Perform social login (Google)
- [ ] Don't hit `Create my account` button
- [ ] Close the controller after doing social login
- [ ] Open Registration screen again by clicking `Create your account button`
- [ ] Fields (Full Name and Email) will be populated
- [ ] Select Country
- [ ] Hit `Create my account` button
- [ ] Registration will be successful

**Case 2**
 It seems the third-party auth also has a link with the login screen.

- [ ] Go to the Register screen and start registration flow with Google.
- [ ] Close the register screen and open the Login screen.
- [ ] Try to login with Facebook(Please make sure the account should not be registered).
- [ ] Go back to the Register screen and observer the response. The server is responding that the registration flow was in the process with Facebook. 
- [ ] Should work as expected

 And the other scenario is:

- [ ] Open the login screen and start the login flow with Google.
- [ ] Close the login screen and open the register screen.
- [ ] You will observe that the server will return info of in-process third party auth.
- [ ] It should work as expected
