### PR TITLE
[fix] remove warnigs generated by xcode 12.5

### DIFF
--- a/Source/AgreementTextView.swift
+++ b/Source/AgreementTextView.swift
@@ -13,7 +13,7 @@ import UIKit
          signUp
 }
 
-@objc protocol AgreementTextViewDelegate: class {
+@objc protocol AgreementTextViewDelegate: AnyObject {
     func agreementTextView(_ textView: AgreementTextView, didSelect url: URL)
 }
 

--- a/Source/AuthenticatedWebViewController.swift
+++ b/Source/AuthenticatedWebViewController.swift
@@ -36,7 +36,7 @@ private protocol WebContentController {
     func resetState()
 }
 
-@objc protocol WebViewNavigationDelegate: class {
+@objc protocol WebViewNavigationDelegate: AnyObject {
     func webView(_ webView: WKWebView, shouldLoad request: URLRequest) -> Bool
     func webViewContainingController() -> UIViewController
 }
@@ -49,7 +49,7 @@ protocol AuthenticatedWebViewControllerDelegate {
     func authenticatedWebViewController(authenticatedController: AuthenticatedWebViewController, didFinishLoading webview: WKWebView)
 }
 
-@objc protocol AJAXCompletionCallbackDelegate: class {
+@objc protocol AJAXCompletionCallbackDelegate: AnyObject {
     func didCompletionCalled(completion: Bool)
 }
 

--- a/Source/CelebratoryModalViewController.swift
+++ b/Source/CelebratoryModalViewController.swift
@@ -14,7 +14,7 @@ enum ActivityType:String {
     case linkedin = "com.linkedin.LinkedIn.ShareExtension"
 }
 
-protocol CelebratoryModalViewControllerDelegate: class {
+protocol CelebratoryModalViewControllerDelegate: AnyObject {
     func modalDidDismiss()
 }
 

--- a/Source/ChromeCastManager.swift
+++ b/Source/ChromeCastManager.swift
@@ -12,7 +12,7 @@ import GoogleCast
 /// This Protocol handles communication between ChromecastManager and Controller which implements it,
 /// It allows to lisen for connection states, i.e
 /// ConnectedToChromeCast, DisconnectedFromChromeCast, StartPlayingOnChromeCast, FinishedPlayingOnChromecast
-protocol ChromeCastPlayerStatusDelegate: class {
+protocol ChromeCastPlayerStatusDelegate: AnyObject {
     func chromeCastDidConnect()
     func chromeCastDidDisconnect(playedTime: TimeInterval)
     func chromeCastVideoPlaying()

--- a/Source/ContentInsetsController.swift
+++ b/Source/ContentInsetsController.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-public protocol ContentInsetsSourceDelegate : class {
+public protocol ContentInsetsSourceDelegate : AnyObject {
     func contentInsetsSourceChanged(source : ContentInsetsSource)
 }
 
-public protocol ContentInsetsSource : class {
+public protocol ContentInsetsSource : AnyObject {
     var currentInsets: UIEdgeInsets { get }
     var insetsDelegate: ContentInsetsSourceDelegate? { get set }
     var affectsScrollIndicators: Bool { get }

--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol CourseContentPageViewControllerDelegate : class {
+public protocol CourseContentPageViewControllerDelegate : AnyObject {
     func courseContentPageViewController(controller : CourseContentPageViewController, enteredBlockWithID blockID : CourseBlockID, parentID : CourseBlockID)
 }
 

--- a/Source/CourseOutlineTableSource.swift
+++ b/Source/CourseOutlineTableSource.swift
@@ -11,7 +11,7 @@ import UIKit
 private let resumeCourseViewPortraitHeight: CGFloat = 72
 private let resumeCourseViewLandscapeHeight: CGFloat = 52
 
-protocol CourseOutlineTableControllerDelegate: class {
+protocol CourseOutlineTableControllerDelegate: AnyObject {
     func outlineTableController(controller: CourseOutlineTableController, choseBlock block: CourseBlock, parent: CourseBlockID)
     func outlineTableController(controller: CourseOutlineTableController, resumeCourse item: ResumeCourseItem)
     func outlineTableController(controller: CourseOutlineTableController, choseDownloadVideos videos: [OEXHelperVideoDownload], rootedAtBlock block: CourseBlock)

--- a/Source/CourseSectionTableViewCell.swift
+++ b/Source/CourseSectionTableViewCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol CourseSectionTableViewCellDelegate : class {
+protocol CourseSectionTableViewCellDelegate : AnyObject {
     func sectionCellChoseDownload(cell : CourseSectionTableViewCell, videos : [OEXHelperVideoDownload], forBlock block : CourseBlock)
     func sectionCellChoseShowDownloads(cell : CourseSectionTableViewCell)
     func reloadCell(cell: UITableViewCell)

--- a/Source/CourseVideoTableViewCell.swift
+++ b/Source/CourseVideoTableViewCell.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 
-protocol CourseVideoTableViewCellDelegate : class {
+protocol CourseVideoTableViewCellDelegate : AnyObject {
     func videoCellChoseDownload(cell : CourseVideoTableViewCell, block : CourseBlock)
     func videoCellChoseShowDownloads(cell : CourseVideoTableViewCell)
     func reloadCell(cell: UITableViewCell)

--- a/Source/CourseVideosHeaderView.swift
+++ b/Source/CourseVideosHeaderView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol CourseVideosHeaderViewDelegate: class {
+protocol CourseVideosHeaderViewDelegate: AnyObject {
     func courseVideosHeaderViewTapped()
     func invalidOrNoNetworkFound()
 }

--- a/Source/CoursesContainerViewController.swift
+++ b/Source/CoursesContainerViewController.swift
@@ -113,7 +113,7 @@ class CourseCardCell : UICollectionViewCell {
     }
 }
 
-protocol CoursesContainerViewControllerDelegate : class {
+protocol CoursesContainerViewControllerDelegate : AnyObject {
     func coursesContainerChoseCourse(course : OEXCourse)
     func showValuePropDetailView(with course: OEXCourse)
 }

--- a/Source/CutomePlayer/OEXVideoPlayerSettings.swift
+++ b/Source/CutomePlayer/OEXVideoPlayerSettings.swift
@@ -18,7 +18,7 @@ public struct OEXVideoPlayerSetting {
     let callback: (_ value: Any)->()
 }
 
-protocol VideoPlayerSettingsDelegate: class {
+protocol VideoPlayerSettingsDelegate: AnyObject {
     func showSubSettings(chooser: UIAlertController)
     func setCaption(language: String)
     func setPlaybackSpeed(speed: OEXVideoSpeed)

--- a/Source/CutomePlayer/TranscriptManager.swift
+++ b/Source/CutomePlayer/TranscriptManager.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol TranscriptManagerDelegate: class {
+protocol TranscriptManagerDelegate: AnyObject {
     func transcriptsLoaded(manager: TranscriptManager, transcripts: [TranscriptObject])
 }
 

--- a/Source/CutomePlayer/VideoPlayer.swift
+++ b/Source/CutomePlayer/VideoPlayer.swift
@@ -19,7 +19,7 @@ private enum PlayerState {
 private let currentItemStatusKey = "currentItem.status"
 private let currentItemPlaybackLikelyToKeepUpKey = "currentItem.playbackLikelyToKeepUp"
 
-protocol VideoPlayerDelegate: class {
+protocol VideoPlayerDelegate: AnyObject {
     func playerDidFinishLoad(videoPlayer: VideoPlayer)
     func playerDidLoadTranscripts(videoPlayer:VideoPlayer, transcripts: [TranscriptObject])
     func playerWillMoveFromWindow(videoPlayer: VideoPlayer)

--- a/Source/CutomePlayer/VideoPlayerControls.swift
+++ b/Source/CutomePlayer/VideoPlayerControls.swift
@@ -13,7 +13,7 @@ enum SeekType {
     case rewind, forward
 }
 
-protocol VideoPlayerControlsDelegate: class {
+protocol VideoPlayerControlsDelegate: AnyObject {
     func playPausePressed(playerControls: VideoPlayerControls, isPlaying: Bool)
     func seekVideo(playerControls: VideoPlayerControls, skipDuration: Double, type: SeekType)
     func seekVideo(playerControls: VideoPlayerControls, skipDuration: Double, type: SeekType, completion: ((Bool)->())?)

--- a/Source/DiscussionCommentsViewController.swift
+++ b/Source/DiscussionCommentsViewController.swift
@@ -270,7 +270,7 @@ class DiscussionCommentCell: UITableViewCell {
     }
 }
 
-protocol DiscussionCommentsViewControllerDelegate: class {
+protocol DiscussionCommentsViewControllerDelegate: AnyObject {
     
     func discussionCommentsView(controller  : DiscussionCommentsViewController, updatedComment comment: DiscussionComment)
 }

--- a/Source/DiscussionNewCommentViewController.swift
+++ b/Source/DiscussionNewCommentViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol DiscussionNewCommentViewControllerDelegate : class {
+protocol DiscussionNewCommentViewControllerDelegate : AnyObject {
     func newCommentController(controller  : DiscussionNewCommentViewController, addedComment comment: DiscussionComment)
 }
 

--- a/Source/DiscussionNewPostViewController.swift
+++ b/Source/DiscussionNewPostViewController.swift
@@ -16,7 +16,7 @@ struct DiscussionNewThread {
     let rawBody: String
 }
 
-protocol DiscussionNewPostViewControllerDelegate : class {
+protocol DiscussionNewPostViewControllerDelegate : AnyObject {
     func newPostController(controller  : DiscussionNewPostViewController, addedPost post: DiscussionThread)
 }
 

--- a/Source/Icon.swift
+++ b/Source/Icon.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol IconRenderer : class {
+protocol IconRenderer : AnyObject {
     var shouldFlip: Bool { get }
     func boundsWithAttributes(attributes: [NSAttributedString.Key : Any], inline : Bool) -> CGRect
     func drawWithAttributes(attributes: [NSAttributedString.Key : Any], inContext context : CGContext)

--- a/Source/LiveObjectCache.swift
+++ b/Source/LiveObjectCache.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol LifetimeTrackable : class {
+public protocol LifetimeTrackable : AnyObject {
     /// Lifetime should be associated with Self such that it gets deallocated when the object owning
     /// get deallocated
     var lifetimeToken : NSObject { get }

--- a/Source/ProfilePictureTaker.swift
+++ b/Source/ProfilePictureTaker.swift
@@ -10,7 +10,7 @@ import Foundation
 
 import MobileCoreServices
 
-protocol ProfilePictureTakerDelegate : class {
+protocol ProfilePictureTakerDelegate : AnyObject {
     func showImagePickerController(picker: UIImagePickerController)
     func showChooserAlert(alert: UIAlertController)
     func imagePicked(image: UIImage, picker: UIImagePickerController)

--- a/Source/PullRefreshController.swift
+++ b/Source/PullRefreshController.swift
@@ -41,7 +41,7 @@ public class PullRefreshView : UIView {
     }
 }
 
-public protocol PullRefreshControllerDelegate : class {
+public protocol PullRefreshControllerDelegate : AnyObject {
     func refreshControllerActivated(controller : PullRefreshController)
 }
 

--- a/Source/Reachability.m
+++ b/Source/Reachability.m
@@ -384,8 +384,8 @@ static void TMReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkRea
 #pragma mark - Debug Description
 
 - (NSString*)description {
-    NSString* description = [NSString stringWithFormat:@"<%@: %#x>",
-                             NSStringFromClass([self class]), (unsigned int) self];
+    NSString* description = [NSString stringWithFormat:@"<%@: %@>",
+                             NSStringFromClass([self class]), self];
     return description;
 }
 

--- a/Source/ResumeCourseController.swift
+++ b/Source/ResumeCourseController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol ResumeCourseControllerDelegate : class {
+public protocol ResumeCourseControllerDelegate : AnyObject {
     func resumeCourseControllerDidFetchResumeCourseItem(item : ResumeCourseItem?)
 }
 

--- a/Source/ResumeCourseProvider.swift
+++ b/Source/ResumeCourseProvider.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol ResumeCourseProvider: class {
+public protocol ResumeCourseProvider: AnyObject {
     func getResumeCourseBlock(for courseID: String) -> ResumeCourseItem?
     func setResumeCourseBlock(with lastVisitedBlockID: String, lastVisitedBlockName: String, courseID: String?, timeStamp: String)
 }

--- a/Source/SeparatorInsetable.swift
+++ b/Source/SeparatorInsetable.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol SeparatorInsetable : class {
+protocol SeparatorInsetable : AnyObject {
     var separatorInset : UIEdgeInsets { get set }
 }
 

--- a/Source/SnapKit/LayoutConstraintItem.swift
+++ b/Source/SnapKit/LayoutConstraintItem.swift
@@ -28,7 +28,7 @@
 #endif
 
 
-public protocol LayoutConstraintItem: class {
+public protocol LayoutConstraintItem: AnyObject {
 }
 
 @available(iOS 9.0, OSX 10.11, *)

--- a/Source/SubjectsDiscovery/PopularSubjectsViewController.swift
+++ b/Source/SubjectsDiscovery/PopularSubjectsViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol PopularSubjectsViewControllerDelegate: class {
+protocol PopularSubjectsViewControllerDelegate: AnyObject {
     func popularSubjectsViewController(_ controller: PopularSubjectsViewController, didSelect subject: Subject)
     func didSelectViewAllSubjects(_ controller: PopularSubjectsViewController)
 }

--- a/Source/SubjectsDiscovery/SubjectsCollectionView.swift
+++ b/Source/SubjectsDiscovery/SubjectsCollectionView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol SubjectsCollectionViewDelegate: class {
+protocol SubjectsCollectionViewDelegate: AnyObject {
     func subjectsCollectionView(_ collectionView: SubjectsCollectionView, didSelect subject: Subject)
     func didSelectViewAllSubjects(_ collectionView: SubjectsCollectionView)
 }

--- a/Source/SubjectsDiscovery/SubjectsViewController.swift
+++ b/Source/SubjectsDiscovery/SubjectsViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol SubjectsViewControllerDelegate: class {
+protocol SubjectsViewControllerDelegate: AnyObject {
     func subjectsViewController(_ controller: SubjectsViewController, didSelect subject: Subject)
 }
 

--- a/Source/Swipeable Cell/SwipeCellActionView.swift
+++ b/Source/Swipeable Cell/SwipeCellActionView.swift
@@ -35,7 +35,7 @@ enum SwipeState: Int {
     var isActive: Bool { return self != .initial }
 }
 
-protocol SwipeActionsViewDelegate: class {
+protocol SwipeActionsViewDelegate: AnyObject {
     func swipeActionsView(_ swipeCellActionView: SwipeCellActionView, didSelect action: SwipeActionButton)
 }
 

--- a/Source/Swipeable Cell/SwipeableCell.swift
+++ b/Source/Swipeable Cell/SwipeableCell.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol SwipeableCellDelegate: class {
+protocol SwipeableCellDelegate: AnyObject {
     
     // The delegate for the actions to display in response to a swipe in the specified row.
     func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> [SwipeActionButton]?

--- a/Source/UserProfilePresenter.swift
+++ b/Source/UserProfilePresenter.swift
@@ -15,13 +15,13 @@ extension Accomplishment {
     }
 }
 
-protocol UserProfilePresenterDelegate : class {
+protocol UserProfilePresenterDelegate : AnyObject {
     func presenter(presenter: UserProfilePresenter, choseShareURL url: NSURL)
 }
 
 typealias ProfileTabItem = (UIScrollView) -> TabItem
 
-protocol UserProfilePresenter: class {
+protocol UserProfilePresenter: AnyObject {
 
     var profileStream: OEXStream<UserProfile> { get }
     var tabStream: OEXStream<[ProfileTabItem]> { get }

--- a/Source/VideoTranscript.swift
+++ b/Source/VideoTranscript.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol VideoTranscriptDelegate: class {
+protocol VideoTranscriptDelegate: AnyObject {
     func didSelectSubtitleAtInterval(time: TimeInterval)
 }
 


### PR DESCRIPTION
### Description

[LEARNER-8376](https://openedx.atlassian.net/browse/LEARNER-8376)

In Xcode 12.5, protocol conformance to `class` is deprecated and is replaced by `AnyObject`. This PR makes that change and codebase is now supported with latest Xcode 12.5


### How to test this PR

- [x] Remove warnings generated by xcode 12.5