### PR TITLE
Fix: Large Course Title is Cutting on Course Dashboard Screen

### DIFF
--- a/Source/CourseCardView.swift
+++ b/Source/CourseCardView.swift
@@ -184,6 +184,7 @@ class CourseCardView: UIView, UIGestureRecognizerDelegate {
         set {
             titleLabel.attributedText = titleTextStyle.attributedString(withText: newValue)
             updateAcessibilityLabel()
+            updateConstraints()
         }
     }
     


### PR DESCRIPTION
### Description

[LEARNER-8088](https://openedx.atlassian.net/browse/LEARNER-8088)

In the case of large course titles, the complete course title is not displaying on the course dashboard screen. This PR fixed the said issue.

### How to test this PR
Open any course with a large title, the complete course title should appear on the course dashboard screen.