### PR TITLE
LEARNER-7840, login screen is not opening

### DIFF
--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -466,7 +466,9 @@ extension OEXRouter {
     
     func showWhatsNew(fromController controller : UIViewController) {
         let whatsNewController = WhatsNewViewController(environment: environment)
-        controller.present(whatsNewController, animated: true, completion: nil)
+        let navController = ForwardingNavigationController(rootViewController: whatsNewController)
+        navController.setNavigationBarHidden(true, animated: false)
+        controller.present(navController, animated: true, completion: nil)
     }
 
     // MARK: - LOGIN / LOGOUT

--- a/Source/OEXRouter.m
+++ b/Source/OEXRouter.m
@@ -122,12 +122,16 @@ OEXRegistrationViewControllerDelegate
 }
 
 - (void)showLoginScreenFromController:(UIViewController*)controller completion:(void(^)(void))completion {
-    UIViewController *topMostController = [[UIApplication sharedApplication] topMostController];
-    if ([topMostController isKindOfClass:[OEXLoginViewController class]] == NO) {
-        [topMostController dismissViewControllerAnimated:true completion:^{
-            [self presentViewController:[self loginViewController] fromController:[[UIApplication sharedApplication] topMostController] completion:completion];
-        }];
-    }
+   UIViewController *topMostController = [[UIApplication sharedApplication] topMostController];
+      if ([topMostController isKindOfClass:[OEXLoginViewController class]] == NO) {
+          if ([topMostController isModal]) {
+              [topMostController dismissViewControllerAnimated:true completion:^{
+                  [self presentViewController:[self loginViewController] fromController:[[UIApplication sharedApplication] topMostController] completion:completion];
+              }];
+          } else {
+               [self presentViewController:[self loginViewController] fromController:[[UIApplication sharedApplication] topMostController] completion:completion];
+          }
+      }
 }
 
 - (UINavigationController *) loginViewController {

--- a/Source/UIViewController+CommonAdditions.swift
+++ b/Source/UIViewController+CommonAdditions.swift
@@ -25,7 +25,7 @@ extension UIViewController {
         return UIApplication.shared.statusBarOrientation
     }
     
-    func isModal() -> Bool {
+   @objc func isModal() -> Bool {
         return (navigationController?.viewControllers.firstIndex(of: self) == 0) &&
             (presentingViewController?.presentedViewController == self
             || isRootModal()


### PR DESCRIPTION
### Description

[LEARNER-7840](https://openedx.atlassian.net/browse/LEARNER-7840)

In this PR I fixed the issue that the login screen was not opening. This issue was particularly producible in iOS-12.x devices.

### How to test this PR
- Start the application, tap on the login button the login screen should show up.
- Login in the application and go into account screen, tap on the logout button the login screen should show up.
