### PR TITLE
XCode 12 Support

### DIFF
--- a/Source/CourseOutlineTableSource.swift
+++ b/Source/CourseOutlineTableSource.swift
@@ -185,12 +185,16 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
         super.viewWillLayoutSubviews()
         updateViewConstraints()
     }
-    
+    // Lifecycle of view has been changed in latest SDK XCode 12.
+    // The app stuck in calling updateViewConstraints forever.
+    // Disabling it for the builds compiling with XCode 12
+    #if swift(<5.3)
     override func updateViewConstraints() {
         super.updateViewConstraints()
         refreshTableHeaderView(lastAccess: lastAccess)
     }
-    
+    #endif
+
     override func numberOfSections(in tableView: UITableView) -> Int {
         return groups.count
     }
@@ -443,6 +447,7 @@ fileprivate extension UITableView {
     func setAndLayoutTableHeaderView(header: UIView) {
         header.setNeedsLayout()
         header.layoutIfNeeded()
+
         let size = header.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
         header.frame = CGRect(x: 0, y: 0, width: size.width, height: size.height)
         tableHeaderView = header


### PR DESCRIPTION
### Description

The `XCode 12` support is on our roadmap but it might delay a bit because of some other high priority tasks. But Don't worry we are here to help you out. You can use this PR to compile the app using the `XCode 12`.

Note: There might be some issues in the app because the app is fully supported on `XCode 11`.
