### PR TITLE
Log non fatal crash and delete cookies before exchange_access_token

### DIFF
--- a/Source/OEXAuthentication.m
+++ b/Source/OEXAuthentication.m
@@ -130,10 +130,8 @@ OEXNSDataTaskRequestHandler OEXWrapURLCompletion(OEXURLRequestHandler completion
         NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
         for(NSHTTPCookie* cookie in cookies) {
             [userInfo setObjectOrNil:cookie.name forKey:cookie.name];
-            NSLog(@"cookie: %@", cookie.name);
         }
         NSError *error = [NSError errorWithDomain:@"org.edx.error" code:-100001 userInfo:userInfo];
-        NSLog(@"error: %@", error);
         [[FIRCrashlytics crashlytics] recordError:error];
 
         //Although this isn't required in normal cases

--- a/Source/OEXPersistentCredentialStorage.h
+++ b/Source/OEXPersistentCredentialStorage.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface OEXPersistentCredentialStorage : NSObject <OEXCredentialStorage>
-
++ (instancetype)sharedKeychainAccess;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
### Description

[LEARNER-8235](https://openedx.atlassian.net/browse/LEARNER-8235)

Mobile iOS users were seeing the error, ["Account Disabled"](https://openedx.atlassian.net/wiki/spaces/ENG/pages/2428796953/RCA+CR-3090+-+Mobile+iOS+users+seeing+error+Account+Disabled) and it was happening because in an unknown scenario somehow app was sending `prod-edx-sessionid` cookie in the `auth2/exchange_access_token` request.

This PR addresses the issue and deletes the cookies if not deleted on logout before the `auth2/exchange_access_token` request. Before deleting the cookies it also logs a non-fatal error on the `Firebase/Crashlytics` for investigation purposes.

### How to test this PR

There isn't any straightforward way to test this PR but it can be tested by creating a special dev environment. To create the dev environment add `return` at the first line of method `clear` in the file `OEXPersistentCredentialStorage.m`, by doing this app won't delete cookies on logout and will log a nonfatal error and delete all the cookies before signing in with an external auth provider.
