### PR TITLE
Fix for segment breaking webview navigation

### DIFF
--- a/Source/AuthenticatedWebViewController.swift
+++ b/Source/AuthenticatedWebViewController.swift
@@ -280,14 +280,19 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
     // MARK: WKWebView delegate
 
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        switch navigationAction.navigationType {
-        case .linkActivated, .formSubmitted, .formResubmitted:
-            if let URL = navigationAction.request.url, webViewDelegate?.webView(webView, shouldLoad: navigationAction.request) ?? true {
-                UIApplication.shared.open(URL, options: [:], completionHandler: nil)
-            }
+        let isWebViewDelegateHandled = !(webViewDelegate?.webView(webView, shouldLoad: navigationAction.request) ?? true)
+        if isWebViewDelegateHandled {
             decisionHandler(.cancel)
-        default:
-            decisionHandler(.allow)
+        } else {
+            switch navigationAction.navigationType {
+            case .linkActivated, .formSubmitted, .formResubmitted:
+                if let URL = navigationAction.request.url {
+                    UIApplication.shared.open(URL, options: [:], completionHandler: nil)
+                }
+                decisionHandler(.cancel)
+            default:
+                decisionHandler(.allow)
+            }
         }
     }
     

--- a/Source/DiscoveryWebViewHelper.swift
+++ b/Source/DiscoveryWebViewHelper.swift
@@ -278,16 +278,20 @@ class DiscoveryWebViewHelper: NSObject {
 extension DiscoveryWebViewHelper: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         let request = navigationAction.request
-        let capturedLink = navigationAction.navigationType == .linkActivated && (delegate?.webView(webView, shouldLoad: request) ?? true)
         
-        let outsideLink = (request.mainDocumentURL?.host != self.request?.url?.host)
-        if let URL = request.url, outsideLink || capturedLink {
-            UIApplication.shared.open(URL, options: [:], completionHandler: nil)
+        let isWebViewDelegateHandled = !(delegate?.webView(webView, shouldLoad: request) ?? true)
+        if isWebViewDelegateHandled {
             decisionHandler(.cancel)
-            return
+        } else {
+            let capturedLink = navigationAction.navigationType == .linkActivated
+            let outsideLink = (request.mainDocumentURL?.host != self.request?.url?.host)
+            if let URL = request.url, outsideLink || capturedLink {
+                UIApplication.shared.open(URL, options: [:], completionHandler: nil)
+                decisionHandler(.cancel)
+            } else {
+                decisionHandler(.allow)
+            }
         }
-        
-        decisionHandler(.allow)
     }
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {


### PR DESCRIPTION
See if the WebViewDelegate wants to handle a navigation action before trying other ways of handling.

This fixes an issue introduced by webpages using Segment's `trackLink()`.  `trackLink()` programmatically changes `window.location.href`, which registers as a navigation action of type `.other`.

### Description

[LEARNER-](https://openedx.atlassian.net/browse/LEARNER-)

Add a description of your changes here.

### Notes

### How to test this PR
