### PR TITLE
Let the WebViewDelegate to handle a navigation action before trying other ways of handling.

### DIFF
--- a/Source/AuthenticatedWebViewController.swift
+++ b/Source/AuthenticatedWebViewController.swift
@@ -280,14 +280,19 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
     // MARK: WKWebView delegate
 
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        switch navigationAction.navigationType {
-        case .linkActivated, .formSubmitted, .formResubmitted:
-            if let URL = navigationAction.request.url, webViewDelegate?.webView(webView, shouldLoad: navigationAction.request) ?? true {
-                UIApplication.shared.open(URL, options: [:], completionHandler: nil)
-            }
+        let isWebViewDelegateHandled = !(webViewDelegate?.webView(webView, shouldLoad: navigationAction.request) ?? true)
+        if isWebViewDelegateHandled {
             decisionHandler(.cancel)
-        default:
-            decisionHandler(.allow)
+        } else {
+            switch navigationAction.navigationType {
+            case .linkActivated, .formSubmitted, .formResubmitted:
+                if let URL = navigationAction.request.url {
+                    UIApplication.shared.open(URL, options: [:], completionHandler: nil)
+                }
+                decisionHandler(.cancel)
+            default:
+                decisionHandler(.allow)
+            }
         }
     }
     

--- a/Source/DiscoveryWebViewHelper.swift
+++ b/Source/DiscoveryWebViewHelper.swift
@@ -278,16 +278,20 @@ class DiscoveryWebViewHelper: NSObject {
 extension DiscoveryWebViewHelper: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         let request = navigationAction.request
-        let capturedLink = navigationAction.navigationType == .linkActivated && (delegate?.webView(webView, shouldLoad: request) ?? true)
         
-        let outsideLink = (request.mainDocumentURL?.host != self.request?.url?.host)
-        if let URL = request.url, outsideLink || capturedLink {
-            UIApplication.shared.open(URL, options: [:], completionHandler: nil)
+        let isWebViewDelegateHandled = !(delegate?.webView(webView, shouldLoad: request) ?? true)
+        if isWebViewDelegateHandled {
             decisionHandler(.cancel)
-            return
+        } else {
+            let capturedLink = navigationAction.navigationType == .linkActivated
+            let outsideLink = (request.mainDocumentURL?.host != self.request?.url?.host)
+            if let URL = request.url, outsideLink || capturedLink {
+                UIApplication.shared.open(URL, options: [:], completionHandler: nil)
+                decisionHandler(.cancel)
+            } else {
+                decisionHandler(.allow)
+            }
         }
-        
-        decisionHandler(.allow)
     }
     
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {


### PR DESCRIPTION
### Description

[LEARNER-8234](https://openedx.atlassian.net/browse/LEARNER-8234)

This fixes an issue introduced by webpages using Segment's `trackLink()`.  `trackLink()` programmatically changes `window.location.href`, which registers as a navigation action of type `.other`.

### Notes

### How to test this PR

The sandbox `prospectus-rgraber.sandbox.edx.org` must be used to test the fix.  I modified this part of the config file:

```DISCOVERY:
    COURSE:
        TYPE: 'webview'
        WEBVIEW:
            SUBJECT_FILTER_ENABLED: true
            BASE_URL: 'https://prospectus-rgraber.sandbox.edx.org/webview/search?tab=course'
            DETAIL_TEMPLATE: 'https://prospectus-rgraber.sandbox.edx.org/webview/course/{path_id}'
            SEARCH_ENABLED: true
    PROGRAM:
        TYPE: 'webview'
        WEBVIEW:
            BASE_URL: 'https://prospectus-rgraber.sandbox.edx.org/webview/search?tab=program'
            DETAIL_TEMPLATE: 'https://prospectus-rgraber.sandbox.edx.org/webview/{path_id}'
            SEARCH_ENABLED: true
    DEGREE:
        TYPE: 'webview'
        WEBVIEW:
            BASE_URL: 'https://prospectus-rgraber.sandbox.edx.org/webview/search?program_type=Masters&tab=program'
            DETAIL_TEMPLATE: 'https://prospectus-rgraber.sandbox.edx.org/webview/{path_id}'
            SEARCH_ENABLED: false
```

Also note that the app caches webviews, so the easiest way I have found to test is to delete the app and run a fresh install.
