### PR TITLE
Registration Form Errors messages showing improvements

### DIFF
--- a/Source/Registration Field Views/RegistrationFormFieldView.swift
+++ b/Source/Registration Field Views/RegistrationFormFieldView.swift
@@ -46,7 +46,7 @@ class RegistrationFormFieldView: UIView {
         textField.autocapitalizationType = .none
         textField.autocorrectionType = .no
         textField.addTarget(self, action: #selector(RegistrationFormFieldView.valueDidChange), for: .editingChanged)
-        textField.addTarget(self, action: #selector(RegistrationFormFieldView.editingEnded), for: .editingDidEnd)
+        textField.addTarget(self, action: #selector(RegistrationFormFieldView.editingDidEnd), for: .editingDidEnd)
         textField.accessibilityIdentifier = "\(accessibilityIdPrefix)-text-input-field"
         return textField
     }()
@@ -210,7 +210,7 @@ class RegistrationFormFieldView: UIView {
         validateInput()
     }
 
-    @objc private  func editingEnded() {
+    @objc private  func editingDidEnd() {
         if tapout { return }
 
         tapout = true

--- a/Source/Registration Field Views/RegistrationFormFieldView.swift
+++ b/Source/Registration Field Views/RegistrationFormFieldView.swift
@@ -21,7 +21,9 @@ class RegistrationFormFieldView: UIView {
     let titleLabelStyle = OEXMutableTextStyle(weight: .normal, size: .base, color: OEXStyles.shared().neutralDark())
     let instructionsLabelStyle = OEXMutableTextStyle(weight: .normal, size: .xxSmall, color: OEXStyles.shared().neutralDark())
     let errorLabelStyle = OEXMutableTextStyle(weight: .normal, size: .xxSmall, color: OEXStyles.shared().errorLight())
-    
+    // This is to keep track of either user tapped out first time from the field or not
+    // Show validation error first time on tap out and then while editing
+    var tapout: Bool = false
     
     private var accessibilityIdPrefix: String {
         return "RegistrationFormFieldView:\(formField?.name ?? "")"
@@ -44,7 +46,8 @@ class RegistrationFormFieldView: UIView {
         textField.autocapitalizationType = .none
         textField.autocorrectionType = .no
         textField.addTarget(self, action: #selector(RegistrationFormFieldView.valueDidChange), for: .editingChanged)
-        textField.accessibilityIdentifier = "\(self.accessibilityIdPrefix)-text-input-field"
+        textField.addTarget(self, action: #selector(RegistrationFormFieldView.editingEnded), for: .editingDidEnd)
+        textField.accessibilityIdentifier = "\(accessibilityIdPrefix)-text-input-field"
         return textField
     }()
     
@@ -202,6 +205,19 @@ class RegistrationFormFieldView: UIView {
     }
     
     @objc func valueDidChange() {
+        if !tapout { return }
+
+        validateInput()
+    }
+
+    @objc private  func editingEnded() {
+        if tapout { return }
+
+        tapout = true
+        validateInput()
+    }
+
+    private func validateInput() {
         errorMessage = validate()
         NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: NOTIFICATION_REGISTRATION_FORM_FIELD_VALUE_DID_CHANGE)))
     }


### PR DESCRIPTION
### Description

[LEARNER-7767](https://openedx.atlassian.net/browse/LEARNER-7767)

This PR improves learner experience with the validation error messages. We were showing an error message to leaner while the learner wasn't finished the input. This PR improve behavior, now first time leaner will see an error message if any on tap out and the then while editing.

### How to test this PR

Open Registration form and starting typing in any field like email.

- [ ] First time leaner won't see any validation error while editing.
- [ ] Learner should see a validation error if any on tap out.
- [ ] For the same field the next time validation error message should update while editing. 
