### PR TITLE
Registration Form Validations

### DIFF
--- a/Source/Core/Code/RegistrationFormAPI.swift
+++ b/Source/Core/Code/RegistrationFormAPI.swift
@@ -24,7 +24,6 @@ public struct RegistrationFormAPI {
     }
     
     private static func regirationFromValidationDeserializer(response: HTTPURLResponse, json: JSON) -> Result<RegistrationFormValidation> {
-        print(json)
         return RegistrationFormValidation(json: json).toResult()
     }
     

--- a/Source/Core/Code/RegistrationFormAPI.swift
+++ b/Source/Core/Code/RegistrationFormAPI.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 public struct RegistrationFormAPI {
+    private static let SignupValidationURL = "/api/user/v1/validation/registration"
     
     private static func registrationFormDeserializer(response : HTTPURLResponse, json : JSON) -> Result<OEXRegistrationDescription> {
         return json.dictionaryObject.map { OEXRegistrationDescription(dictionary: $0) }.toResult()
@@ -29,7 +30,7 @@ public struct RegistrationFormAPI {
     
     public static func registrationFormValidationRequest(parameters: [String : String]) -> NetworkRequest<RegistrationFormValidation> {
         return NetworkRequest(method: .POST,
-                              path: SIGN_UP_VALIDATION_URL,
+                              path: SignupValidationURL,
                               body: .jsonBody(JSON(parameters)),
                               deserializer: .jsonResponse(regirationFromValidationDeserializer))
     }

--- a/Source/Core/Code/RegistrationFormAPI.swift
+++ b/Source/Core/Code/RegistrationFormAPI.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct RegistrationFormAPI {
-    private static let RegistrationValidationURL = "/api/user/v1/validation/registration"
+    private static let RegistrationValidationPath = "/api/user/v1/validation/registration"
     
     private static func registrationFormDeserializer(response : HTTPURLResponse, json : JSON) -> Result<OEXRegistrationDescription> {
         return json.dictionaryObject.map { OEXRegistrationDescription(dictionary: $0) }.toResult()
@@ -30,7 +30,7 @@ public struct RegistrationFormAPI {
     
     public static func registrationFormValidationRequest(parameters: [String : String]) -> NetworkRequest<RegistrationFormValidation> {
         return NetworkRequest(method: .POST,
-                              path: RegistrationValidationURL,
+                              path: RegistrationValidationPath,
                               body: .jsonBody(JSON(parameters)),
                               deserializer: .jsonResponse(regirationFromValidationDeserializer))
     }

--- a/Source/Core/Code/RegistrationFormAPI.swift
+++ b/Source/Core/Code/RegistrationFormAPI.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public struct RegistrationFormAPI {
-    private static let SignupValidationURL = "/api/user/v1/validation/registration"
+    private static let RegistrationValidationURL = "/api/user/v1/validation/registration"
     
     private static func registrationFormDeserializer(response : HTTPURLResponse, json : JSON) -> Result<OEXRegistrationDescription> {
         return json.dictionaryObject.map { OEXRegistrationDescription(dictionary: $0) }.toResult()
@@ -30,7 +30,7 @@ public struct RegistrationFormAPI {
     
     public static func registrationFormValidationRequest(parameters: [String : String]) -> NetworkRequest<RegistrationFormValidation> {
         return NetworkRequest(method: .POST,
-                              path: SignupValidationURL,
+                              path: RegistrationValidationURL,
                               body: .jsonBody(JSON(parameters)),
                               deserializer: .jsonResponse(regirationFromValidationDeserializer))
     }

--- a/Source/Core/Code/RegistrationFormAPI.swift
+++ b/Source/Core/Code/RegistrationFormAPI.swift
@@ -28,7 +28,6 @@ public struct RegistrationFormAPI {
     }
     
     public static func registrationFormValidationRequest(parameters: [String : String]) -> NetworkRequest<RegistrationFormValidation> {
-        print(SIGN_UP_VALIDATION_URL)
         return NetworkRequest(method: .POST,
                               path: SIGN_UP_VALIDATION_URL,
                               body: .jsonBody(JSON(parameters)),

--- a/Source/Core/Code/RegistrationFormAPI.swift
+++ b/Source/Core/Code/RegistrationFormAPI.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public struct RegistrationFormAPI {
     
-    static func registrationFormDeserializer(response : HTTPURLResponse, json : JSON) -> Result<OEXRegistrationDescription> {
+    private static func registrationFormDeserializer(response : HTTPURLResponse, json : JSON) -> Result<OEXRegistrationDescription> {
         return json.dictionaryObject.map { OEXRegistrationDescription(dictionary: $0) }.toResult()
     }
     
@@ -21,5 +21,18 @@ public struct RegistrationFormAPI {
                               path: path,
                               deserializer: .jsonResponse(registrationFormDeserializer))
         
+    }
+    
+    private static func regirationFromValidationDeserializer(response: HTTPURLResponse, json: JSON) -> Result<RegistrationFormValidation> {
+        print(json)
+        return RegistrationFormValidation(json: json).toResult()
+    }
+    
+    public static func registrationFormValidationRequest(parameters: [String : String]) -> NetworkRequest<RegistrationFormValidation> {
+        print(SIGN_UP_VALIDATION_URL)
+        return NetworkRequest(method: .POST,
+                       path: SIGN_UP_VALIDATION_URL,
+                       body: .jsonBody(JSON(parameters)),
+                       deserializer: .jsonResponse(regirationFromValidationDeserializer))
     }
 }

--- a/Source/Core/Code/RegistrationFormAPI.swift
+++ b/Source/Core/Code/RegistrationFormAPI.swift
@@ -30,8 +30,8 @@ public struct RegistrationFormAPI {
     public static func registrationFormValidationRequest(parameters: [String : String]) -> NetworkRequest<RegistrationFormValidation> {
         print(SIGN_UP_VALIDATION_URL)
         return NetworkRequest(method: .POST,
-                       path: SIGN_UP_VALIDATION_URL,
-                       body: .jsonBody(JSON(parameters)),
-                       deserializer: .jsonResponse(regirationFromValidationDeserializer))
+                              path: SIGN_UP_VALIDATION_URL,
+                              body: .jsonBody(JSON(parameters)),
+                              deserializer: .jsonResponse(regirationFromValidationDeserializer))
     }
 }

--- a/Source/OEXNetworkConstants.h
+++ b/Source/OEXNetworkConstants.h
@@ -36,6 +36,5 @@
 #define URL_COURSE_ENROLLMENT @"/api/enrollment/v1/enrollment"
 #define URL_COURSE_ENROLLMENT_EMAIL_OPT_IN @"/api/user_api/v1/preferences/email_opt_in"
 #define SIGN_UP_URL @"/user_api/{version}/account/registration/"
-#define SIGN_UP_VALIDATION_URL @"/api/user/v1/validation/registration"
 
 #endif

--- a/Source/OEXNetworkConstants.h
+++ b/Source/OEXNetworkConstants.h
@@ -36,5 +36,6 @@
 #define URL_COURSE_ENROLLMENT @"/api/enrollment/v1/enrollment"
 #define URL_COURSE_ENROLLMENT_EMAIL_OPT_IN @"/api/user_api/v1/preferences/email_opt_in"
 #define SIGN_UP_URL @"/user_api/{version}/account/registration/"
+#define SIGN_UP_VALIDATION_URL @"/api/user/v1/validation/registration"
 
 #endif

--- a/Source/OEXRegistrationViewController+Swift.swift
+++ b/Source/OEXRegistrationViewController+Swift.swift
@@ -27,7 +27,7 @@ extension OEXRegistrationViewController {
         }
     }
     
-    private func errorWithErrorType(name: String, validation: ValidationDecisions) -> String? {
+    private func error(with name: String, validation: ValidationDecisions) -> String? {
         guard let value = ValidationDecisions.Keys(rawValue: name),
             ValidationDecisions.Keys.allCases.contains(value),
             let errorValue = validation.value(forKeyPath: value.rawValue) as? String,
@@ -54,7 +54,7 @@ extension OEXRegistrationViewController {
             for case let controller as OEXRegistrationFieldController in owner.fieldControllers {
                 controller.accessibleInputField?.resignFirstResponder()
                 
-                if let error = owner.errorWithErrorType(name: controller.field.name, validation: validation) {
+                if let error = owner.error(with: controller.field.name, validation: validation) {
                     controller.handleError(error)
                     if firstControllerWithError == nil {
                         firstControllerWithError = controller

--- a/Source/OEXRegistrationViewController+Swift.swift
+++ b/Source/OEXRegistrationViewController+Swift.swift
@@ -28,42 +28,11 @@ extension OEXRegistrationViewController {
     }
     
     private func errorWithErrorType(name: String, validation: ValidationDecisions) -> String? {
-        switch name {
-        case ValidationDecisions.Keys.name.rawValue:
-            if !validation.name.isEmpty {
-                return validation.name
-            }
-            break
-            
-        case ValidationDecisions.Keys.username.rawValue:
-            if !validation.username.isEmpty {
-                return validation.username
-            }
-            break
-            
-        case ValidationDecisions.Keys.email.rawValue:
-            if !validation.email.isEmpty {
-                return validation.email
-            }
-            break
-            
-        case ValidationDecisions.Keys.password.rawValue:
-            if !validation.password.isEmpty {
-                return validation.password
-            }
-            break
-            
-        case ValidationDecisions.Keys.country.rawValue:
-            if !validation.country.isEmpty {
-                return validation.country
-            }
-            break
-            
-        default:
-            return nil
-        }
-        
-        return nil
+        guard let value = ValidationDecisions.Keys(rawValue: name),
+            ValidationDecisions.Keys.allCases.contains(value),
+            let errorValue = validation.value(forKeyPath: value.rawValue) as? String,
+            !errorValue.isEmpty else { return nil }
+        return errorValue
     }
     
     @objc func validateRegistrationForm(parameters: [String: String]) {

--- a/Source/OEXRegistrationViewController+Swift.swift
+++ b/Source/OEXRegistrationViewController+Swift.swift
@@ -28,28 +28,34 @@ extension OEXRegistrationViewController {
     }
     
     private func errorWithErrorType(name: String, validation: ValidationDecisions) -> String? {
-       switch name {
-        case "name":
+        switch name {
+        case ValidationDecisions.Keys.name.rawValue:
             if !validation.name.isEmpty {
                 return validation.name
             }
             break
             
-        case "username":
+        case ValidationDecisions.Keys.username.rawValue:
             if !validation.username.isEmpty {
                 return validation.username
             }
             break
             
-        case "email":
+        case ValidationDecisions.Keys.email.rawValue:
             if !validation.email.isEmpty {
                 return validation.email
             }
             break
             
-        case "password":
+        case ValidationDecisions.Keys.password.rawValue:
             if !validation.password.isEmpty {
                 return validation.password
+            }
+            break
+            
+        case ValidationDecisions.Keys.country.rawValue:
+            if !validation.country.isEmpty {
+                return validation.country
             }
             break
             

--- a/Source/OEXRegistrationViewController+Swift.swift
+++ b/Source/OEXRegistrationViewController+Swift.swift
@@ -27,33 +27,29 @@ extension OEXRegistrationViewController {
         }
     }
     
-    private func matchControllerWithValidation(controller: inout OEXRegistrationFieldController, validation: ValidationDecisions) -> OEXRegistrationFieldController? {
-        switch controller.field.name {
+    private func errorWithErrorType(name: String, validation: ValidationDecisions) -> String? {
+       switch name {
         case "name":
             if !validation.name.isEmpty {
-                controller.handleError(validation.name)
-                return controller
+                return validation.name
             }
             break
             
         case "username":
             if !validation.username.isEmpty {
-                controller.handleError(validation.username)
-                return controller
+                return validation.username
             }
             break
             
         case "email":
             if !validation.email.isEmpty {
-                controller.handleError(validation.email)
-                return controller
+                return validation.email
             }
             break
             
         case "password":
             if !validation.password.isEmpty {
-                controller.handleError(validation.password)
-                return controller
+                return validation.password
             }
             break
             
@@ -80,12 +76,14 @@ extension OEXRegistrationViewController {
             
             var firstControllerWithError: OEXRegistrationFieldController?
             
-            for case var controller as OEXRegistrationFieldController in owner.fieldControllers {
+            for case let controller as OEXRegistrationFieldController in owner.fieldControllers {
                 controller.accessibleInputField?.resignFirstResponder()
                 
-                let errorController = owner.matchControllerWithValidation(controller: &controller, validation: validation)
-                if firstControllerWithError == nil {
-                    firstControllerWithError = errorController
+                if let error = owner.errorWithErrorType(name: controller.field.name, validation: validation) {
+                    controller.handleError(error)
+                    if firstControllerWithError == nil {
+                        firstControllerWithError = controller
+                    }
                 }
             }
             

--- a/Source/OEXRegistrationViewController+Swift.swift
+++ b/Source/OEXRegistrationViewController+Swift.swift
@@ -27,10 +27,10 @@ extension OEXRegistrationViewController {
         }
     }
     
-    private func error(with name: String, validation: ValidationDecisions) -> String? {
+    private func error(with name: String, _ validationDecisions: ValidationDecisions) -> String? {
         guard let value = ValidationDecisions.Keys(rawValue: name),
             ValidationDecisions.Keys.allCases.contains(value),
-            let errorValue = validation.value(forKeyPath: value.rawValue) as? String,
+            let errorValue = validationDecisions.value(forKeyPath: value.rawValue) as? String,
             !errorValue.isEmpty else { return nil }
         return errorValue
     }
@@ -43,7 +43,7 @@ extension OEXRegistrationViewController {
         
         networkManager.taskForRequest(networkRequest) { [weak self] result in
             guard let owner = self,
-                let validation = result.data?.validationDecisions else {
+                let validationDecisions = result.data?.validationDecisions else {
                     self?.showProgress(false)
                     self?.register(withParameters: parameters)
                     return
@@ -54,7 +54,7 @@ extension OEXRegistrationViewController {
             for case let controller as OEXRegistrationFieldController in owner.fieldControllers {
                 controller.accessibleInputField?.resignFirstResponder()
                 
-                if let error = owner.error(with: controller.field.name, validation: validation) {
+                if let error = owner.error(with: controller.field.name, validationDecisions) {
                     controller.handleError(error)
                     if firstControllerWithError == nil {
                         firstControllerWithError = controller

--- a/Source/OEXRegistrationViewController+Swift.swift
+++ b/Source/OEXRegistrationViewController+Swift.swift
@@ -27,7 +27,7 @@ extension OEXRegistrationViewController {
         }
     }
     
-    private func matchPropertyWithErrorType(controller: inout OEXRegistrationFieldController, validation: ValidationDecisions) -> OEXRegistrationFieldController? {
+    private func matchControllerWithValidation(controller: inout OEXRegistrationFieldController, validation: ValidationDecisions) -> OEXRegistrationFieldController? {
         switch controller.field.name {
         case "name":
             if !validation.name.isEmpty {
@@ -83,7 +83,7 @@ extension OEXRegistrationViewController {
             for case var controller as OEXRegistrationFieldController in owner.fieldControllers {
                 controller.accessibleInputField?.resignFirstResponder()
                 
-                let errorController = owner.matchPropertyWithErrorType(controller: &controller, validation: validation)
+                let errorController = owner.matchControllerWithValidation(controller: &controller, validation: validation)
                 if firstControllerWithError == nil {
                     firstControllerWithError = errorController
                 }

--- a/Source/OEXRegistrationViewController+Swift.swift
+++ b/Source/OEXRegistrationViewController+Swift.swift
@@ -27,6 +27,43 @@ extension OEXRegistrationViewController {
         }
     }
     
+    private func matchPropertyWithErrorType(controller: inout OEXRegistrationFieldController, validation: ValidationDecisions) -> OEXRegistrationFieldController? {
+        switch controller.field.name {
+        case "name":
+            if !validation.name.isEmpty {
+                controller.handleError(validation.name)
+                return controller
+            }
+            break
+            
+        case "username":
+            if !validation.username.isEmpty {
+                controller.handleError(validation.username)
+                return controller
+            }
+            break
+            
+        case "email":
+            if !validation.email.isEmpty {
+                controller.handleError(validation.email)
+                return controller
+            }
+            break
+            
+        case "password":
+            if !validation.password.isEmpty {
+                controller.handleError(validation.password)
+                return controller
+            }
+            break
+            
+        default:
+            return nil
+        }
+        
+        return nil
+    }
+    
     @objc func validateRegistrationForm(parameters: [String: String]) {
         showProgress(true)
         
@@ -43,42 +80,12 @@ extension OEXRegistrationViewController {
             
             var firstControllerWithError: OEXRegistrationFieldController?
             
-            for case let controller as OEXRegistrationFieldController in owner.fieldControllers {
+            for case var controller as OEXRegistrationFieldController in owner.fieldControllers {
                 controller.accessibleInputField?.resignFirstResponder()
                 
-                if !validation.name.isEmpty && controller.field.name == "name" {
-                    controller.handleError(validation.name)
-                    if firstControllerWithError == nil {
-                        firstControllerWithError = controller
-                    }
-                }
-                
-                if !validation.username.isEmpty && controller.field.name == "username" {
-                    controller.handleError(validation.username)
-                    if firstControllerWithError == nil {
-                        firstControllerWithError = controller
-                    }
-                }
-                
-                if !validation.email.isEmpty && controller.field.name == "email" {
-                    controller.handleError(validation.email)
-                    if firstControllerWithError == nil {
-                        firstControllerWithError = controller
-                    }
-                }
-                
-                if !validation.password.isEmpty && controller.field.name == "password" {
-                    controller.handleError(validation.password)
-                    if firstControllerWithError == nil {
-                        firstControllerWithError = controller
-                    }
-                }
-                
-                if !validation.country.isEmpty && controller.field.name == "country" {
-                    controller.handleError(validation.country)
-                    if firstControllerWithError == nil {
-                        firstControllerWithError = controller
-                    }
+                let errorController = owner.matchPropertyWithErrorType(controller: &controller, validation: validation)
+                if firstControllerWithError == nil {
+                    firstControllerWithError = errorController
                 }
             }
             
@@ -97,7 +104,7 @@ extension OEXRegistrationViewController {
     
     @objc func register(withParameters parameter:[String:String]) {
         showProgress(true)
-        let infoDict :[String: String] = [OEXAnalyticsKeyProvider: self.externalProvider?.backendName ?? ""]
+        let infoDict: [String: String] = [OEXAnalyticsKeyProvider: externalProvider?.backendName ?? ""]
         environment.analytics.trackEvent(OEXAnalytics.registerEvent(name: AnalyticsEventName.UserRegistrationClick.rawValue, displayName: AnalyticsDisplayName.CreateAccount.rawValue), forComponent: nil, withInfo: infoDict)
         let apiVersion = environment.config.apiUrlVersionConfig.registration
         OEXAuthentication.registerUser(withApiVersion: apiVersion, paramaters: parameter) { [weak self] (data: Data?, response: HTTPURLResponse?, error: Error?) in

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -535,7 +535,7 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
         [parameters setSafeObject:self.environment.config.oauthClientID forKey:@"client_id"];
     }
     
-    [self registerWithParameters:parameters];
+    [self validateRegistrationFormWithParameters:parameters];
 }
 
 - (void) showInputErrorAlert {

--- a/Source/Registration Field Views/RegistrationFormFieldView.swift
+++ b/Source/Registration Field Views/RegistrationFormFieldView.swift
@@ -205,13 +205,8 @@ class RegistrationFormFieldView: UIView {
     }
     
     @objc func valueDidChange(isPicker: Bool = false) {
-        if isPicker {
-            validateInput()
-        } else {
-            if !tapout { return }
-
-            validateInput()
-        }
+        if !tapout && !isPicker { return }
+        validateInput()
     }
 
     @objc private  func editingDidEnd() {

--- a/Source/Registration Field Views/RegistrationFormFieldView.swift
+++ b/Source/Registration Field Views/RegistrationFormFieldView.swift
@@ -204,10 +204,14 @@ class RegistrationFormFieldView: UIView {
         errorMessage = nil
     }
     
-    @objc func valueDidChange() {
-        if !tapout { return }
+    @objc func valueDidChange(isPicker: Bool = false) {
+        if isPicker {
+            validateInput()
+        } else {
+            if !tapout { return }
 
-        validateInput()
+            validateInput()
+        }
     }
 
     @objc private  func editingDidEnd() {

--- a/Source/RegistrationFormValidation.swift
+++ b/Source/RegistrationFormValidation.swift
@@ -11,12 +11,12 @@ import Foundation
 public class RegistrationFormValidation: NSObject {
     let validationDecisions: ValidationDecisions?
     
-    private enum Keys: String {
+    private enum Keys: String, RawStringExtractable {
         case validationDecisions = "validation_decisions"
     }
     
     public init?(json: JSON) {
-        let validationDecisionJson = json[Keys.validationDecisions.rawValue]
+        let validationDecisionJson = json[Keys.validationDecisions]
         validationDecisions = ValidationDecisions(json: validationDecisionJson) ?? nil
     }
 }
@@ -24,7 +24,7 @@ public class RegistrationFormValidation: NSObject {
 class ValidationDecisions: NSObject {
     @objc let name, email, username, password, country: String
     
-    private enum Keys: String {
+    private enum Keys: String, RawStringExtractable {
         case name
         case email
         case username
@@ -33,10 +33,10 @@ class ValidationDecisions: NSObject {
     }
     
     public init?(json: JSON) {
-        name = json[Keys.name.rawValue].string ?? ""
-        email = json[Keys.email.rawValue].string ?? ""
-        username = json[Keys.username.rawValue].string ?? ""
-        password = json[Keys.password.rawValue].string ?? ""
-        country = json[Keys.country.rawValue].string ?? ""
+        name = json[Keys.name].string ?? ""
+        email = json[Keys.email].string ?? ""
+        username = json[Keys.username].string ?? ""
+        password = json[Keys.password].string ?? ""
+        country = json[Keys.country].string ?? ""
     }
 }

--- a/Source/RegistrationFormValidation.swift
+++ b/Source/RegistrationFormValidation.swift
@@ -1,0 +1,30 @@
+//
+//  RegistrationFormValidation.swift
+//  edX
+//
+//  Created by Muhammad Umer on 13/07/2020.
+//  Copyright © 2020 edX. All rights reserved.
+//
+
+import Foundation
+
+public class RegistrationFormValidation: NSObject {
+    let validationDecisions: ValidationDecisions?
+    
+    public init?(json: JSON) {
+        let validationDecisionJson = json["validation_decisions"]
+        validationDecisions = ValidationDecisions(json: validationDecisionJson) ?? nil
+    }
+}
+
+class ValidationDecisions: NSObject {
+    @objc let name, email, username, password, country: String
+    
+    public init?(json: JSON) {
+        name = json["name"].string ?? ""
+        email = json["email"].string ?? ""
+        username = json["username"].string ?? ""
+        password = json["password"].string ?? ""
+        country = json["country"].string ?? ""
+    }
+}

--- a/Source/RegistrationFormValidation.swift
+++ b/Source/RegistrationFormValidation.swift
@@ -24,7 +24,7 @@ public class RegistrationFormValidation: NSObject {
 class ValidationDecisions: NSObject {
     @objc let name, email, username, password, country: String
     
-    enum Keys: String, RawStringExtractable {
+    enum Keys: String, RawStringExtractable, CaseIterable {
         case name
         case email
         case username

--- a/Source/RegistrationFormValidation.swift
+++ b/Source/RegistrationFormValidation.swift
@@ -11,8 +11,12 @@ import Foundation
 public class RegistrationFormValidation: NSObject {
     let validationDecisions: ValidationDecisions?
     
+    private enum Keys: String {
+        case validationDecisions = "validation_decisions"
+    }
+    
     public init?(json: JSON) {
-        let validationDecisionJson = json["validation_decisions"]
+        let validationDecisionJson = json[Keys.validationDecisions.rawValue]
         validationDecisions = ValidationDecisions(json: validationDecisionJson) ?? nil
     }
 }
@@ -20,11 +24,19 @@ public class RegistrationFormValidation: NSObject {
 class ValidationDecisions: NSObject {
     @objc let name, email, username, password, country: String
     
+    private enum Keys: String {
+        case name
+        case email
+        case username
+        case password
+        case country
+    }
+    
     public init?(json: JSON) {
-        name = json["name"].string ?? ""
-        email = json["email"].string ?? ""
-        username = json["username"].string ?? ""
-        password = json["password"].string ?? ""
-        country = json["country"].string ?? ""
+        name = json[Keys.name.rawValue].string ?? ""
+        email = json[Keys.email.rawValue].string ?? ""
+        username = json[Keys.username.rawValue].string ?? ""
+        password = json[Keys.password.rawValue].string ?? ""
+        country = json[Keys.country.rawValue].string ?? ""
     }
 }

--- a/Source/RegistrationFormValidation.swift
+++ b/Source/RegistrationFormValidation.swift
@@ -24,7 +24,7 @@ public class RegistrationFormValidation: NSObject {
 class ValidationDecisions: NSObject {
     @objc let name, email, username, password, country: String
     
-    private enum Keys: String, RawStringExtractable {
+    enum Keys: String, RawStringExtractable {
         case name
         case email
         case username

--- a/Source/RegistrationSelectOptionView.swift
+++ b/Source/RegistrationSelectOptionView.swift
@@ -97,7 +97,7 @@ class RegistrationSelectOptionView: RegistrationFormFieldView {
                 } else {
                     self?.selected = item
                     self?.setButtonTitle(title: item.name)
-                    self?.valueDidChange()
+                    self?.valueDidChange(isPicker: true)
                 }
                 self?.alertController.dismiss(animated: true, completion: nil)
             }

--- a/Source/RegistrationSelectOptionView.swift
+++ b/Source/RegistrationSelectOptionView.swift
@@ -94,6 +94,7 @@ class RegistrationSelectOptionView: RegistrationFormFieldView {
             if let item = item {
                 if item.value.isEmpty {
                     self?.setButtonTitle(title: "")
+                    self?.selected = nil
                 } else {
                     self?.selected = item
                     self?.setButtonTitle(title: item.name)

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		5F514FBA240696D700BA113A /* MSAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F514FB9240696D700BA113A /* MSAL.framework */; };
 		5F514FBB240696D700BA113A /* MSAL.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5F514FB9240696D700BA113A /* MSAL.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5FB44C1324978EFB00C59DD0 /* RegistrationSelectOptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB44C1224978EFB00C59DD0 /* RegistrationSelectOptionViewController.swift */; };
+		5FB69A8E24BC2CD800BBCAD7 /* RegistrationFormValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB69A8D24BC2CD800BBCAD7 /* RegistrationFormValidation.swift */; };
 		67FDC7528B4181D9153A7C36 /* Pods_edXTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F80CBFF126E890C3709DEAF /* Pods_edXTests.framework */; };
 		6919F5FF1D65CD27006935C8 /* OEXColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6919F5FE1D65CD27006935C8 /* OEXColors.swift */; };
 		6926CDAB1D59BE3600A16E22 /* ic_next_press.png in Resources */ = {isa = PBXBuildFile; fileRef = 6926CDA41D59BE3600A16E22 /* ic_next_press.png */; };
@@ -1178,6 +1179,7 @@
 		5F4AB7782463F891002D1C9C /* GoogleCast.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleCast.framework; path = Libraries/Cast/GoogleCast.framework; sourceTree = "<group>"; };
 		5F514FB9240696D700BA113A /* MSAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MSAL.framework; path = Libraries/MSAL/MSAL.framework; sourceTree = "<group>"; };
 		5FB44C1224978EFB00C59DD0 /* RegistrationSelectOptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationSelectOptionViewController.swift; sourceTree = "<group>"; };
+		5FB69A8D24BC2CD800BBCAD7 /* RegistrationFormValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationFormValidation.swift; sourceTree = "<group>"; };
 		61E8D7FCCFA0751E2D510864 /* libPods-EndToEndTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EndToEndTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6919F5FE1D65CD27006935C8 /* OEXColors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OEXColors.swift; sourceTree = "<group>"; };
 		6926CDA41D59BE3600A16E22 /* ic_next_press.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = ic_next_press.png; sourceTree = "<group>"; };
@@ -3383,6 +3385,7 @@
 				B4B6D5FD1A949EFC000F44E8 /* OEXRegistrationAgreement.m */,
 				B4B6D5FE1A949EFC000F44E8 /* OEXRegistrationErrorMessage.h */,
 				B4B6D5FF1A949EFC000F44E8 /* OEXRegistrationErrorMessage.m */,
+				5FB69A8D24BC2CD800BBCAD7 /* RegistrationFormValidation.swift */,
 			);
 			name = Model;
 			sourceTree = "<group>";
@@ -5004,6 +5007,7 @@
 				B4D5C7EC1A6FBAA300427D1D /* OEXPersistentCredentialStorage.m in Sources */,
 				7713DFBF1AC3C16C005A1756 /* OEXRegisteringUserDetails.m in Sources */,
 				77FDF40F1AFBAE7700E8C639 /* OEXRouter+Swift.swift in Sources */,
+				5FB69A8E24BC2CD800BBCAD7 /* RegistrationFormValidation.swift in Sources */,
 				77056C3E1B3F320800D9DB4A /* DetailToolbarButton.swift in Sources */,
 				77691F9C1B3A0774003922F2 /* Result+JSON.swift in Sources */,
 				772619B71ADDA8ED005BD7E4 /* OEXPushSettingsManager.m in Sources */,


### PR DESCRIPTION
### Description

[LEARNER-7834](https://openedx.atlassian.net/browse/LEARNER-7834)

- Validate the registration form using the API: `POST /api/user/v1/validation/registration`
- The validation API should be hit before the actual registration API
- The validation API should be initiated upon the click of Register button
- If the validation API doesn't return any error in its response, the app should automatically call the registration API and register the learner
- If the validation API returns an error in its response, the app should not call the registration API and show the error inline with each field that had invalid data

### Notes

### How to test this PR

- [x] Use some previously used username in Registration form, it should give invalid error after hitting validation api

- [x] Use some previously used email in Registration form, it should give invalid error after hitting validation api 

- [x] Use invalid password, i.e without numbers, it should give invalid error after hitting validation api 

- [x] If validation api returns no invalid form field, then usual registration flow should work, i.e. Register user and navigation to Home Screen