### PR TITLE
Disabled Account Handling

### DIFF
--- a/Source/EmailTemplates.swift
+++ b/Source/EmailTemplates.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-class EmailTemplates {
+@objc class EmailTemplates: NSObject {
     
-    static func supportEmailMessageTemplate() -> String {
+  @objc static func supportEmailMessageTemplate() -> String {
         let osVersionText = Strings.SubmitFeedback.osVersion(version: UIDevice.current.systemVersion)
         let appVersionText = Strings.SubmitFeedback.appVersion(version: Bundle.main.oex_shortVersionString(), build: Bundle.main.oex_buildVersionString())
         let deviceModelText = Strings.SubmitFeedback.deviceModel(model: UIDevice.current.model)

--- a/Source/NSError+JSON.swift
+++ b/Source/NSError+JSON.swift
@@ -14,6 +14,7 @@ enum APIErrorCode : String {
     case OAuth2Expired = "token_expired"
     case OAuth2Nonexistent = "token_nonexistent"
     case OAuth2InvalidGrant = "invalid_grant"
+    case OAuth2DisabledUser = "user_is_disabled"
 }
 
 fileprivate enum ErrorFields: String, RawStringExtractable {

--- a/Source/NetworkManager+Authenticators.swift
+++ b/Source/NetworkManager+Authenticators.swift
@@ -54,7 +54,7 @@ extension NetworkManager {
                    return refreshAccessToken(clientId: clientId, refreshToken: refreshToken, session: session)
                 }
 
-                if error.isAPIError(code: .OAuth2InvalidGrant) {
+                if error.isAPIError(code: .OAuth2InvalidGrant) || error.isAPIError(code: .OAuth2DisabledUser) {
                     return logout(router: router)
                 }
             }

--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -699,7 +699,7 @@
     return UIInterfaceOrientationMaskAllButUpsideDown;
 }
 
-#pragma mark - Emaila and MFMailComposeViewControllerDelegate methods
+#pragma mark - Email and MFMailComposeViewControllerDelegate methods
 - (void) launchEmailComposer {
     if (![MFMailComposeViewController canSendMail]) {
         [[UIAlertController alloc] showAlertWithTitle:[Strings emailAccountNotSetUpTitle] message:[Strings emailAccountNotSetUpMessage] onViewController:self.navigationController];

--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -36,7 +36,7 @@
 
 #define USER_EMAIL @"USERNAME"
 
-@interface OEXLoginViewController () <AgreementTextViewDelegate, InterfaceOrientationOverriding>
+@interface OEXLoginViewController () <AgreementTextViewDelegate, InterfaceOrientationOverriding, MFMailComposeViewControllerDelegate>
 {
     CGPoint originalOffset;     // store the offset of the scrollview.
     UITextField* activeField;   // assign textfield object which is in active state.
@@ -419,6 +419,9 @@
             NSString *errorMessage = [Strings authProviderErrorWithAuthProvider:self.authProvider.displayName platformName:self.environment.config.platformName];
             [self loginFailedWithErrorMessage:errorMessage title:nil];
         }
+        else if (httpResp.statusCode == OEXHTTPStatusCode403Forbidden && self.authProvider != nil) {
+            [self showDisabledUserMessage];
+        }
         else if(httpResp.statusCode >= 400 && httpResp.statusCode < 500) {
                 [self loginFailedWithErrorMessage:[Strings invalidUsernamePassword] title:nil];
         }
@@ -525,6 +528,19 @@
     [self setLoginDefaultState];
 
     [self tappedToDismiss];
+}
+
+- (void) showDisabledUserMessage {
+    [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+    [self setLoginDefaultState];
+    [self tappedToDismiss];
+
+    UIAlertController *alertController = [[UIAlertController alloc] showAlertWithTitle:[Strings floatingErrorLoginTitle] message:[Strings authProviderDisabledUserError] cancelButtonTitle:[Strings cancel] onViewController:self];
+
+    __block OEXLoginViewController *blockSelf = self;
+    [alertController addButtonWithTitle:[Strings customerSupport] actionBlock:^(UIAlertAction * _Nonnull action) {
+        [blockSelf launchEmailComposer];
+    }];
 }
 
 - (void) showUpdateRequiredMessage {
@@ -681,6 +697,31 @@
 
 - (UIInterfaceOrientationMask) supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskAllButUpsideDown;
+}
+
+#pragma mark - Emaila and MFMailComposeViewControllerDelegate methods
+- (void) launchEmailComposer {
+    if (![MFMailComposeViewController canSendMail]) {
+        [[UIAlertController alloc] showAlertWithTitle:[Strings emailAccountNotSetUpTitle] message:[Strings emailAccountNotSetUpMessage] onViewController:self.navigationController];
+        return;
+    }
+
+    MFMailComposeViewController *mailComposer = [[MFMailComposeViewController alloc] init];
+    mailComposer.mailComposeDelegate = self;
+    mailComposer.navigationBar.tintColor = [[OEXStyles sharedStyles] navigationItemTintColor];
+    [mailComposer setSubject:[Strings accountDisabled]];
+    [mailComposer setMessageBody:[EmailTemplates supportEmailMessageTemplate] isHTML:false];
+
+    NSString *fbAddress = self.environment.config.feedbackEmailAddress;
+    if (fbAddress) {
+        [mailComposer setToRecipients:[NSArray arrayWithObject:fbAddress]];
+    }
+
+    [self presentViewController:mailComposer animated:true completion:nil];
+}
+
+- (void) mailComposeController:(MFMailComposeViewController *)controller didFinishWithResult:(MFMailComposeResult)result error:(NSError *)error {
+    [self dismissViewControllerAnimated:true completion:nil];
 }
 
 @end

--- a/Source/OEXRegistrationViewController.m
+++ b/Source/OEXRegistrationViewController.m
@@ -640,7 +640,7 @@ NSString* const OEXExternalRegistrationWithExistingAccountNotification = @"OEXEx
     return [UIApplication sharedApplication].userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft;
 }
 
-#pragma mark - Emaila and MFMailComposeViewControllerDelegate methods
+#pragma mark - Email and MFMailComposeViewControllerDelegate methods
 - (void) launchEmailComposer {
     if (![MFMailComposeViewController canSendMail]) {
         [[UIAlertController alloc] showAlertWithTitle:[Strings emailAccountNotSetUpTitle] message:[Strings emailAccountNotSetUpMessage] onViewController:self.navigationController];

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -166,6 +166,8 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profile";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
+/*Email subjact for disabled account*/
+"ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "الإنجازات";
 /* Default text template when user shares an accomplishment */
@@ -234,6 +236,8 @@
 "ASTERIC" = "*";
 /* This error message will be shown if user tried to login with third party (facebook/google) and server returns 400 status code*/
 "AUTH_PROVIDER_ERROR" = "This {auth_provider} account is not linked with any {platform_name} account. Please register.";
+/* This error message will be shown if user tried to login with third party (facebook/google) and server returns 403 status code, Disabled user*/
+"AUTH_PROVIDER_DISABLED_USER_ERROR" = "Your account is disabled. Please contact customer support for assistance.";
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is single video*/
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is number of videos*/
 "BULK_DOWNLOAD_VIDEOS_SUB_TITLE##{zero}" = "{count} Videos, {videos_size}MB total";
@@ -408,6 +412,8 @@
 "COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} seconds";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Your access to this course has expired";
+/*Customer support text, using as button title for disabled user*/
+"CUSTOMER_SUPPORT" = "Customer Support";
 /* Title text for the Announcements section within the course dashboard */
 "DASHBOARD.COURSE_ANNOUNCEMENTS"="الإعلانات";
 /* Text describing the Announcements section within the course dashboard */

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profile";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
-/*Email subjact for disabled account*/
+/*Email subject for disabled account*/
 "ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "الإنجازات";

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -154,7 +154,7 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profil";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Bild";
-/*Email subjact for disabled account*/
+/*Email subject for disabled account*/
 "ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Leistungen";

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -154,6 +154,8 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profil";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Bild";
+/*Email subjact for disabled account*/
+"ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Leistungen";
 /* Default text template when user shares an accomplishment */
@@ -222,6 +224,8 @@
 "ASTERIC" = "*";
 /* This error message will be shown if user tried to login with third party (facebook/google) and server returns 400 status code*/
 "AUTH_PROVIDER_ERROR" = "Das {auth_provider} Konto ist mit keinem Benutzerkonto der {platform_name} verlinkt. Bitte registrieren Sie sich.";
+/* This error message will be shown if user tried to login with third party (facebook/google) and server returns 403 status code, Disabled user*/
+"AUTH_PROVIDER_DISABLED_USER_ERROR" = "Your account is disabled. Please contact customer support for assistance.";
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is single video*/
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is number of videos*/
 "BULK_DOWNLOAD_VIDEOS_SUB_TITLE##{one}" = "{count} Video, {videos_size}MB gesamt";
@@ -368,6 +372,8 @@
 "COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} Sekunden";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Ihre Zugangsberechtigung zu diesem Kurs ist abgelaufen.";
+/*Customer support text, using as button title for disabled user*/
+"CUSTOMER_SUPPORT" = "Customer Support";
 /* Title text for the Announcements section within the course dashboard */
 "DASHBOARD.COURSE_ANNOUNCEMENTS"="Ankündigungen";
 /* Text describing the Announcements section within the course dashboard */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -154,7 +154,7 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profile";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
-/*Email subjact for disabled account*/
+/*Email subject for disabled account*/
 "ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Accomplishments";

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -154,6 +154,8 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profile";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
+/*Email subjact for disabled account*/
+"ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Accomplishments";
 /* Default text template when user shares an accomplishment */
@@ -222,6 +224,8 @@
 "ASTERIC" = "*";
 /* This error message will be shown if user tried to login with third party (facebook/google) and server returns 400 status code*/
 "AUTH_PROVIDER_ERROR" = "This {auth_provider} account is not linked with any {platform_name} account. Please register.";
+/* This error message will be shown if user tried to login with third party (facebook/google) and server returns 403 status code, Disabled user*/
+"AUTH_PROVIDER_DISABLED_USER_ERROR" = "Your account is disabled. Please contact customer support for assistance.";
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is single video*/
 "BULK_DOWNLOAD_VIDEOS_SUB_TITLE##{one}" = "{count} Video, {videos_size}MB total";
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is number of videos*/
@@ -368,6 +372,8 @@
 "COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} seconds";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Your access to this course has expired";
+/*Customer support text, using as button title for disabled user*/
+"CUSTOMER_SUPPORT" = "Customer Support";
 /* Title text for the Announcements section within the course dashboard */
 "DASHBOARD.COURSE_ANNOUNCEMENTS"="Announcements";
 /* Text describing the Announcements section within the course dashboard */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -154,7 +154,7 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Perfil";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
-/*Email subjact for disabled account*/
+/*Email subject for disabled account*/
 "ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Logros";

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -154,6 +154,8 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Perfil";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
+/*Email subjact for disabled account*/
+"ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Logros";
 /* Default text template when user shares an accomplishment */
@@ -222,6 +224,8 @@
 "ASTERIC" = "*";
 /* This error message will be shown if user tried to login with third party (facebook/google) and server returns 400 status code*/
 "AUTH_PROVIDER_ERROR" = "Esta cuenta {auth_provider} no esta asociada con ninguna cuenta de {platform_name}. Por favor regístrela.";
+/* This error message will be shown if user tried to login with third party (facebook/google) and server returns 403 status code, Disabled user*/
+"AUTH_PROVIDER_DISABLED_USER_ERROR" = "Your account is disabled. Please contact customer support for assistance.";
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is single video*/
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is number of videos*/
 "BULK_DOWNLOAD_VIDEOS_SUB_TITLE##{one}" = "{count} Video, {videos_size}MB en total";
@@ -368,6 +372,8 @@
 "COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} seconds";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Your access to this course has expired";
+/*Customer support text, using as button title for disabled user*/
+"CUSTOMER_SUPPORT" = "Customer Support";
 /* Title text for the Announcements section within the course dashboard */
 "DASHBOARD.COURSE_ANNOUNCEMENTS"="Anuncios";
 /* Text describing the Announcements section within the course dashboard */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -154,6 +154,8 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profil";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
+/*Email subjact for disabled account*/
+"ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Récompenses";
 /* Default text template when user shares an accomplishment */
@@ -222,6 +224,8 @@
 "ASTERIC" = "*";
 /* This error message will be shown if user tried to login with third party (facebook/google) and server returns 400 status code*/
 "AUTH_PROVIDER_ERROR" = "Ce compte {auth_provider} n'est pas lié à un compte {platform_name}. Inscrivez-vous.";
+/* This error message will be shown if user tried to login with third party (facebook/google) and server returns 403 status code, Disabled user*/
+"AUTH_PROVIDER_DISABLED_USER_ERROR" = "Your account is disabled. Please contact customer support for assistance.";
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is single video*/
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is number of videos*/
 "BULK_DOWNLOAD_VIDEOS_SUB_TITLE##{one}" = "{count} Vidéo, {videos_size}MB total";
@@ -368,6 +372,8 @@
 "COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} secondes";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Votre accès à ce cours a expiré";
+/*Customer support text, using as button title for disabled user*/
+"CUSTOMER_SUPPORT" = "Customer Support";
 /* Title text for the Announcements section within the course dashboard */
 "DASHBOARD.COURSE_ANNOUNCEMENTS"="Annonces";
 /* Text describing the Announcements section within the course dashboard */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -154,7 +154,7 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profil";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
-/*Email subjact for disabled account*/
+/*Email subject for disabled account*/
 "ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Récompenses";

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -160,7 +160,7 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profile";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
-/*Email subjact for disabled account*/
+/*Email subject for disabled account*/
 "ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "הישגים";

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -160,6 +160,8 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profile";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
+/*Email subjact for disabled account*/
+"ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "הישגים";
 /* Default text template when user shares an accomplishment */
@@ -228,6 +230,8 @@
 "ASTERIC" = "*";
 /* This error message will be shown if user tried to login with third party (facebook/google) and server returns 400 status code*/
 "AUTH_PROVIDER_ERROR" = "חשבון {auth_provider} זה אינו מקושר עם שום חשבון {platform_name}. אנא הירשמו.";
+/* This error message will be shown if user tried to login with third party (facebook/google) and server returns 403 status code, Disabled user*/
+"AUTH_PROVIDER_DISABLED_USER_ERROR" = "Your account is disabled. Please contact customer support for assistance.";
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is single video*/
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is number of videos*/
 "BULK_DOWNLOAD_VIDEOS_SUB_TITLE##{one}" = "קובץ וידאו{count}, סה\"כ {videos_size}MB ";
@@ -386,6 +390,8 @@
 "COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} seconds";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Your access to this course has expired";
+/*Customer support text, using as button title for disabled user*/
+"CUSTOMER_SUPPORT" = "Customer Support";
 /* Title text for the Announcements section within the course dashboard */
 "DASHBOARD.COURSE_ANNOUNCEMENTS"="הודעות";
 /* Text describing the Announcements section within the course dashboard */

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -151,6 +151,8 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profile";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
+/*Email subjact for disabled account*/
+"ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "業績";
 /* Default text template when user shares an accomplishment */
@@ -219,6 +221,8 @@
 "ASTERIC" = "*";
 /* This error message will be shown if user tried to login with third party (facebook/google) and server returns 400 status code*/
 "AUTH_PROVIDER_ERROR" = "This {auth_provider} account is not linked with any {platform_name} account. Please register.";
+/* This error message will be shown if user tried to login with third party (facebook/google) and server returns 403 status code, Disabled user*/
+"AUTH_PROVIDER_DISABLED_USER_ERROR" = "Your account is disabled. Please contact customer support for assistance.";
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is single video*/
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is number of videos*/
 "BULK_DOWNLOAD_VIDEOS_SUB_TITLE##{other}" = "{count} Videos, {videos_size}MB total";
@@ -358,6 +362,8 @@
 "COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} seconds";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Your access to this course has expired";
+/*Customer support text, using as button title for disabled user*/
+"CUSTOMER_SUPPORT" = "Customer Support";
 /* Title text for the Announcements section within the course dashboard */
 "DASHBOARD.COURSE_ANNOUNCEMENTS"="お知らせ";
 /* Text describing the Announcements section within the course dashboard */

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -151,7 +151,7 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profile";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
-/*Email subjact for disabled account*/
+/*Email subject for disabled account*/
 "ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "業績";

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -154,7 +154,7 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Perfil";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
-/*Email subjact for disabled account*/
+/*Email subject for disabled account*/
 "ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Realizações";

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -154,6 +154,8 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Perfil";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
+/*Email subjact for disabled account*/
+"ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Realizações";
 /* Default text template when user shares an accomplishment */
@@ -222,6 +224,8 @@
 "ASTERIC" = "*";
 /* This error message will be shown if user tried to login with third party (facebook/google) and server returns 400 status code*/
 "AUTH_PROVIDER_ERROR" = "A sua conta no {auth_provider} não está associada à conta do {platform_name}. Por favor registre-se.";
+/* This error message will be shown if user tried to login with third party (facebook/google) and server returns 403 status code, Disabled user*/
+"AUTH_PROVIDER_DISABLED_USER_ERROR" = "Your account is disabled. Please contact customer support for assistance.";
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is single video*/
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is number of videos*/
 "BULK_DOWNLOAD_VIDEOS_SUB_TITLE##{one}" = "{count} Vídeo, {videos_size}MB total";
@@ -368,6 +372,8 @@
 "COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} segundos";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Seu acesso a este curso expirou";
+/*Customer support text, using as button title for disabled user*/
+"CUSTOMER_SUPPORT" = "Customer Support";
 /* Title text for the Announcements section within the course dashboard */
 "DASHBOARD.COURSE_ANNOUNCEMENTS"="Anúncios";
 /* Text describing the Announcements section within the course dashboard */

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -154,7 +154,7 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profil";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
-/*Email subjact for disabled account*/
+/*Email subject for disabled account*/
 "ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Başarılar";

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -154,6 +154,8 @@
 "ACCESSIBILITY.PROFILE_LABEL"="Profil";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
+/*Email subjact for disabled account*/
+"ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "Başarılar";
 /* Default text template when user shares an accomplishment */
@@ -222,6 +224,8 @@
 "ASTERIC" = "*";
 /* This error message will be shown if user tried to login with third party (facebook/google) and server returns 400 status code*/
 "AUTH_PROVIDER_ERROR" = "Bu {auth_provider} hesabı herhangi bir {platform_name} hesabıyla bağlantılı değil. Lütfen kaydolun.";
+/* This error message will be shown if user tried to login with third party (facebook/google) and server returns 403 status code, Disabled user*/
+"AUTH_PROVIDER_DISABLED_USER_ERROR" = "Your account is disabled. Please contact customer support for assistance.";
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is single video*/
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is number of videos*/
 "BULK_DOWNLOAD_VIDEOS_SUB_TITLE##{one}" = "{count} Video, toplam {videos_size}MB";
@@ -368,6 +372,8 @@
 "COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} saniye";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Bu derse erişiminiz sona ermiştir";
+/*Customer support text, using as button title for disabled user*/
+"CUSTOMER_SUPPORT" = "Customer Support";
 /* Title text for the Announcements section within the course dashboard */
 "DASHBOARD.COURSE_ANNOUNCEMENTS"="Duyurular";
 /* Text describing the Announcements section within the course dashboard */

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -149,6 +149,8 @@
 "ACCESSIBILITY.CLOSE_LABEL"="Đóng";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
+/*Email subjact for disabled account*/
+"ACCOUNT_DISABLED" = "Account Disabled";
 /*Accessibility text for profile button*/
 "ACCESSIBILITY.PROFILE_LABEL"="Hồ sơ";
 /* Title of user profile section for user accomplishments (like badges) */
@@ -219,6 +221,8 @@
 "ASTERIC" = "*";
 /* This error message will be shown if user tried to login with third party (facebook/google) and server returns 400 status code*/
 "AUTH_PROVIDER_ERROR" = "Tài khoản {auth_provider} này chưa liên kết với bất kỳ tài khoản {platform_name} nào. Vui lòng đăng ký.";
+/* This error message will be shown if user tried to login with third party (facebook/google) and server returns 403 status code, Disabled user*/
+"AUTH_PROVIDER_DISABLED_USER_ERROR" = "Your account is disabled. Please contact customer support for assistance.";
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is single video*/
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is number of videos*/
 "BULK_DOWNLOAD_VIDEOS_SUB_TITLE##{other}" = "{count} Video, {videos_size}MB tổng cộng";
@@ -358,6 +362,8 @@
 "COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} giây";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "Quyền truy cập của bạn đến khóa học này đã hết hạn";
+/*Customer support text, using as button title for disabled user*/
+"CUSTOMER_SUPPORT" = "Customer Support";
 /* Title text for the Announcements section within the course dashboard */
 "DASHBOARD.COURSE_ANNOUNCEMENTS"="Thông báo";
 /* Text describing the Announcements section within the course dashboard */

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -149,7 +149,7 @@
 "ACCESSIBILITY.CLOSE_LABEL"="Đóng";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
-/*Email subjact for disabled account*/
+/*Email subject for disabled account*/
 "ACCOUNT_DISABLED" = "Account Disabled";
 /*Accessibility text for profile button*/
 "ACCESSIBILITY.PROFILE_LABEL"="Hồ sơ";

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -151,6 +151,8 @@
 "ACCESSIBILITY.PROFILE_LABEL"="档案";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
+/*Email subjact for disabled account*/
+"ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "成就";
 /* Default text template when user shares an accomplishment */
@@ -219,6 +221,8 @@
 "ASTERIC" = "*";
 /* This error message will be shown if user tried to login with third party (facebook/google) and server returns 400 status code*/
 "AUTH_PROVIDER_ERROR" = "此{auth_provider}账号未与任何{platform_name}账号相关联，请先注册。";
+/* This error message will be shown if user tried to login with third party (facebook/google) and server returns 403 status code, Disabled user*/
+"AUTH_PROVIDER_DISABLED_USER_ERROR" = "Your account is disabled. Please contact customer support for assistance.";
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is single video*/
 /*Subtitle for bulk download view when in new, partial or downloaded state - {count} is number of videos*/
 "BULK_DOWNLOAD_VIDEOS_SUB_TITLE##{other}" = "{count}个视频，总共{videos_size}MB";
@@ -358,6 +362,8 @@
 "COURSE_AUDIT_REMAINING_SECONDS##{other}" = "{seconds} 秒";
 /*Error meessage on course content screen if course audit expires*/
 "COURSE_AUDIT_EXPIRED_ERROR_MESSAGE" = "你的课程访问权已经过期";
+/*Customer support text, using as button title for disabled user*/
+"CUSTOMER_SUPPORT" = "Customer Support";
 /* Title text for the Announcements section within the course dashboard */
 "DASHBOARD.COURSE_ANNOUNCEMENTS"="公告";
 /* Text describing the Announcements section within the course dashboard */

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -151,7 +151,7 @@
 "ACCESSIBILITY.PROFILE_LABEL"="档案";
 /* Accessibility trait for image */
 "ACCESSIBILITY_IMAGE_VOICE_OVER_HINT"="Image";
-/*Email subjact for disabled account*/
+/*Email subject for disabled account*/
 "ACCOUNT_DISABLED" = "Account Disabled";
 /* Title of user profile section for user accomplishments (like badges) */
 "ACCOMPLISHMENTS.TITLE" = "成就";


### PR DESCRIPTION
### Description

[LEARNER-7898](https://openedx.atlassian.net/browse/LEARNER-7898)

Disabled account handling on mobile.

### How to test this PR
- [x] Learners should not be able to sign in with the disabled social accounts. At the sign-in and registration screen, a popup with a proper message should be displayed with an option of contact to customer support.
- [x] Already signed in learner should logout.

### Config
```
API_HOST_URL: 'https://socialauthn.sandbox.edx.org'
OAUTH_CLIENT_ID: '76hs3musgAMq4QiMqRZFQ6MxgiUEW27Fd7KlHExy'
```

Learner active status can be managed by following this URL https://socialauthn.sandbox.edx.org/support/manage_user


Note: You can use your prod or stage configuration of Google auth to test the PR.