### PR TITLE
Add NSUserTrackingUsageDescription Key and info Message

### DIFF
--- a/Source/edX-Info.plist
+++ b/Source/edX-Info.plist
@@ -88,6 +88,8 @@
 	<string>so user can access photo librart</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>so you can select a profile image</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>The data will be used to track your activity to address app functionality and gather data analytics for multiple purposes.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>FontAwesome.ttf</string>


### PR DESCRIPTION
### Description

[LEARNER-8136](https://openedx.atlassian.net/browse/LEARNER-8136)

To prepare the app for the iOS 14 before Apple enforces IDFA enforcement in 2021. Add NSUserTrackingUsageDescription key into `info.plist` so the app won't break when apple enforces the IDFA changes.

Info Message:

`The data will be used to track your activity to address app functionality and gather data analytics for multiple purposes.`