### PR TITLE
[feat] Open rendered xBlock in Mobile Browser

### DIFF
--- a/Source/Icon.swift
+++ b/Source/Icon.swift
@@ -156,6 +156,7 @@ public enum Icon {
     case Account
     case ArrowLeft
     case Clone
+    case OpenInBrowser
     
     private var renderer : IconRenderer {
         switch self {
@@ -297,6 +298,8 @@ public enum Icon {
             return MaterialIconRenderer(icon: .keyboardArrowLeft)
         case .Language:
             return MaterialIconRenderer(icon: .language)
+        case .OpenInBrowser:
+            return MaterialIconRenderer(icon: .openInNew)
         }
     }
     

--- a/Source/OpenInExternalBrowserView.swift
+++ b/Source/OpenInExternalBrowserView.swift
@@ -70,8 +70,7 @@ class OpenInExternalBrowserView: UIView, UITextViewDelegate {
 
         let clickableStyle = OEXTextStyle(weight : .normal, size: .base, color: OEXStyles.shared().neutralXDark())
         let clickableText = clickableStyle.attributedString(withText: Strings.OpenInExternalBrowser.openInBroswer).addUnderline(foregroundColor: OEXStyles.shared().neutralXDark())
-        let formattedText = NSAttributedString.joinInNaturalLayout(
-            attributedStrings: [message, clickableText, browserIcon])
+        let formattedText = NSAttributedString.joinInNaturalLayout(attributedStrings: [message, clickableText, browserIcon])
         messageLabel.attributedText = formattedText
 
         button.oex_addAction({[weak self] (action) in

--- a/Source/OpenInExternalBrowserView.swift
+++ b/Source/OpenInExternalBrowserView.swift
@@ -8,14 +8,14 @@
 
 import Foundation
 
-protocol OpenInExternalBrowserViewDelegate: class {
+protocol OpenInExternalBrowserViewDelegate: AnyObject {
     func openInExternalBrower()
 }
 
 class OpenInExternalBrowserView: UIView, UITextViewDelegate {
-    let container = UIView()
-    let messageLabel = UILabel()
-    let button = UIButton()
+    private let container = UIView()
+    private let messageLabel = UILabel()
+    private let button = UIButton()
 
     weak var delegate: OpenInExternalBrowserViewDelegate?
 
@@ -52,21 +52,19 @@ class OpenInExternalBrowserView: UIView, UITextViewDelegate {
             make.edges.equalTo(container)
         }
 
-        let textStyle : OEXTextStyle = OEXTextStyle(weight : .normal, size: .small, color: OEXStyles.shared().neutralXDark())
+        let textStyle = OEXTextStyle(weight : .normal, size: .small, color: OEXStyles.shared().neutralXDark())
         let message = textStyle.attributedString(withText: Strings.OpenInExternalBrowser.message)
 
 
-        let clickAbleStyle : OEXTextStyle = OEXTextStyle(weight : .normal, size: .base, color: OEXStyles.shared().neutralXDark())
-        let clickAbleText = clickAbleStyle.attributedString(withText: Strings.OpenInExternalBrowser.openInBroswer).addUnderline(foregroundColor: OEXStyles.shared().neutralXDark())
-        let icon = Icon.OpenInBrowser.attributedTextWithStyle(style: clickAbleStyle)
-
+        let clickableStyle = OEXTextStyle(weight : .normal, size: .base, color: OEXStyles.shared().neutralXDark())
+        let clickableText = clickableStyle.attributedString(withText: Strings.OpenInExternalBrowser.openInBroswer).addUnderline(foregroundColor: OEXStyles.shared().neutralXDark())
+        let icon = Icon.OpenInBrowser.attributedTextWithStyle(style: clickableStyle)
         let formattedText = NSAttributedString.joinInNaturalLayout(
-            attributedStrings: [message, clickAbleText, icon])
-
+            attributedStrings: [message, clickableText, icon])
         messageLabel.attributedText = formattedText
 
         button.oex_addAction({[weak self] (action) in
             self?.delegate?.openInExternalBrower()
-        }, for: UIControl.Event.touchUpInside)
+        }, for: .touchUpInside)
     }
 }

--- a/Source/OpenInExternalBrowserView.swift
+++ b/Source/OpenInExternalBrowserView.swift
@@ -1,0 +1,72 @@
+//
+//  OpenInExternalBrowserView.swift
+//  edX
+//
+//  Created by Saeed Bashir on 4/21/21.
+//  Copyright © 2021 edX. All rights reserved.
+//
+
+import Foundation
+
+protocol OpenInExternalBrowserViewDelegate: class {
+    func openInExternalBrower()
+}
+
+class OpenInExternalBrowserView: UIView, UITextViewDelegate {
+    let container = UIView()
+    let messageLabel = UILabel()
+    let button = UIButton()
+
+    weak var delegate: OpenInExternalBrowserViewDelegate?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupView() {
+
+        messageLabel.numberOfLines = 0
+        container.backgroundColor = OEXStyles.shared().infoXXLight()
+
+        container.addSubview(messageLabel)
+        container.addSubview(button)
+        addSubview(container)
+
+        container.snp.remakeConstraints { make in
+            make.edges.equalTo(self)
+        }
+
+        messageLabel.snp.remakeConstraints { make in
+            make.leading.equalTo(container).offset(StandardHorizontalMargin)
+            make.trailing.equalTo(container).inset(StandardHorizontalMargin)
+            make.centerY.equalTo(container)
+        }
+
+        button.snp.remakeConstraints{ make in
+            make.edges.equalTo(container)
+        }
+
+        let textStyle : OEXTextStyle = OEXTextStyle(weight : .normal, size: .small, color: OEXStyles.shared().neutralXDark())
+        let message = textStyle.attributedString(withText: Strings.OpenInExternalBrowser.message)
+
+
+        let clickAbleStyle : OEXTextStyle = OEXTextStyle(weight : .normal, size: .base, color: OEXStyles.shared().neutralXDark())
+        let clickAbleText = clickAbleStyle.attributedString(withText: Strings.OpenInExternalBrowser.openInBroswer).addUnderline(foregroundColor: OEXStyles.shared().neutralXDark())
+        let icon = Icon.OpenInBrowser.attributedTextWithStyle(style: clickAbleStyle)
+
+        let formattedText = NSAttributedString.joinInNaturalLayout(
+            attributedStrings: [message, clickAbleText, icon])
+
+        messageLabel.attributedText = formattedText
+
+        button.oex_addAction({[weak self] (action) in
+            self?.delegate?.openInExternalBrower()
+        }, for: UIControl.Event.touchUpInside)
+    }
+}

--- a/Source/OpenInExternalBrowserView.swift
+++ b/Source/OpenInExternalBrowserView.swift
@@ -52,15 +52,28 @@ class OpenInExternalBrowserView: UIView, UITextViewDelegate {
             make.edges.equalTo(container)
         }
 
-        let textStyle = OEXTextStyle(weight : .normal, size: .small, color: OEXStyles.shared().neutralXDark())
+        let textStyle = OEXTextStyle(weight : .normal, size: .base, color: OEXStyles.shared().neutralXDark())
         let message = textStyle.attributedString(withText: Strings.OpenInExternalBrowser.message)
 
 
         let clickableStyle = OEXTextStyle(weight : .normal, size: .base, color: OEXStyles.shared().neutralXDark())
         let clickableText = clickableStyle.attributedString(withText: Strings.OpenInExternalBrowser.openInBroswer).addUnderline(foregroundColor: OEXStyles.shared().neutralXDark())
-        let icon = Icon.OpenInBrowser.attributedTextWithStyle(style: clickableStyle)
+
+        var attributedIcon: NSAttributedString {
+            let icon = Icon.OpenInBrowser.imageWithFontSize(size: 18).image(with: OEXStyles.shared().neutralXDark())
+            let attachment = NSTextAttachment()
+            attachment.image = icon
+
+            let imageOffsetY: CGFloat = -4.0
+            if let image = attachment.image {
+                attachment.bounds = CGRect(x: 0, y: imageOffsetY, width: image.size.width, height: image.size.height)
+            }
+
+            return NSAttributedString(attachment: attachment)
+        }
+        
         let formattedText = NSAttributedString.joinInNaturalLayout(
-            attributedStrings: [message, clickableText, icon])
+            attributedStrings: [message, clickableText, attributedIcon])
         messageLabel.attributedText = formattedText
 
         button.oex_addAction({[weak self] (action) in

--- a/Source/OpenInExternalBrowserView.swift
+++ b/Source/OpenInExternalBrowserView.swift
@@ -17,6 +17,19 @@ class OpenInExternalBrowserView: UIView, UITextViewDelegate {
     private let messageLabel = UILabel()
     private let button = UIButton()
 
+    private var browserIcon: NSAttributedString {
+        let icon = Icon.OpenInBrowser.imageWithFontSize(size: 18).image(with: OEXStyles.shared().neutralXDark())
+        let attachment = NSTextAttachment()
+        attachment.image = icon
+
+        let imageOffsetY: CGFloat = -4.0
+        if let image = attachment.image {
+            attachment.bounds = CGRect(x: 0, y: imageOffsetY, width: image.size.width, height: image.size.height)
+        }
+
+        return NSAttributedString(attachment: attachment)
+    }
+
     weak var delegate: OpenInExternalBrowserViewDelegate?
 
     override init(frame: CGRect) {
@@ -55,29 +68,22 @@ class OpenInExternalBrowserView: UIView, UITextViewDelegate {
         let textStyle = OEXTextStyle(weight : .normal, size: .base, color: OEXStyles.shared().neutralXDark())
         let message = textStyle.attributedString(withText: Strings.OpenInExternalBrowser.message)
 
-
         let clickableStyle = OEXTextStyle(weight : .normal, size: .base, color: OEXStyles.shared().neutralXDark())
         let clickableText = clickableStyle.attributedString(withText: Strings.OpenInExternalBrowser.openInBroswer).addUnderline(foregroundColor: OEXStyles.shared().neutralXDark())
-
-        var attributedIcon: NSAttributedString {
-            let icon = Icon.OpenInBrowser.imageWithFontSize(size: 18).image(with: OEXStyles.shared().neutralXDark())
-            let attachment = NSTextAttachment()
-            attachment.image = icon
-
-            let imageOffsetY: CGFloat = -4.0
-            if let image = attachment.image {
-                attachment.bounds = CGRect(x: 0, y: imageOffsetY, width: image.size.width, height: image.size.height)
-            }
-
-            return NSAttributedString(attachment: attachment)
-        }
-        
         let formattedText = NSAttributedString.joinInNaturalLayout(
-            attributedStrings: [message, clickableText, attributedIcon])
+            attributedStrings: [message, clickableText, browserIcon])
         messageLabel.attributedText = formattedText
 
         button.oex_addAction({[weak self] (action) in
             self?.delegate?.openInExternalBrower()
         }, for: .touchUpInside)
+
+        setAccessibilityIdentifiers()
+    }
+
+    private func setAccessibilityIdentifiers() {
+        container.accessibilityIdentifier = "OpenInExternalBrowserView:container-view"
+        messageLabel.accessibilityIdentifier = "OpenInExternalBrowserView:message-label"
+        button.accessibilityIdentifier = "OpenInExternalBrowserView:open-in-browser-button"
     }
 }

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -596,6 +596,10 @@
 "EXTERNAL_REGISTRATION_BECAME_LOGIN" = "لقد قمت بالفعل بربط حسابك في {platform_name} مع {service}. لقد تم تسجيل دخولك باستخدام ذلك الحساب.";
 /* Endorsed text */
 "ENDORSED" = "مصادق عليه";
+/*Open in external browser banner message*/
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+/*Open in external browser banner underline text*/
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
 /* Facebook login method */
 "FACEBOOK"="فيسبوك";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -548,6 +548,10 @@
 "EXTERNAL_REGISTRATION_BECAME_LOGIN" = "Sie haben bereits ein Benutzerkonto bei der {platform_name} über ihr {service} Konto erstellt. ";
 /* Endorsed text */
 "ENDORSED" = "Bestätigt";
+/*Open in external browser banner message*/
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+/*Open in external browser banner underline text*/
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -548,6 +548,10 @@
 "EXTERNAL_REGISTRATION_BECAME_LOGIN" = "You already set up an {platform_name} account with your {service} account. You have been logged in with that account.";
 /* Endorsed text */
 "ENDORSED" = "Endorsed";
+/*Open in external browser banner message*/
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+/*Open in external browser banner underline text*/
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -548,6 +548,10 @@
 "EXTERNAL_REGISTRATION_BECAME_LOGIN" = "Ya estableció una cuenta de {platform_name} usando su cuenta de {service}. Se ha iniciado sesión con esa cuenta.";
 /* Endorsed text */
 "ENDORSED" = "Validado";
+/*Open in external browser banner message*/
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+/*Open in external browser banner underline text*/
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -548,6 +548,10 @@
 "EXTERNAL_REGISTRATION_BECAME_LOGIN" = "Vous avez déjà un compte {platform_name} avec votre compte {service}. Vous avez été connecté avec ce compte.";
 /* Endorsed text */
 "ENDORSED" = "Voté";
+/*Open in external browser banner message*/
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+/*Open in external browser banner underline text*/
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -568,6 +568,10 @@
 "EXTERNAL_REGISTRATION_BECAME_LOGIN" = "כבר יצרתם חשבון ב-{platform_name} באמצעות חשבון ה-{service} שלכם. נכנסתם כעת באמצעות חשבון זה.";
 /* Endorsed text */
 "ENDORSED" = "התקבל";
+/*Open in external browser banner message*/
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+/*Open in external browser banner underline text*/
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
 /* Facebook login method */
 "FACEBOOK"="פייסבוק";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -536,6 +536,10 @@
 "EXTERNAL_REGISTRATION_BECAME_LOGIN" = "あなたは {service} アカウントで既に {platform_name} アカウントを作成済です。そのアカウントでログイン中です。";
 /* Endorsed text */
 "ENDORSED" = "いいね！";
+/*Open in external browser banner message*/
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+/*Open in external browser banner underline text*/
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -548,6 +548,10 @@
 "EXTERNAL_REGISTRATION_BECAME_LOGIN" = "Você já configurou uma conta para {platform_name} com sua conta do {service}. ";
 /* Endorsed text */
 "ENDORSED" = "Endossado";
+/*Open in external browser banner message*/
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+/*Open in external browser banner underline text*/
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -548,6 +548,10 @@
 "EXTERNAL_REGISTRATION_BECAME_LOGIN" = "{platform_name} platformu hesabınızı {service} hesabıyla bağlamışsınız. Bu hesap ile giriş yaptınız.";
 /* Endorsed text */
 "ENDORSED" = "En İyi Cevap Olarak Seçildi";
+/*Open in external browser banner message*/
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+/*Open in external browser banner underline text*/
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -536,6 +536,10 @@
 "EXTERNAL_REGISTRATION_BECAME_LOGIN" = "Tài khoản {platform_name} đã liên kết với tài khoản {service}. Bạn đã đăng nhập với tài khoản đó.";
 /* Endorsed text */
 "ENDORSED" = "Chứng thực";
+/*Open in external browser banner message*/
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+/*Open in external browser banner underline text*/
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -536,6 +536,10 @@
 "EXTERNAL_REGISTRATION_BECAME_LOGIN" = "您已用您的{service}经建立好一个{platform_name}账号。您已经用此账号登录。";
 /* Endorsed text */
 "ENDORSED" = "已认可";
+/*Open in external browser banner message*/
+"OPEN_IN_EXTERNAL_BROWSER.MESSAGE"="This part of course may work best in a web browser.";
+/*Open in external browser banner underline text*/
+"OPEN_IN_EXTERNAL_BROWSER.OPEN_IN_BROSWER"="Open in browser";
 /* Facebook login method */
 "FACEBOOK"="Facebook";
 /* Overlay message shown when facebook login fails because the user's account isn't linked */

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -844,6 +844,7 @@
 		E0241782254043BB00E397EA /* SEGFirebaseIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = E024177F254043BB00E397EA /* SEGFirebaseIntegrationFactory.m */; };
 		E0241783254043BB00E397EA /* SEGFirebaseIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = E0241780254043BB00E397EA /* SEGFirebaseIntegration.m */; };
 		E0241785254043C400E397EA /* read-this-before-update.rtf in Resources */ = {isa = PBXBuildFile; fileRef = E0241784254043C400E397EA /* read-this-before-update.rtf */; };
+		E0249F2B26305486007F9AE1 /* OpenInExternalBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0249F2A26305486007F9AE1 /* OpenInExternalBrowserView.swift */; };
 		E024B0001EC4589800498ECA /* WhatsNewViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E024AFFF1EC4589800498ECA /* WhatsNewViewControllerTests.swift */; };
 		E02661732269A821002721B7 /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E02661672269A821002721B7 /* libOCMock.a */; };
 		E02E59EF1F0E231000060AE0 /* VersionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E02E59EE1F0E231000060AE0 /* VersionParser.swift */; };
