### PR TITLE
Error Showing on login failure

### DIFF
--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -408,11 +408,11 @@
         else if(httpResp.statusCode == OEXHTTPStatusCode426UpgradeRequired) {
             [self showUpdateRequiredMessage];
         }
-        else if (httpResp.statusCode == OEXHTTPStatusCode400BadRequest) {
+        else if (httpResp.statusCode == OEXHTTPStatusCode400BadRequest && self.authProvider != nil) {
             NSString *errorMessage = [Strings authProviderErrorWithAuthProvider:self.authProvider.displayName platformName:self.environment.config.platformName];
             [self loginFailedWithErrorMessage:errorMessage title:nil];
         }
-        else if(httpResp.statusCode >= 400 && httpResp.statusCode <= 500) {
+        else if(httpResp.statusCode >= 400 && httpResp.statusCode < 500) {
                 [self loginFailedWithErrorMessage:[Strings invalidUsernamePassword] title:nil];
         }
         else {


### PR DESCRIPTION
### Description

[LEARNER-7753](https://openedx.atlassian.net/browse/LEARNER-7753)

Proper error showing in case of login failure.

### How to test this PR
1. Open login screen

- [x] Don't enter any data in any field and Hit `Sign In` button. Alert with text**Please enter your username or e-mail address and try again.** should appear. 
- [x] Only enter username and Hit `Sign In` button. Alert with text  **Please enter your password and try again.** should appear. 
- [x] Enter wrong username or password and `Hit Sign In`. Alert with text **Please make sure that your username or e-mail address and password are correct and try again** should appear.
