### PR TITLE
[feat] handle calendar presentation modal

### DIFF
--- a/Source/CalendarManager.swift
+++ b/Source/CalendarManager.swift
@@ -157,6 +157,8 @@ class CalendarManager: NSObject {
             try eventStore.removeCalendar(calendar, commit: true)
             if removeEntry {
                 removeCalendarEntry()
+            } else {
+                turnOffCalendar()
             }
             completion?(true)
         } catch {
@@ -290,6 +292,23 @@ class CalendarManager: NSObject {
         
         if let index = courseCalendars.firstIndex(where: { $0.courseID == courseID }) {
             courseCalendars.remove(at: index)
+        }
+        
+        if let data = try? PropertyListEncoder().encode(courseCalendars) {
+            UserDefaults.standard.set(data, forKey: calendarKey)
+            UserDefaults.standard.synchronize()
+        }
+    }
+    
+    private func turnOffCalendar() {
+        guard let data = UserDefaults.standard.data(forKey: calendarKey),
+              var courseCalendars = try? PropertyListDecoder().decode([CourseCalendar].self, from: data)
+        else { return }
+        
+        if let index = courseCalendars.firstIndex(where: { $0.courseID == courseID }) {
+            courseCalendars.modifyElement(atIndex: index) { element in
+                element.isOn = false
+            }
         }
         
         if let data = try? PropertyListEncoder().encode(courseCalendars) {

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -102,9 +102,9 @@ class CourseDatesViewController: UIViewController, InterfaceOrientationOverridin
                 }
             } else {
                 trackCalendarEvent(for: .CalendarToggleOff, eventName: .CalendarToggleOff)
-                removeCourseCalendar { [weak self] success in
+                removeCourseCalendar(removeEntry: false) { [weak self] success in
                     if success {
-                        self?.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsRemoved, delay: 2)
+                        self?.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsRemoved, duration: 2)
                     }
                 }
             }
@@ -410,13 +410,24 @@ extension CourseDatesViewController {
     }
     
     private func eventsAddedSuccessAlert() {
+        guard !calendar.isModalPresented else {
+            showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsAdded, duration: 2)
+            return
+        }
+        
         let title = Strings.Coursedates.datesAddedAlertMessage(calendarName: calendar.calendarName)
         let alertController = UIAlertController().showAlert(withTitle: title, message: "", cancelButtonTitle: nil, onViewController: self) { _, _, _ in }
         
+        alertController.addButton(withTitle: Strings.Coursedates.calendarViewEvents) { _ in
+            guard let url = URL(string: "calshow://") else { return }
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+        
         alertController.addButton(withTitle: Strings.ok) { [weak self] _ in
             self?.trackCalendarEvent(for: .CalendarAddConfirmation, eventName: .CalendarAddConfirmation)
-            self?.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsAdded, delay: 2)
         }
+        
+        calendar.isModalPresented = true
     }
     
     private func trackCalendarEvent(for displayName: AnalyticsDisplayName, eventName: AnalyticsEventName) {

--- a/Source/UIViewController+Overlay.swift
+++ b/Source/UIViewController+Overlay.swift
@@ -181,14 +181,14 @@ extension UIViewController {
         }
     }
     
-    func showCalendarActionSnackBar(message: String, autoDismiss: Bool = true, delay: TimeInterval = 5) {
+    func showCalendarActionSnackBar(message: String, autoDismiss: Bool = true, duration: TimeInterval = 5) {
         let hideInfo = objc_getAssociatedObject(self, &SnackBarHideActionKey) as? Box<TemporaryViewRemovalInfo>
         hideInfo?.value.action()
         let view = CalendarActionToastView(message: message)
         view.layer.cornerRadius = 4
         showSnackBarView(snackBarView: view, addOffset: true)
         if autoDismiss {
-            perform(#selector(hideSnackBar), with: nil, afterDelay: delay)
+            perform(#selector(hideSnackBar), with: nil, afterDelay: duration)
         }
     }
 }

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -352,6 +352,8 @@
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
 /* Course Dates Open Settings */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates View Events in Calendar */
+"COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */
 "CANCEL"="إلغاء";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
 /* Course Dates Open Settings */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates View Events in Calendar */
+"COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */
 "CANCEL"="Abbrechen";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
 /* Course Dates Open Settings */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates View Events in Calendar */
+"COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */
 "CANCEL"="Cancel";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
 /* Course Dates Open Settings */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates View Events in Calendar */
+"COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */
 "CANCEL"="Cancelar";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
 /* Course Dates Open Settings */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates View Events in Calendar */
+"COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */
 "CANCEL"="Annuler";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -344,6 +344,8 @@
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
 /* Course Dates Open Settings */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates View Events in Calendar */
+"COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */
 "CANCEL"="ביטול";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -332,6 +332,8 @@
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
 /* Course Dates Open Settings */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates View Events in Calendar */
+"COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */
 "CANCEL"="キャンセル";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
 /* Course Dates Open Settings */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates View Events in Calendar */
+"COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */
 "CANCEL"="Cancelar";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -336,6 +336,8 @@
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
 /* Course Dates Open Settings */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates View Events in Calendar */
+"COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */
 "CANCEL"="İptal";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -332,6 +332,8 @@
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
 /* Course Dates Open Settings */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates View Events in Calendar */
+"COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */
 "CANCEL"="Hủy";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -332,6 +332,8 @@
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
 /* Course Dates Open Settings */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates View Events in Calendar */
+"COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */
 "CANCEL"="取消";
 /* Alert explaining charges will apply since the "Wi-fi only" switch was turned off */


### PR DESCRIPTION
### Description

[LEARNER-8353](https://openedx.atlassian.net/browse/LEARNER-8353)

For each course, the first time sync is turned on, a native alert shows with the copy “<Calendar Name>” has been added to your calendar.


### How to test this PR

The displayed alert has two options

- [ ] Done - Dismisses the alert
- [ ] View events - dismisses the alert and brings the user to their calendar app
- [ ] The alert is not shown after the first sync (i.e., not more than once per course)

