### PR TITLE
[feat] update course calendar on device after shifting course dates

### DIFF
--- a/Source/CalendarManager.swift
+++ b/Source/CalendarManager.swift
@@ -11,7 +11,7 @@ import EventKit
 import EventKitUI
 
 struct CourseCalendar: Codable {
-    let identifier: String
+    var identifier: String
     let courseID: String
     var isOn: Bool
 }
@@ -141,11 +141,13 @@ class CalendarManager: NSObject {
         }
     }
     
-    func removeCalendar(completion: ((Bool)->())? = nil) {
+    func removeCalendar(removeEntry: Bool = true, completion: ((Bool)->())? = nil) {
         guard let calendar = localCalendar else { return }
         do {
             try eventStore.removeCalendar(calendar, commit: true)
-            removeCalendarEntry()
+            if removeEntry {
+                removeCalendarEntry()
+            }
             completion?(true)
         } catch {
             completion?(false)
@@ -218,6 +220,7 @@ class CalendarManager: NSObject {
         if let index = courseCalendars.firstIndex(where: { $0.courseID == courseID }) {
             courseCalendars.modifyElement(atIndex: index) { element in
                 element.isOn = isOn
+                element.identifier = courseCalendar.identifier
             }
         } else {
             courseCalendars.append(courseCalendar)

--- a/Source/CourseDates.swift
+++ b/Source/CourseDates.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 let NOTIFICATION_SHIFT_COURSE_DATES = "ShiftCourseDatesNotification"
+let NOTIFICATION_WILL_SHIFT_COURSE_DATES = "WillShiftCourseDatesNotification"
 
 enum DateBlockStatus {
     case completed

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -156,6 +156,10 @@ class CourseDatesViewController: UIViewController, InterfaceOrientationOverridin
     }
     
     private func addObserver() {
+        NotificationCenter.default.oex_addObserver(observer: self, name: NOTIFICATION_WILL_SHIFT_COURSE_DATES) { _, observer, _ in
+            observer.prepareCalendarForDatesShift()
+        }
+        
         NotificationCenter.default.oex_addObserver(observer: self, name: NOTIFICATION_SHIFT_COURSE_DATES) { _, observer, _ in
             observer.loadStreams()
         }
@@ -296,23 +300,26 @@ class CourseDatesViewController: UIViewController, InterfaceOrientationOverridin
         }
     }
     
-    private func resetCourseDate() {
-        trackDatesShiftTapped()
-        
+    private func prepareCalendarForDatesShift() {
         if calendar.calendarState {
             syncCourseCalendarAfterCourseDatesReset = true
             removeCourseCalendar(removeEntry: false)
         }
+    }
+    
+    private func resetCourseDate() {
+        trackDatesShiftTapped()
+        prepareCalendarForDatesShift()
         
         let request = CourseDateBannerAPI.courseDatesResetRequest(courseID: courseID)
         environment.networkManager.taskForRequest(request) { [weak self] result  in
             guard let weakSelf = self else { return }
             if let _ = result.error {
                 weakSelf.trackDatesShiftEvent(success: false)
-                weakSelf.showDateResetSnackBar(message: Strings.Coursedates.ResetDate.errorMessage)
+                weakSelf.showCalendarActionSnackBar(message: Strings.Coursedates.ResetDate.errorMessage)
             } else {
                 weakSelf.trackDatesShiftEvent(success: true)
-                weakSelf.showDateResetSnackBar(message: Strings.Coursedates.ResetDate.successMessage)
+                weakSelf.showCalendarActionSnackBar(message: Strings.Coursedates.ResetDate.successMessage)
                 weakSelf.postCourseDateResetNotification()
             }
         }

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -355,6 +355,7 @@ public class CourseOutlineViewController :
     }
     
     private func postCourseDateResetNotification() {
+        NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: NOTIFICATION_WILL_SHIFT_COURSE_DATES)))
         NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: NOTIFICATION_SHIFT_COURSE_DATES)))
     }
     

--- a/Source/HTMLBlockViewController.swift
+++ b/Source/HTMLBlockViewController.swift
@@ -232,6 +232,7 @@ class HTMLBlockViewController: UIViewController, CourseBlockViewController, Prel
     }
     
     private func courseDatesResetSuccess() {
+        NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: NOTIFICATION_WILL_SHIFT_COURSE_DATES)))
         NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: NOTIFICATION_SHIFT_COURSE_DATES)))
         showSnackBar()
     }


### PR DESCRIPTION
### Description

[LEARNER-8303](https://openedx.atlassian.net/browse/LEARNER-8303)

When Course Dates calendar sync is turned on, after user shifts course dates, events on the calendar must be changes to reflect new dates.

### How to test this PR

- [ ] If syncing is on, "Shift Dates" CTA edits the dates/times of the calendar events to reflect the new dates/times on the Course Dates page.  Event changes are visible in the calendar
- [ ] If syncing in off, nothing should happen related to calendar
