### PR TITLE
Fix Discovery Screen Title

### DIFF
--- a/Source/CourseCatalogViewController.swift
+++ b/Source/CourseCatalogViewController.swift
@@ -20,12 +20,6 @@ class CourseCatalogViewController: UIViewController, CoursesContainerViewControl
         self.environment = environment
         coursesContainer = CoursesContainerViewController(environment: environment, context: .courseCatalog)
         super.init(nibName: nil, bundle: nil)
-        navigationItem.title = Strings.findCourses
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: " ", style: .plain, target: nil, action: nil)
-        navigationItem.backBarButtonItem?.accessibilityIdentifier = "CourseCatalogViewController:cancel-bar-button-item"
-        view.accessibilityIdentifier = "course-catalog-screen"
-
-        setupAndLoadCourseCatalog()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -43,9 +37,24 @@ class CourseCatalogViewController: UIViewController, CoursesContainerViewControl
         return PaginationController(paginator: paginator, collectionView: coursesContainer.collectionView)
     }()
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+    }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        navigationItem.title = Strings.findCourses
+        tabBarController?.navigationItem.title = Strings.findCourses
         environment.analytics.trackScreen(withName: OEXAnalyticsScreenFindCourses)
+    }
+    
+    private func setupView() {
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: " ", style: .plain, target: nil, action: nil)
+        navigationItem.backBarButtonItem?.accessibilityIdentifier = "CourseCatalogViewController:cancel-bar-button-item"
+        view.accessibilityIdentifier = "course-catalog-screen"
+        
+        setupAndLoadCourseCatalog()
     }
 
     private func setupAndLoadCourseCatalog() {

--- a/Source/DiscoveryViewController.swift
+++ b/Source/DiscoveryViewController.swift
@@ -53,11 +53,15 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
         self.bottomBar = bottomBar
         self.searchQuery = searchQuery
         super.init(nibName: nil, bundle: nil)
-        setupView()
     }
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -115,6 +119,7 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
                 assert(true, "Invalid control")
             }
         }, for: .valueChanged)
+        tabBarController?.navigationItem.title = Strings.discover
         navigationItem.title = Strings.discover
     }
     
@@ -183,7 +188,7 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
         return requiredIndex
     }
     
-    // MARK: Deep Linking    
+    // MARK: Deep Linking
     func switchSegment(with type: DeepLinkType) {
         switch type {
         case .courseDiscovery, .courseDetail:

--- a/Source/DiscoveryViewController.swift
+++ b/Source/DiscoveryViewController.swift
@@ -69,6 +69,8 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
         if environment.session.currentUser != nil {
             bottomBar?.removeFromSuperview()
         }
+        tabBarController?.navigationItem.title = Strings.discover
+        navigationItem.title = Strings.discover
     }
     
     private func prepareSegmentViewData() {
@@ -119,8 +121,6 @@ class DiscoveryViewController: UIViewController, InterfaceOrientationOverriding 
                 assert(true, "Invalid control")
             }
         }, for: .valueChanged)
-        tabBarController?.navigationItem.title = Strings.discover
-        navigationItem.title = Strings.discover
     }
     
     private func controllerVisibility(with segmentIndex: Int) {

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -400,6 +400,9 @@ extension OEXRouter {
         guard let controller = discoveryViewController(bottomBar: bottomBar, searchQuery: searchQuery) else { return }
         if let fromController = fromController {
             fromController.tabBarController?.selectedIndex = EnrolledTabBarViewController.courseCatalogIndex
+            if let discovery = fromController.tabBarController?.children.first(where: { $0.isKind(of: DiscoveryViewController.self)} ) as? DiscoveryViewController {
+                discovery.switchSegment(with: .courseDiscovery)
+            }
         } else {
             showControllerFromStartupScreen(controller: controller)
         }


### PR DESCRIPTION
### Description

[LEARNER-7588](https://openedx.atlassian.net/browse/LEARNER-7588)


- [x]  From Course Dashboard Screen tap on "FIND A COURSE" button
- [x]  It will load Discovery screen with Title "Courses"
- [x]  Select the Programs tab 
- [x] Screen Title should change to Discovery
- [x] Native `CourseCatalogView` title should be updated
