### PR TITLE
iOS - Video Player - selected speed option is not persisted.

### DIFF
--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -612,6 +612,8 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
             if self?.playerState == .playing {
                 self?.controls?.autoHide()
                 self?.player.play()
+                let speed = OEXInterface.getCCSelectedPlaybackSpeed()
+                self?.rate = OEXInterface.getOEXVideoSpeed(speed)
             }
             else {
                 self?.savePlayedTime()


### PR DESCRIPTION
### Description

[LEARNER-7785](https://openedx.atlassian.net/browse/LEARNER-7785)

iOS - Video Player - selected speed option is not persisted navigating between Next & Previous Videos

### How to test this PR
Open any video of any course and set some playback speed.
When we seek forward or backward the speed comes to normal as 1.0x in hearing but on the table it shows some different value which we set before.
Now on seeking the play speed should be as selected on play speed rate options.