### PR TITLE
Microsoft login - Keychain sharing

### DIFF
--- a/edX.entitlements
+++ b/edX.entitlements
@@ -16,6 +16,7 @@
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)org.edx.mobile</string>
+		<string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
### Description

[LEARNER-7849](https://openedx.atlassian.net/browse/LEARNER-7849)

This PR adds `com.microsoft.adalcache` in keychain sharing, thus it allows edX app to open `Authenticator` app if installed, to allow user to login from there or revert to local webview to allow signin. 

### How to test this PR

- [x] Signin using Microsoft Login

- [x] If `Authenticator` app from Microsoft is installed, then it opens that to allow login from there, then redirects back to edX.
