### PR TITLE
Course cards are not aligning properly on iPad

### DIFF
--- a/Source/CoursesContainerViewController.swift
+++ b/Source/CoursesContainerViewController.swift
@@ -163,6 +163,10 @@ class CoursesContainerViewController: UICollectionViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         insetsController.updateInsets()
+        
+        if UIDevice.isiOSVersionLess(than: 14) {
+            collectionView.collectionViewLayout.invalidateLayout()
+        }
     }
 }
 

--- a/Source/UIDevice+OSVersion.swift
+++ b/Source/UIDevice+OSVersion.swift
@@ -20,4 +20,8 @@ extension UIDevice {
     class func isOSVersionAtLeast9() -> Bool {
         return current.isOSVersionAtLeast(version: 9)
     }
+    
+    class func isiOSVersionLess(than version: Int) -> Bool {
+        return NSString(string: UIDevice.current.systemVersion).intValue < version
+    }
 }


### PR DESCRIPTION
### Description

[LEARNER-8124](https://openedx.atlassian.net/browse/LEARNER-8124)

### How to test this PR

- [ ] On iPad the course cards should appear as two cards per row with proper spacing.