### PR TITLE
fix: sharpen blurry checkmark icon

### DIFF
--- a/Source/CourseOutlineItemView.swift
+++ b/Source/CourseOutlineItemView.swift
@@ -185,7 +185,7 @@ public class CourseOutlineItemView: UIView {
     
     func setContentIcon(icon: Icon?, color: UIColor) {
         shouldShowLeadingView = true
-        let image = icon?.imageWithFontSize(size: SmallIconSize).image(with: color)
+        let image = icon?.imageWithFontSize(size: SmallIconSize)
         leadingImageButton.setImage(image, for: .normal)
         leadingImageButton.tintColor = color
         if let accessibilityText = icon?.accessibilityText {


### PR DESCRIPTION
### Description

`image(with)` is currently buggy and returns an image with the wrong scale (causing it to be blurry).  Remove this call, it is actually unnecessary because `tintColor` does the same thing.

(No JIRA ticket)

### Notes

### How to test this PR

Look at the completion checkmark in a course outline.