@@ -2015,6 +2016,7 @@
 		E0241780254043BB00E397EA /* SEGFirebaseIntegration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEGFirebaseIntegration.m; sourceTree = "<group>"; };
 		E0241781254043BB00E397EA /* SEGFirebaseIntegrationFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEGFirebaseIntegrationFactory.h; sourceTree = "<group>"; };
 		E0241784254043C400E397EA /* read-this-before-update.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = "read-this-before-update.rtf"; sourceTree = "<group>"; };
+		E0249F2A26305486007F9AE1 /* OpenInExternalBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenInExternalBrowserView.swift; sourceTree = "<group>"; };
 		E024AFFF1EC4589800498ECA /* WhatsNewViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhatsNewViewControllerTests.swift; sourceTree = "<group>"; };
 		E02661672269A821002721B7 /* libOCMock.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libOCMock.a; sourceTree = "<group>"; };
 		E02661692269A821002721B7 /* OCMockObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCMockObject.h; sourceTree = "<group>"; };
@@ -3823,6 +3825,7 @@
 				7772BE791AF41E660081CA7A /* CourseBlockViewController.swift */,
 				7772BE951AF9587E0081CA7A /* CourseContentPageViewController.swift */,
 				770C514A1B1685E3009B9696 /* HTMLBlockViewController.swift */,
