### PR TITLE
Fix time formatting crash

### DIFF
--- a/DateFormatting.swift
+++ b/DateFormatting.swift
@@ -19,11 +19,7 @@ open class DateFormatting: NSObject {
     
     /// Formats a time interval for display as a video duration like 23:35 or 01:14:33
     @objc open class func formatSeconds(asVideoLength totalSeconds: TimeInterval) -> String {
-        var timeInterval = totalSeconds
-        if timeInterval.isNaN {
-            timeInterval = 0
-        }
-
+        let timeInterval = totalSeconds.isNaN ? 0 : totalSeconds
         let seconds = Int(timeInterval.truncatingRemainder(dividingBy: 60))
         let minutes = Int((timeInterval / 60).truncatingRemainder(dividingBy: 60))
         let hours = Int(timeInterval / 3600)

--- a/DateFormatting.swift
+++ b/DateFormatting.swift
@@ -19,9 +19,14 @@ open class DateFormatting: NSObject {
     
     /// Formats a time interval for display as a video duration like 23:35 or 01:14:33
     @objc open class func formatSeconds(asVideoLength totalSeconds: TimeInterval) -> String {
-        let seconds = Int(totalSeconds.truncatingRemainder(dividingBy: 60))
-        let minutes = Int((totalSeconds / 60).truncatingRemainder(dividingBy: 60))
-        let hours = Int(totalSeconds / 3600)
+        var timeInterval = totalSeconds
+        if timeInterval.isNaN {
+            timeInterval = 0
+        }
+
+        let seconds = Int(timeInterval.truncatingRemainder(dividingBy: 60))
+        let minutes = Int((timeInterval / 60).truncatingRemainder(dividingBy: 60))
+        let hours = Int(timeInterval / 3600)
         if hours == 0 {
             return String(format:"%02d:%02d", minutes, seconds)
         }


### PR DESCRIPTION
### Description

[LEARNER-8087](https://openedx.atlassian.net/browse/LEARNER-8087)

The app was crashing on hitting rewind buttons while the video is loading. This PR fixed the crash.

### How to test this PR
Go to a video component and hit the rewind forward or rewind back button while the video is loading. The app should not crash.