### PR TITLE
Fix video seeking tests

### DIFF
--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -567,7 +567,7 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         }
     }
         
-    func seekVideo(playerControls: VideoPlayerControls, skipDuration: Double, type: SeekType) {
+    func seekVideo(playerControls: VideoPlayerControls, skipDuration: Double, type: SeekType, completion: ((Bool)->())? = nil) {
         let oldTime = currentTime
         let videoDuration = CMTimeGetSeconds(duration)
         let elapsedTime: Float64 = videoDuration * Float64(playerControls.durationSliderValue)
@@ -576,7 +576,7 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         let estimatedSliderValue = Float(updatedElapseTime / duration.seconds)
         playerControls.durationSliderValue = estimatedSliderValue
         playerControls.updateTimeLabel(elapsedTime: updatedElapseTime, duration: CMTimeGetSeconds(self.duration))
-        seek(to: elapsedTime + requestedDuration)
+        seek(to: elapsedTime + requestedDuration, completion: completion)
         
         if let videoId = video?.summary?.videoID,
             let courseId = video?.course_id,
@@ -617,17 +617,22 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         }
     }
 
-    func seek(to time: Double) {
+    func seek(to time: Double, completion: ((Bool)->())? = nil) {
         if player.currentItem?.status != .readyToPlay { return }
         let cmTime = CMTimeMakeWithSeconds(time, preferredTimescale: preferredTimescale)
         lastElapsedTime = time
-        player.currentItem?.seek(to: cmTime, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self]
+        guard let currentItem = player.currentItem else {
+            completion?(false)
+            return
+        }
+        currentItem.seek(to: cmTime, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self]
             (completed: Bool) -> Void in
                 if self?.playerState == .playing {
                     self?.controls?.autoHide()
                     self?.player.play()
                 }
                 self?.savePlayedTime(time: time)
+                completion?(completed)
         }
     }
     

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -16,12 +16,19 @@ enum SeekType {
 protocol VideoPlayerControlsDelegate: class {
     func playPausePressed(playerControls: VideoPlayerControls, isPlaying: Bool)
     func seekVideo(playerControls: VideoPlayerControls, skipDuration: Double, type: SeekType)
+    func seekVideo(playerControls: VideoPlayerControls, skipDuration: Double, type: SeekType, completion: ((Bool)->())?)
     func fullscreenPressed(playerControls: VideoPlayerControls)
     func setPlayBackSpeed(playerControls: VideoPlayerControls, speed:OEXVideoSpeed)
     func sliderValueChanged(playerControls: VideoPlayerControls)
     func sliderTouchBegan(playerControls: VideoPlayerControls)
     func sliderTouchEnded(playerControls: VideoPlayerControls)
     func captionUpdate(playerControls: VideoPlayerControls, language: String)
+}
+
+extension VideoPlayerControlsDelegate {
+    func seekVideo(playerControls: VideoPlayerControls, skipDuration: Double, type: SeekType) {
+        seekVideo(playerControls: playerControls, skipDuration: skipDuration, type: type, completion: nil)
+    }
 }
 
 class VideoPlayerControls: UIView, VideoPlayerSettingsDelegate, UIGestureRecognizerDelegate {

--- a/Source/CutomePlayer/YoutubeVideoPlayer.swift
+++ b/Source/CutomePlayer/YoutubeVideoPlayer.swift
@@ -127,8 +127,9 @@ class YoutubeVideoPlayer: VideoPlayer {
         }
     }
 
-    override func seek(to time: Double) {
+    override func seek(to time: Double, completion: ((Bool)->())? = nil) {
         playerView.seek(toSeconds: Float(time), allowSeekAhead: true)
+        completion?(true)
     }
     
     private func showErrorMessage(message : String) {

--- a/Test/VideoPlayerTests.swift
+++ b/Test/VideoPlayerTests.swift
@@ -46,6 +46,17 @@ class VideoPlayerTests: XCTestCase {
             stopPlayer()
     }
     
+    func loadVideoPlayerAndSeek(to seekTime: Double, completion: ( (_ videoPlayer : VideoPlayer) -> Void)? = nil) {
+        let expectations = expectation(description: "player seek completed")
+        loadVideoPlayer { videoPlayer in
+            XCTAssertEqual(videoPlayer.t_playerCurrentState, .readyToPlay)
+            videoPlayer.seek(to: seekTime) { _ in
+                completion?(videoPlayer)
+                expectations.fulfill()
+            }
+        }
+    }
+    
     func stopPlayer() {
         videoPlayer?.t_stop()
     }
@@ -73,10 +84,9 @@ class VideoPlayerTests: XCTestCase {
     }
     
     // Test the video is resume successfully
+    // FIXME: This is not actually testing anything, since resume() is an async call and we are not waiting for it to complete
     func testVideoResume() {
-        loadVideoPlayer { videoPlayer in
-            XCTAssertEqual(videoPlayer.t_playerCurrentState, .readyToPlay)
-            videoPlayer.seek(to: 10.168155555555558)
+        loadVideoPlayerAndSeek(to: 10.168155555555558){ videoPlayer in
             videoPlayer.t_controls?.durationSliderValue = 1.01
             let  pauseTime = videoPlayer.currentTime
             XCTAssertGreaterThan(videoPlayer.rate, 0)
@@ -90,33 +100,41 @@ class VideoPlayerTests: XCTestCase {
     
     // Test the backward seek functionality
     func testSeekBackword() {
-        loadVideoPlayer { videoPlayer in
-            XCTAssertEqual(videoPlayer.t_playerCurrentState, .readyToPlay)
-            videoPlayer.seek(to: 34.168155555555558)
-            videoPlayer.t_controls?.durationSliderValue = 1.01
-            videoPlayer.seekVideo(playerControls: videoPlayer.t_controls!, skipDuration: 10, type: .rewind)
-            let currentTime = videoPlayer.currentTime
-            XCTAssertGreaterThanOrEqual(currentTime, 23.93)
+        let expectations = expectation(description: "player seek video completed")
+        loadVideoPlayerAndSeek(to: 34.168155555555558) { videoPlayer in
+            // We are performing another seek inside the completion block of the first seek, so we must dispatch async on main queue.
+            DispatchQueue.main.async {
+                videoPlayer.t_controls?.durationSliderValue = Float(34.168155555555558 / videoPlayer.duration.seconds)
+                videoPlayer.seekVideo(playerControls: videoPlayer.t_controls!, skipDuration: 10, type: .rewind) { _ in
+                    let currentTime = videoPlayer.currentTime
+                    XCTAssertGreaterThanOrEqual(currentTime, 23.93)
+                    XCTAssertLessThanOrEqual(currentTime, 25.93)
+                    expectations.fulfill()
+                }
+            }
         }
     }
     
     // Test the forward seek functionality
     func testSeekForword() {
-        loadVideoPlayer { videoPlayer in
-            XCTAssertEqual(videoPlayer.t_playerCurrentState, .readyToPlay)
-            videoPlayer.seek(to: 34.168155555555558)
-            videoPlayer.t_controls?.durationSliderValue = 1.01
-            videoPlayer.seekVideo(playerControls: videoPlayer.t_controls!, skipDuration: 15, type: .forward)
-            let currentTime = videoPlayer.currentTime
-            XCTAssertGreaterThanOrEqual(currentTime, 23.93)
+        let expectations = expectation(description: "player seek video completed")
+        loadVideoPlayerAndSeek(to: 14.168155555555558) { videoPlayer in
+            // We are performing another seek inside the completion block of the first seek, so we must dispatch async on main queue.
+            DispatchQueue.main.async {
+                videoPlayer.t_controls?.durationSliderValue = Float(14.168155555555558 / videoPlayer.duration.seconds)
+                videoPlayer.seekVideo(playerControls: videoPlayer.t_controls!, skipDuration: 10, type: .forward) { _ in
+                    let currentTime = videoPlayer.currentTime
+                    XCTAssertGreaterThanOrEqual(currentTime, 23.93)
+                    XCTAssertLessThanOrEqual(currentTime, 25.93)
+                    expectations.fulfill()
+                }
+            }
         }
     }
     
     // Test the seeking functionality 
     func testSeeking() {
-        loadVideoPlayer { videoPlayer in
-            XCTAssertEqual(videoPlayer.t_playerCurrentState, .readyToPlay)
-            videoPlayer.seek(to: 34.168155555555558)
+        loadVideoPlayerAndSeek(to: 34.168155555555558) { videoPlayer in
             videoPlayer.t_controls?.durationSliderValue = 1.01
             let currentTime = videoPlayer.currentTime
             XCTAssertGreaterThanOrEqual(currentTime, 33.934)


### PR DESCRIPTION
### Description

https://openedx.atlassian.net/browse/LEARNER-8256

The default implementation of `seek` is async.  Add in completion blocks so the tests can wait for the seek to finish before continuing.

Make seekVideo accept a completion block as well.

### Notes

*Note this is note tracked in JIRA*

### How to test this PR

Video seeking unit tests should now work when building on Travis!

But please check for any potential issues in the code.
