### PR TITLE
JS Error: undefined is not an object

### DIFF
--- a/Source/DiscoveryWebViewHelper.swift
+++ b/Source/DiscoveryWebViewHelper.swift
@@ -291,21 +291,21 @@ extension DiscoveryWebViewHelper: WKNavigationDelegate {
     }
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        self.loadController.state = .Loaded
+        loadController.state = .Loaded
         
         //Setting webView accessibilityValue for testing
-        webView.evaluateJavaScript("document.getElementsByClassName('discovery-card')[0].innerText",
-                                   completionHandler: { [weak self] (result: Any?, error: Error?) in
+        webView.evaluateJavaScript("document.getElementsByClassName('discovery-card')[0].innerText", completionHandler: { [weak self] (result: Any?, error: Error?) in
 
-                                    if (error == nil) {
-                                        self?.webView.accessibilityValue = self?.discovryAccessibilityValue
-                                    }
+            if (error == nil) {
+                self?.webView.accessibilityValue = self?.discovryAccessibilityValue
+            }
         })
 
         if let bar = bottomBar {
             bar.superview?.bringSubviewToFront(bar)
         }
     }
+
     private var discovryAccessibilityValue: String {
         switch discoveryType {
         case .course:

--- a/Source/DiscoveryWebViewHelper.swift
+++ b/Source/DiscoveryWebViewHelper.swift
@@ -294,18 +294,29 @@ extension DiscoveryWebViewHelper: WKNavigationDelegate {
         self.loadController.state = .Loaded
         
         //Setting webView accessibilityValue for testing
-        webView.evaluateJavaScript("document.getElementsByClassName('course-card')[0].innerText",
+        webView.evaluateJavaScript("document.getElementsByClassName('discovery-card')[0].innerText",
                                    completionHandler: { [weak self] (result: Any?, error: Error?) in
-                                    
+
                                     if (error == nil) {
-                                        self?.webView.accessibilityValue = self?.discoveryType ?? .course == .course ? "findCoursesLoaded" : "findProgramsLoaded"
+                                        self?.webView.accessibilityValue = self?.discovryAccessibilityValue
                                     }
         })
+
         if let bar = bottomBar {
             bar.superview?.bringSubviewToFront(bar)
         }
     }
-    
+    private var discovryAccessibilityValue: String {
+        switch discoveryType {
+        case .course:
+            return "findCoursesLoaded"
+        case .program:
+            return "findProgramsLoaded"
+        case .degree:
+            return "findDegreeLoaded"
+        }
+    }
+
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         showError(error: error as NSError)
     }


### PR DESCRIPTION
### Description

[LEARNER-7927](https://openedx.atlassian.net/browse/LEARNER-7927)

On iOS, we were using `document.getElementsByClassName('course-card')` in e2e tests to make sure discovery page is loaded successfully or not. While transitioning from Drupal based discovery to prospectus based discovery the class named changes from `course-card` to `discovery-card` and it started through the error `JS Error: undefined is not an object`. 

In this PR I've addressed the issue and updated the class name.

