### PR TITLE
Video Download Spinner Isn't Working

### DIFF
--- a/Source/CourseVideoTableViewCell.swift
+++ b/Source/CourseVideoTableViewCell.swift
@@ -160,6 +160,7 @@ class CourseVideoTableViewCell: SwipeableCell, CourseBlockContainerCell {
             return
         }
         
+        content.trailingView = downloadView
         downloadView.state = downloadState
     }
     


### PR DESCRIPTION
### Description

[LEARNER-8332](https://openedx.atlassian.net/browse/LEARNER-8332)

Fix Video Download Spinner on navigation between screens

### How to test this PR
- [x] Start downloading of a video, move between different screens, spinner should remain in downloading state when downloading is in progress