### PR TITLE
Refresh Access Token in case of Non Existent token

### DIFF
--- a/Test/NetworkManager+AuthenticatorTests.swift
+++ b/Test/NetworkManager+AuthenticatorTests.swift
@@ -49,15 +49,24 @@ class NetworkManager_AuthenticationTests : XCTestCase {
         XCTAssertTrue(router.logoutCalled)
     }
     
-    func testLogoutForErrorsOtherThanExpiredAccessToken() {
+    func testNonExistentAccessToken() {
         let router = MockRouter()
         let session = sessionWithRefreshTokenBuilder()
         let response = simpleResponseBuilder(401)
         let data = "{\"error_code\":\"token_nonexistent\"}".data(using: String.Encoding.utf8)!
         let result = authenticatorResponseForRequest(response!, data: data, session: session, router: router, waitForLogout: true)
+        XCTAssertTrue(result.isAuthenticate)
+        
+    }
+
+    func testLogoutForInvalidGrantAccessToken() {
+        let router = MockRouter()
+        let session = sessionWithRefreshTokenBuilder()
+        let response = simpleResponseBuilder(401)
+        let data = "{\"error_code\":\"invalid_grant\"}".data(using: String.Encoding.utf8)!
+        let result = authenticatorResponseForRequest(response!, data: data, session: session, router: router, waitForLogout: true)
         XCTAssertTrue(result.isProceed)
         XCTAssertTrue(router.logoutCalled)
-        
     }
     
     func testLogoutWithNonJSONData() {

--- a/Test/NetworkManager+AuthenticatorTests.swift
+++ b/Test/NetworkManager+AuthenticatorTests.swift
@@ -52,11 +52,10 @@ class NetworkManager_AuthenticationTests : XCTestCase {
     func testNonExistentAccessToken() {
         let router = MockRouter()
         let session = sessionWithRefreshTokenBuilder()
-        let response = simpleResponseBuilder(401)
-        let data = "{\"error_code\":\"token_nonexistent\"}".data(using: String.Encoding.utf8)!
-        let result = authenticatorResponseForRequest(response!, data: data, session: session, router: router, waitForLogout: true)
+        let response = simpleResponseBuilder(400)
+        let data = "{\"error\":\"token_nonexistent\"}".data(using: String.Encoding.utf8)!
+        let result = authenticatorResponseForRequest(response!, data: data, session: session, router: router, waitForLogout: false)
         XCTAssertTrue(result.isAuthenticate)
-        
     }
 
     func testLogoutForInvalidGrantAccessToken() {


### PR DESCRIPTION
### Description

[LEARNER-7776](https://openedx.atlassian.net/browse/LEARNER-7776)

In case when asynchronous calls are made and are attempting to refresh the access_token where one call succeeds but the other fails. Reserver responds with `token_nonexistent` access token.
```
{
  "error_code" : "token_nonexistent",
  "developer_message": "The provided access token does not match any valid tokens."
}
```
On iOS, we were logging out learners whenever the server responds with token_nonexistent, but in this PR I'm refreshing access_token instead of logging out learner.

### How to test this PR

1. Login to https://debugtoken.sandbox.edx.org/admin using credentials `admin/Hamilton`
2. Login to the mobile app using credentials `staff/edx`
3. Expires `staff` user access token.
4. Navigate to the app or use pull to refresh to hit new API's 

- [x] App should refresh access token instead of log out whenever server responds with `token_nonexistent`
