### PR TITLE
Case in Sensitive Dictionary Keys Comparison

### DIFF
--- a/Source/VersionUpgradeInfoController.swift
+++ b/Source/VersionUpgradeInfoController.swift
@@ -34,7 +34,7 @@ class VersionUpgradeInfoController: NSObject {
         
         var postNotification:Bool = false
         
-        if let appLatestVersion = responseHeaders[AppLatestVersionKey] as? String {
+        if let appLatestVersion = responseHeaders[caseInsensitive: AppLatestVersionKey] as? String {
             postNotification = latestVersion != appLatestVersion
             latestVersion = appLatestVersion
         }
@@ -46,7 +46,7 @@ class VersionUpgradeInfoController: NSObject {
             }
         }
         
-        if let versionLastSupportedDate = responseHeaders[AppVersionLastSupportedDateKey] as? String {
+        if let versionLastSupportedDate = responseHeaders[caseInsensitive: AppVersionLastSupportedDateKey] as? String {
             lastSupportedDateString = versionLastSupportedDate
         }
         
@@ -58,6 +58,17 @@ class VersionUpgradeInfoController: NSObject {
     private func postVersionUpgradeNotification() {
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: NSNotification.Name(rawValue: AppNewVersionAvailableNotification), object: self)
+        }
+    }
+}
+
+extension Dictionary where Key == String {
+    subscript(caseInsensitive key: Key) -> Value? {
+        get {
+            if let k = keys.first(where: { $0.caseInsensitiveCompare(key) == .orderedSame }) {
+                return self[k]
+            }
+            return nil
         }
     }
 }


### PR DESCRIPTION
### Description

[LEARNER-7940](https://openedx.atlassian.net/browse/LEARNER-7940)

Due to some unknown reasons server started responding with the case in-sensitive headers. On iOS, we were expecting case sensitive headers. This breaks the version upgrade functionality. This PR makes the extraction of version upgrade info case insensitive.

### How to test this PR

Change the `build` number to see the version upgrade info snack bar and fullscreen update messages. 
- [x] Change the build number to 2.20.0-2.22.0 to see the upgrade snack bar.
- [x] Change the build number to 2.19.0 to see a fullscreen version upgrade screen.