+				E0249F2A26305486007F9AE1 /* OpenInExternalBrowserView.swift */,
 				7772BE721AF2FECC0081CA7A /* CourseOutlineHeaderCell.swift */,
 				773A047F1AF2E6DA0076532C /* CourseOutlineTableSource.swift */,
 				773A04771AF2D5DE0076532C /* CourseOutlineViewController.swift */,
@@ -5263,6 +5266,7 @@
 				B4B6D62D1A949F1B000F44E8 /* OEXRegistrationFieldCheckBoxController.m in Sources */,
 				77691FA31B3B4596003922F2 /* UIColor+OEXHex.m in Sources */,
 				E01F45671E03D04100B9D7DC /* FirebaseAnalyticsTracker.swift in Sources */,
+				E0249F2B26305486007F9AE1 /* OpenInExternalBrowserView.swift in Sources */,
 				B7CCC724209B16B100A66923 /* ConstraintInsets.swift in Sources */,
 				B7CCC72A209B16B100A66923 /* ConstraintConfig.swift in Sources */,
 				B7CCC72B209B16B100A66923 /* UILayoutSupport+Extensions.swift in Sources */,


### PR DESCRIPTION
### Description

[LEARNER-8360](https://openedx.atlassian.net/browse/LEARNER-8360)

Allow the learner to open a rendered HTML-based xblocks in the external browser. Open in external browser option will be available all the rendered xblocks other than HTML(.Base), video, and discussion xblocks.


### How to test this PR
Open any component like the problem, draganddrop or cloudr-word and open in external option will be available at the bottom of view.