### PR TITLE
Offline Support for Video Block

### DIFF
--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -250,6 +250,7 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
     }
     
     func removeControls() {
+        controls?.reset()
         controls?.removeFromSuperview()
         controls = nil
     }
@@ -393,6 +394,7 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
     @objc private func movieTimedOut() {
         stop()
         playerDelegate?.playerDidTimeout(videoPlayer: self)
+        loadingIndicatorView.stopAnimating()
     }
     
     fileprivate func resume() {


### PR DESCRIPTION
### Description

[LEARNER-7813](https://openedx.atlassian.net/browse/LEARNER-7813)

This PR adds support of Offline Snackbar to the Video Block View.

### Notes
We won't be able to achieve the exact same behavior of Android because the players' callbacks are different. And there isn't any indication in the callbacks that there isn't any network connection.
