### PR TITLE
Configure TOS, EULA and Privacy Policy Independently

### DIFF
--- a/Source/AgreementTextView.swift
+++ b/Source/AgreementTextView.swift
@@ -40,11 +40,15 @@ class AgreementTextView: UITextView {
         let privacyPolicyText = Strings.Agreement.linkTextPrivacyPolicy
         let agreementText = "\(prefix)\(Strings.Agreement.text(eula: eulaText, tos: tosText, platformName: platformName, privacyPolicy: privacyPolicyText))"
         var attributedString = style.attributedString(withText: agreementText)
-        if let eulaUrl = config?.agreementURLsConfig.eulaURL,
-            let tosUrl = config?.agreementURLsConfig.tosURL,
-            let privacyPolicyUrl = config?.agreementURLsConfig.privacyPolicyURL {
+        if let eulaUrl = config?.agreementURLsConfig.eulaURL {
             attributedString = attributedString.addLink(on: eulaText, value: eulaUrl)
+        }
+
+        if let tosUrl = config?.agreementURLsConfig.tosURL {
             attributedString = attributedString.addLink(on: tosText, value: tosUrl)
+        }
+
+        if let privacyPolicyUrl = config?.agreementURLsConfig.privacyPolicyURL {
             attributedString = attributedString.addLink(on: privacyPolicyText, value: privacyPolicyUrl)
         }
         attributedText = attributedString

--- a/Source/AgreementURLsConfig.swift
+++ b/Source/AgreementURLsConfig.swift
@@ -14,30 +14,32 @@ fileprivate enum AgreementURLsKeys: String, RawStringExtractable {
 }
 
 class AgreementURLsConfig : NSObject {
-    let eulaURL: URL?
-    let tosURL: URL?
-    let privacyPolicyURL: URL?
+    var eulaURL: URL? = nil
+    var tosURL: URL? = nil
+    var privacyPolicyURL: URL? = nil
     
     init(dictionary: [String: AnyObject]) {
-        if let eulaURL = dictionary[AgreementURLsKeys.eulaURL] as? String {
-            self.eulaURL = URL(string: eulaURL)
+        let eulaURL = dictionary[AgreementURLsKeys.eulaURL] as? String
+        let tosURL = dictionary[AgreementURLsKeys.tosURL] as? String
+        let privacyPolicyURL = dictionary[AgreementURLsKeys.privacyPolicyURL] as? String
+
+        if eulaURL != nil || tosURL != nil || privacyPolicyURL != nil {
+            if let eulaURL = eulaURL, !eulaURL.isEmpty {
+                self.eulaURL = URL(string: eulaURL)
+            }
+
+            if let tosURL = tosURL, !tosURL.isEmpty {
+                self.tosURL = URL(string: tosURL)
+            }
+
+            if let privacyPolicyURL = privacyPolicyURL, !privacyPolicyURL.isEmpty {
+                self.privacyPolicyURL = URL(string: privacyPolicyURL)
+            }
         }
         else {
-            eulaURL = Bundle.main.url(forResource: "MobileAppEula", withExtension: "htm")
-        }
-        
-        if let tosURL = dictionary[AgreementURLsKeys.tosURL] as? String {
-            self.tosURL = URL(string: tosURL)
-        }
-        else {
-            tosURL = Bundle.main.url(forResource: "TermsOfServices", withExtension: "htm")
-        }
-        
-        if let privacyPolicyURL = dictionary[AgreementURLsKeys.privacyPolicyURL] as? String {
-            self.privacyPolicyURL = URL(string: privacyPolicyURL)
-        }
-        else {
-            privacyPolicyURL = Bundle.main.url(forResource: "PrivacyPolicy", withExtension: "htm")
+            self.eulaURL = Bundle.main.url(forResource: "MobileAppEula", withExtension: "htm")
+            self.tosURL = Bundle.main.url(forResource: "TermsOfServices", withExtension: "htm")
+            self.privacyPolicyURL = Bundle.main.url(forResource: "PrivacyPolicy", withExtension: "htm")
         }
     }
 }

--- a/Source/OEXUserLicenseAgreementViewController.m
+++ b/Source/OEXUserLicenseAgreementViewController.m
@@ -51,11 +51,12 @@
     webView = [[WKWebView alloc] init];
     webView.navigationDelegate = self;
     [self.view addSubview:webView];
-    [self.view bringSubviewToFront:webView];
 
     [webView mas_makeConstraints:^(MASConstraintMaker *make) {
         make.edges.equalTo(webviewContainer);
     }];
+
+    [self.view bringSubviewToFront:activityIndicator];
 }
 
 - (void)addObserver {
@@ -90,16 +91,17 @@
 
     switch (navigationAction.navigationType) {
         case WKNavigationTypeLinkActivated:
+        WKNavigationTypeFormSubmitted:
+        WKNavigationTypeFormResubmitted:
             if ([[UIApplication sharedApplication] canOpenURL:URL]) {
                 [[UIApplication sharedApplication] openURL:URL];
             }
+            decisionHandler(WKNavigationActionPolicyCancel);
             break;
         default:
+            decisionHandler(WKNavigationActionPolicyAllow);
             break;
     }
-
-    decisionHandler(WKNavigationActionPolicyCancel);
-
 }
 
 - (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error {

--- a/Test/AgreementURLsConfigTests.swift
+++ b/Test/AgreementURLsConfigTests.swift
@@ -64,12 +64,9 @@ class AgreementURLsConfigTests : XCTestCase {
         let config = OEXConfig(dictionary: configDictionary)
         
         XCTAssertNotNil(config.agreementURLsConfig)
-
-        let tosUrlBundle = Bundle.main.url(forResource: "TermsOfServices", withExtension: "htm")
-        let privacyPolicyUrlBundle = Bundle.main.url(forResource: "PrivacyPolicy", withExtension: "htm")
-        
         XCTAssertEqual(config.agreementURLsConfig.eulaURL?.absoluteString, eulaUrlOverride)
-        XCTAssertEqual(config.agreementURLsConfig.tosURL, tosUrlBundle)
-        XCTAssertEqual(config.agreementURLsConfig.privacyPolicyURL, privacyPolicyUrlBundle)
+
+        XCTAssertNil(config.agreementURLsConfig.tosURL)
+        XCTAssertNil(config.agreementURLsConfig.privacyPolicyURL)
     }
 }


### PR DESCRIPTION
### Description

[LEARNER-7761](https://openedx.atlassian.net/browse/LEARNER-7761)

This PR allows all the agreement URLs to be configured independently.

If the `AGREEMENT_URLS` dictionary present in the config and any agreement URL is missing or having an empty value then that agreement value should not be clickable.

### Config
```
AGREEMENT_URLS:
    EULA_URL: 'https://www.example.com'
    TOS_URL: 'https://www.example.com'
    PRIVACY_POLICY_URL: 'https://www.example.com'
```
### How to Test this PR

1. Add and change values in the config
2. Open Login or Register screen to see the changes in action.