### PR TITLE
Always play AVPlayer by setting the rate directly.

### DIFF
--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -81,9 +81,6 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         get {
             return player.rate
         }
-        set {
-            player.rate = newValue
-        }
     }
     
     var duration: CMTime {
@@ -298,9 +295,6 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
             if let newStatusAsNumber = change?[NSKeyValueChangeKey.newKey] as? NSNumber, let newStatus = AVPlayerItem.Status(rawValue: newStatusAsNumber.intValue) {
                 switch newStatus {
                 case .readyToPlay:
-                    let speed = OEXInterface.getCCSelectedPlaybackSpeed()
-                    rate = OEXInterface.getOEXVideoSpeed(speed)
-                    
                     //This notification call specifically for test cases in readyToPlay state
                     perform(#selector(t_postNotification))
                     
@@ -392,7 +386,7 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
     }
     
     private func play(at timeInterval: TimeInterval) {
-        player.play()
+        playAtSelectedPlaybackSpeed()
         lastElapsedTime = timeInterval
         var resumeObserver: AnyObject?
         resumeObserver = player.addPeriodicTimeObserver(forInterval: CMTime(value: 1, timescale: 3), queue: DispatchQueue.main) { [weak self]
@@ -405,6 +399,10 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
                 }
             }
             } as AnyObject
+    }
+    
+    private func playAtSelectedPlaybackSpeed() {
+        player.rate = OEXInterface.getOEXVideoSpeed(OEXInterface.getCCSelectedPlaybackSpeed())
     }
     
     @objc private func movieTimedOut() {
@@ -421,7 +419,7 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
         if player.currentItem?.status == .readyToPlay {
             player.currentItem?.seek(to: CMTimeMakeWithSeconds(time, preferredTimescale: preferredTimescale), toleranceBefore: CMTime.zero, toleranceAfter: CMTime.zero) { [weak self]
                 (completed: Bool) -> Void in
-                self?.player.play()
+                self?.playAtSelectedPlaybackSpeed()
                 self?.playerState = .playing
                 self?.controls?.setPlayPauseButtonState(isSelected: false)
             }
@@ -625,7 +623,7 @@ class VideoPlayer: UIViewController,VideoPlayerControlsDelegate,TranscriptManage
             (completed: Bool) -> Void in
                 if self?.playerState == .playing {
                     self?.controls?.autoHide()
-                    self?.player.play()
+                    self?.playAtSelectedPlaybackSpeed()
                 }
                 self?.savePlayedTime(time: time)
         }


### PR DESCRIPTION
Remove the previous method of observing when the player changed state and setting the rate afterward.
There is an issue in `resume(at:)` that resulted in `player.play()` being called, but a play status change either not happening or not being observed.  This meant that the rate was sometimes not set after play began with the default 1.0 rate.

### Description

[LEARNER-8163](https://openedx.atlassian.net/browse/LEARNER-8163)

Add a description of your changes here.

### Notes

### How to test this PR

I was able to reproduce the original issue by pressing Back while watching a video on 2.0 speed, then navigating to a different video I had not yet played.  I couldn't get this to reliably reproduce, but managed to make it happen fairly often.
