### PR TITLE
Don't Force Logout for invalid_grant

### DIFF
--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -275,10 +275,7 @@ public class CourseOutlineViewController :
     private func loadHeaderStream() {
         headersLoader.listen(self, success: { [weak self] headers in
                 self?.setupNavigationItem(block: headers.block)
-            }, failure: {[weak self] error in
-                self?.showErrorIfNecessary(error: error)
-            }
-        )
+        }, failure: { _ in })
     }
     
     private func loadRowsStream() {

--- a/Source/NetworkManager+Authenticators.swift
+++ b/Source/NetworkManager+Authenticators.swift
@@ -55,7 +55,7 @@ extension NetworkManager {
                 }
                 if error.isAPIError(code: .OAuth2InvalidGrant) {
                     //TODO: Handle invalid_grant gracefully,
-                    //Most if the times it's happening because of hitting /oauth2/access_token/ multiple times with refresh_token
+                    //Most of the times it's happening because of hitting /oauth2/access_token/ multiple times with refresh_token
                     //Only send one request for /oauth2/access_token/
                     Logger.logError("Network Authenticator", "invalid_grant: " + response.debugDescription)
                 }

--- a/Source/NetworkManager+Authenticators.swift
+++ b/Source/NetworkManager+Authenticators.swift
@@ -53,8 +53,14 @@ extension NetworkManager {
                 if error.isAPIError(code: .OAuth2Nonexistent) {
                    return refreshAccessToken(clientId: clientId, refreshToken: refreshToken, session: session)
                 }
+                if error.isAPIError(code: .OAuth2InvalidGrant) {
+                    //TODO: Handle invalid_grant gracefully,
+                    //Most if the times it's happening because of hitting /oauth2/access_token/ multiple times with refresh_token
+                    //Only send one request for /oauth2/access_token/
+                    Logger.logError("Network Authenticator", "invalid_grant: " + response.debugDescription)
+                }
 
-                if error.isAPIError(code: .OAuth2InvalidGrant) || error.isAPIError(code: .OAuth2DisabledUser) {
+                if error.isAPIError(code: .OAuth2DisabledUser) {
                     return logout(router: router)
                 }
             }

--- a/Test/NetworkManager+AuthenticatorTests.swift
+++ b/Test/NetworkManager+AuthenticatorTests.swift
@@ -58,14 +58,14 @@ class NetworkManager_AuthenticationTests : XCTestCase {
         XCTAssertTrue(result.isAuthenticate)
     }
 
-    func testLogoutForInvalidGrantAccessToken() {
+    func testInvalidGrantAccessToken() {
         let router = MockRouter()
         let session = sessionWithRefreshTokenBuilder()
         let response = simpleResponseBuilder(401)
         let data = "{\"error_code\":\"invalid_grant\"}".data(using: String.Encoding.utf8)!
-        let result = authenticatorResponseForRequest(response!, data: data, session: session, router: router, waitForLogout: true)
+        let result = authenticatorResponseForRequest(response!, data: data, session: session, router: router, waitForLogout: false)
         XCTAssertTrue(result.isProceed)
-        XCTAssertTrue(router.logoutCalled)
+        XCTAssertFalse(router.logoutCalled)
     }
     
     func testLogoutWithNonJSONData() {


### PR DESCRIPTION
### Description

[LEARNER-8223](https://openedx.atlassian.net/browse/LEARNER-8223)

The app was logout learner forcefully on receiving the `invalid_grant` from the server. And it was happening almost every time the app tried to refresh `access_token`  with a `refresh_token`.

In case of async requests, a number of requests were being made to refresh the `access_token`, and after the first successful request server was returning `invalid_grant` for subsequent requests.

This PR address only a fraction of the problem and not forcefully logout on receiving the `invalid_grant`.

### Notes

Invalid_grant will be gracefully handled under [LEARNER-8224](https://openedx.atlassian.net/browse/LEARNER-8224).

###Sandbox

API_HOST_URL: https://invalidgrant.sandbox.edx.org
OAUTH_CLIENT_ID: 'LCAi11sUG233NYD5JoX3NmnsjEeD7ecQAhbN52jo'

### How to test this PR
Testing the app in the real scenario is a bit hard but it can be tested by forcefully expiring the acess_token from the admin panel.

1. Login using the credentials `staff/edx`
2. Expire access_token from the [admin panel](https://invalidgrant.sandbox.edx.org/admin/oauth2_provider/accesstoken/) at different levels of the app and perform different actions. App should refresh the access_token and perform the action with new access_token.

- [ ] App should refresh access_token and work seamlessly. 


