### PR TITLE
iOS - Add value prop behind remote config feature flag

### DIFF
--- a/Source/CourseCatalogViewController.swift
+++ b/Source/CourseCatalogViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class CourseCatalogViewController: UIViewController, CoursesContainerViewControllerDelegate, InterfaceOrientationOverriding {
-    typealias Environment = NetworkManagerProvider & OEXRouterProvider & OEXSessionProvider & OEXConfigProvider & OEXAnalyticsProvider & OEXInterfaceProvider
+    typealias Environment = NetworkManagerProvider & OEXRouterProvider & OEXSessionProvider & OEXConfigProvider & OEXAnalyticsProvider & OEXInterfaceProvider & RemoteConfigProvider
     
     private let environment : Environment
     private let coursesContainer : CoursesContainerViewController

--- a/Source/CourseGenericBlockTableViewCell.swift
+++ b/Source/CourseGenericBlockTableViewCell.swift
@@ -30,7 +30,7 @@ class CourseGenericBlockTableViewCell : UITableViewCell, CourseBlockContainerCel
     var block : CourseBlock? = nil {
         didSet {
             if block?.isGated ?? false {
-                if OEXConfig.shared().isValuePropEnabled {
+                if FirebaseRemoteConfiguration.shared.isValuePropEnabled {
                     content.trailingView = valuePropAccessoryView
                     content.setDetailText(title: Strings.ValueProp.learnHowToUnlock, blockType: block?.type, underline: true)
                 } else {

--- a/Source/CourseUnknownBlockViewController.swift
+++ b/Source/CourseUnknownBlockViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class CourseUnknownBlockViewController: UIViewController, CourseBlockViewController {
     
-    typealias Environment = DataManagerProvider & OEXInterfaceProvider & OEXAnalyticsProvider & OEXConfigProvider & OEXStylesProvider & OEXRouterProvider & DataManagerProvider
+    typealias Environment = DataManagerProvider & OEXInterfaceProvider & OEXAnalyticsProvider & OEXConfigProvider & OEXStylesProvider & OEXRouterProvider & DataManagerProvider & RemoteConfigProvider
     
     private let environment: Environment
         
@@ -67,7 +67,7 @@ class CourseUnknownBlockViewController: UIViewController, CourseBlockViewControl
     
     private func showError() {
         if let block = block, block.isGated {
-            if environment.config.isValuePropEnabled {
+            if environment.remoteConfig.isValuePropEnabled {
                 showValuePropMessageView()
             } else {
                 showGatedContentMessageView()

--- a/Source/CoursesContainerViewController.swift
+++ b/Source/CoursesContainerViewController.swift
@@ -140,7 +140,7 @@ class CoursesContainerViewController: UICollectionViewController {
         case none = "none"
     }
     
-    typealias Environment = NetworkManagerProvider & OEXRouterProvider & OEXConfigProvider & OEXInterfaceProvider & OEXAnalyticsProvider
+    typealias Environment = NetworkManagerProvider & OEXRouterProvider & OEXConfigProvider & OEXInterfaceProvider & OEXAnalyticsProvider & RemoteConfigProvider
     
     private let environment : Environment
     private let context: Context
@@ -151,7 +151,7 @@ class CoursesContainerViewController: UICollectionViewController {
             if isiPad() {
                 let auditModeCourses = courses.filter { course -> Bool in
                     let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id)
-                    if enrollment?.mode == EnrollmentMode.audit.rawValue && environment.config.isValuePropEnabled {
+                    if enrollment?.mode == EnrollmentMode.audit.rawValue && environment.remoteConfig.isValuePropEnabled {
                         return true
                     }
                     return false
@@ -266,7 +266,7 @@ class CoursesContainerViewController: UICollectionViewController {
     
     private func shouldShowValueProp(for course: OEXCourse) -> Bool {
         let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id)
-        return enrollment?.mode == EnrollmentMode.audit.rawValue && environment.config.isValuePropEnabled
+        return enrollment?.mode == EnrollmentMode.audit.rawValue && environment.remoteConfig.isValuePropEnabled
     }
     
     private func calculateValuePropHeight(for indexPath: IndexPath) -> CGFloat {

--- a/Source/EnrolledCoursesViewController.swift
+++ b/Source/EnrolledCoursesViewController.swift
@@ -12,7 +12,7 @@ var isActionTakenOnUpgradeSnackBar: Bool = false
 
 class EnrolledCoursesViewController : OfflineSupportViewController, CoursesContainerViewControllerDelegate, PullRefreshControllerDelegate, LoadStateViewReloadSupport,InterfaceOrientationOverriding {
     
-    typealias Environment = OEXAnalyticsProvider & OEXConfigProvider & DataManagerProvider & NetworkManagerProvider & ReachabilityProvider & OEXRouterProvider & OEXStylesProvider & OEXInterfaceProvider
+    typealias Environment = OEXAnalyticsProvider & OEXConfigProvider & DataManagerProvider & NetworkManagerProvider & ReachabilityProvider & OEXRouterProvider & OEXStylesProvider & OEXInterfaceProvider & RemoteConfigProvider
     
     private let environment : Environment
     private let coursesContainer : CoursesContainerViewController

--- a/Source/EnrolledTabBarViewController.swift
+++ b/Source/EnrolledTabBarViewController.swift
@@ -28,7 +28,7 @@ private enum TabBarOptions: Int {
 
 class EnrolledTabBarViewController: UITabBarController, UITabBarControllerDelegate, InterfaceOrientationOverriding, ChromeCastConnectedButtonDelegate {
     
-    typealias Environment = OEXAnalyticsProvider & OEXConfigProvider & DataManagerProvider & NetworkManagerProvider & OEXRouterProvider & OEXInterfaceProvider & ReachabilityProvider & OEXSessionProvider & OEXStylesProvider
+    typealias Environment = OEXAnalyticsProvider & OEXConfigProvider & DataManagerProvider & NetworkManagerProvider & OEXRouterProvider & OEXInterfaceProvider & ReachabilityProvider & OEXSessionProvider & OEXStylesProvider & RemoteConfigProvider
     
     fileprivate let environment: Environment
     private var tabBarItems : [TabBarItem] = []

--- a/Source/FirebaseRemoteConfiguration.swift
+++ b/Source/FirebaseRemoteConfiguration.swift
@@ -11,16 +11,16 @@ import UIKit
 private let remoteConfigUserDefaultKey = "remote-config"
 
 protocol RemoteConfigProvider {
-  var remoteConfig: FirebaseRemoteConfiguration { get }
+    var remoteConfig: FirebaseRemoteConfiguration { get }
 }
 
 extension RemoteConfigProvider {
-  var remoteConfig: FirebaseRemoteConfiguration {
-    return FirebaseRemoteConfiguration.shared
-  }
+    var remoteConfig: FirebaseRemoteConfiguration {
+        return FirebaseRemoteConfiguration.shared
+    }
 }
 
-fileprivate enum remoteConfigKeys: String, RawStringExtractable {
+fileprivate enum keys: String, RawStringExtractable {
     case valuePropEnabled = "VALUE_PROP_ENABLED"
 }
 
@@ -33,21 +33,22 @@ fileprivate enum remoteConfigKeys: String, RawStringExtractable {
     }
     
     @objc func initialize(remoteConfig: RemoteConfig) {
-        isValuePropEnabled = remoteConfig.configValue(forKey: remoteConfigKeys.valuePropEnabled.rawValue).boolValue
-        let dataDictionary:[String:Any] = [remoteConfigKeys.valuePropEnabled.rawValue:isValuePropEnabled]
-        setUserdefaults(dictionary: dataDictionary)
+        
+        isValuePropEnabled = remoteConfig.configValue(forKey: keys.valuePropEnabled.rawValue).boolValue
+        let dataDictionary: [String:Any] = [keys.valuePropEnabled.rawValue:isValuePropEnabled]
+        saveRemoteConfig(with: dataDictionary)
     }
     
     @objc func initialize() {
-        guard let value = UserDefaults.standard.object(forKey: remoteConfigUserDefaultKey) as? [String: Any] else {
+        guard let remoteConfig = UserDefaults.standard.object(forKey: remoteConfigUserDefaultKey) as? [String: Any], remoteConfig.count > 0 else {
             return
         }
     
-        isValuePropEnabled = value[remoteConfigKeys.valuePropEnabled] as? Bool ?? false
+        isValuePropEnabled = remoteConfig[keys.valuePropEnabled] as? Bool ?? false
     }
     
-    private func setUserdefaults(dictionary: [String: Any]) {
-        UserDefaults.standard.set(dictionary, forKey: remoteConfigUserDefaultKey)
+    private func saveRemoteConfig(with values: [String: Any]) {
+        UserDefaults.standard.set(values, forKey: remoteConfigUserDefaultKey)
         UserDefaults.standard.synchronize()
     }
 }

--- a/Source/FirebaseRemoteConfiguration.swift
+++ b/Source/FirebaseRemoteConfiguration.swift
@@ -34,15 +34,20 @@ fileprivate enum remoteConfigKeys: String, RawStringExtractable {
     
     @objc func initialize(remoteConfig: RemoteConfig) {
         isValuePropEnabled = remoteConfig.configValue(forKey: remoteConfigKeys.valuePropEnabled.rawValue).boolValue
-        UserDefaults.standard.set(isValuePropEnabled, forKey: remoteConfigUserDefaultKey)
-        UserDefaults.standard.synchronize()
+        let dataDictionary:[String:Any] = [remoteConfigKeys.valuePropEnabled.rawValue:isValuePropEnabled]
+        setUserdefaults(dictionary: dataDictionary)
     }
     
     @objc func initialize() {
-        guard let value = UserDefaults.standard.object(forKey: remoteConfigUserDefaultKey) as? Bool else {
+        guard let value = UserDefaults.standard.object(forKey: remoteConfigUserDefaultKey) as? [String: Any] else {
             return
         }
-        
-        isValuePropEnabled = value
+    
+        isValuePropEnabled = value[remoteConfigKeys.valuePropEnabled] as? Bool ?? false
+    }
+    
+    private func setUserdefaults(dictionary: [String: Any]) {
+        UserDefaults.standard.set(dictionary, forKey: remoteConfigUserDefaultKey)
+        UserDefaults.standard.synchronize()
     }
 }

--- a/Source/FirebaseRemoteConfiguration.swift
+++ b/Source/FirebaseRemoteConfiguration.swift
@@ -34,9 +34,10 @@ fileprivate enum keys: String, RawStringExtractable {
     
     @objc func initialize(remoteConfig: RemoteConfig) {
         
-        let isValuePropEnabled = remoteConfig.configValue(forKey: keys.valuePropEnabled.rawValue).boolValue
-        let dataDictionary: [String:Any] = [keys.valuePropEnabled.rawValue:isValuePropEnabled]
-        saveRemoteConfig(with: dataDictionary)
+        let valueProp = remoteConfig.configValue(forKey: keys.valuePropEnabled.rawValue).boolValue
+        
+        let dictionary: [String:Any] = [keys.valuePropEnabled.rawValue:valueProp]
+        saveRemoteConfig(with: dictionary)
     }
     
     @objc func initialize() {

--- a/Source/FirebaseRemoteConfiguration.swift
+++ b/Source/FirebaseRemoteConfiguration.swift
@@ -1,5 +1,5 @@
 //
-//  RemoteConfig.swift
+//  FirebaseRemoteConfiguration.swift
 //  edX
 //
 //  Created by Salman on 04/11/2020.
@@ -7,6 +7,8 @@
 //
 
 import UIKit
+
+private let remoteConfigUserDefaultKey = "remote-config"
 
 protocol RemoteConfigProvider {
   var remoteConfig: FirebaseRemoteConfiguration { get }
@@ -18,19 +20,29 @@ extension RemoteConfigProvider {
   }
 }
 
+fileprivate enum remoteConfigKeys: String, RawStringExtractable {
+    case valuePropEnabled = "VALUE_PROP_ENABLED"
+}
+
 @objc class FirebaseRemoteConfiguration: NSObject {
     @objc static let shared =  FirebaseRemoteConfiguration()
+    var isValuePropEnabled: Bool = false
     
     private override init() {
         super.init()
     }
     
     @objc func initialize(remoteConfig: RemoteConfig) {
-        //TODO: Make the required changes here. Not using the Firebase Remote config at this moment
+        isValuePropEnabled = remoteConfig.configValue(forKey: remoteConfigKeys.valuePropEnabled.rawValue).boolValue
+        UserDefaults.standard.set(isValuePropEnabled, forKey: remoteConfigUserDefaultKey)
+        UserDefaults.standard.synchronize()
     }
     
     @objc func initialize() {
-        //TODO: Make the required changes here. Not using the Firebase Remote config at this moment
+        guard let value = UserDefaults.standard.object(forKey: remoteConfigUserDefaultKey) as? Bool else {
+            return
+        }
+        
+        isValuePropEnabled = value
     }
 }
-

--- a/Source/FirebaseRemoteConfiguration.swift
+++ b/Source/FirebaseRemoteConfiguration.swift
@@ -34,7 +34,7 @@ fileprivate enum keys: String, RawStringExtractable {
     
     @objc func initialize(remoteConfig: RemoteConfig) {
         
-        isValuePropEnabled = remoteConfig.configValue(forKey: keys.valuePropEnabled.rawValue).boolValue
+        let isValuePropEnabled = remoteConfig.configValue(forKey: keys.valuePropEnabled.rawValue).boolValue
         let dataDictionary: [String:Any] = [keys.valuePropEnabled.rawValue:isValuePropEnabled]
         saveRemoteConfig(with: dataDictionary)
     }

--- a/Source/OEXConfig+AppFeatures.swift
+++ b/Source/OEXConfig+AppFeatures.swift
@@ -82,8 +82,4 @@ extension OEXConfig {
         }
         return false
     }
-    
-    var isValuePropEnabled: Bool {
-        return bool(forKey: "VALUE_PROP_ENABLED", defaultValue: true)
-    }
 }


### PR DESCRIPTION
### Description

[LEARNER-8109](https://openedx.atlassian.net/browse/LEARNER-8109)

In this PR I have added the value prop feature behind the remote config feature flag and remove its dependency on local config.

### Note
We are updating the value prop feature flag from remote config passively. On the first launch when the remote config call is in progress the app has set all the environment variables so in that case if we set the feature flag after getting a response the app user experience disturbs so we just store the remote config values in the user defaults and when the app relaunch again we read the remote config values from the user default and use them to show the value prop. 
In short the remote config value will actually work in app relaunch.

### How to test this PR
We have updated the flag from this place 
https://console.firebase.google.com/u/2/project/openedx-mobile-stage-2a1bd/config
