### PR TITLE
iOS - Text in the value prop modal should not be tappable

### DIFF
--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -24,6 +24,7 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
         tableView.delegate = self
         tableView.separatorStyle = .none
         tableView.backgroundColor = .clear
+        tableView.allowsSelection = false
         tableView.register(ValuePropMessageCell.self, forCellReuseIdentifier: ValuePropMessageCell.identifier)
         tableView.register(ValuePropDetailHeaderView.self, forHeaderFooterViewReuseIdentifier: ValuePropDetailHeaderView.identifier)
         tableView.accessibilityIdentifier = "ValuePropDetailView:tableView"


### PR DESCRIPTION
### Description

[LEARNER-8244](https://openedx.atlassian.net/browse/LEARNER-8244)

The fix for the text in the value prop modal should not be tappable.

### How to test this PR
- Start the app.
- Tap on the learn more button the value prop detail view will open.
- The points should not be tappable. 
