### PR TITLE
[feat] shift course calendar events after shift due date

### DIFF
--- a/Source/CalendarManager.swift
+++ b/Source/CalendarManager.swift
@@ -15,7 +15,7 @@ struct CourseCalendar: Codable {
     let courseID: String
     var isOn: Bool
     var modalPresented: Bool
-    var needShifting: Bool = false
+    var syncRequired: Bool = false
 }
 
 class CalendarManager: NSObject {
@@ -95,12 +95,12 @@ class CalendarManager: NSObject {
         }
     }
     
-    var needShifting: Bool {
+    var syncRequired: Bool {
         set {
-            setShiftState(needShifting: newValue)
+            setSyncState(state: newValue)
         }
         get {
-            return getShiftState()
+            return getSyncState()
         }
     }
     
@@ -308,24 +308,24 @@ class CalendarManager: NSObject {
         return calendar.modalPresented
     }
     
-    private func setShiftState(needShifting: Bool) {
+    private func setSyncState(state: Bool) {
         guard var calendars = courseCalendars(),
               let index = calendars.firstIndex(where: { $0.courseID == courseID })
         else { return }
         
         calendars.modifyElement(atIndex: index) { element in
-            element.needShifting = needShifting
+            element.syncRequired = state
         }
         
         saveCalendarEntry(calendars: calendars)
     }
     
-    private func getShiftState() -> Bool {
+    private func getSyncState() -> Bool {
         guard let calendars = courseCalendars(),
               let calendar = calendars.first(where: { $0.courseID == courseID })
         else { return false }
         
-        return calendar.needShifting
+        return calendar.syncRequired
     }
     
     private func removeCalendarEntry() {

--- a/Source/CalendarManager.swift
+++ b/Source/CalendarManager.swift
@@ -15,6 +15,7 @@ struct CourseCalendar: Codable {
     let courseID: String
     var isOn: Bool
     var modalPresented: Bool
+    var needShifting: Bool = false
 }
 
 class CalendarManager: NSObject {
@@ -91,6 +92,15 @@ class CalendarManager: NSObject {
         }
         get {
             return getModalPresented()
+        }
+    }
+    
+    var needShifting: Bool {
+        set {
+            setShiftState(needShifting: newValue)
+        }
+        get {
+            return getShiftState()
         }
     }
     
@@ -296,6 +306,26 @@ class CalendarManager: NSObject {
         else { return false }
         
         return calendar.modalPresented
+    }
+    
+    private func setShiftState(needShifting: Bool) {
+        guard var calendars = courseCalendars(),
+              let index = calendars.firstIndex(where: { $0.courseID == courseID })
+        else { return }
+        
+        calendars.modifyElement(atIndex: index) { element in
+            element.needShifting = needShifting
+        }
+        
+        saveCalendarEntry(calendars: calendars)
+    }
+    
+    private func getShiftState() -> Bool {
+        guard let calendars = courseCalendars(),
+              let calendar = calendars.first(where: { $0.courseID == courseID })
+        else { return false }
+        
+        return calendar.needShifting
     }
     
     private func removeCalendarEntry() {

--- a/Source/CalendarManager.swift
+++ b/Source/CalendarManager.swift
@@ -138,7 +138,6 @@ class CalendarManager: NSObject {
         }
         
         let events = generateEvents(for: dateBlocks)
-        
         let allEvents = events.allSatisfy { alreadyExist(event: $0) }
         
         return !allEvents

--- a/Source/CalendarManager.swift
+++ b/Source/CalendarManager.swift
@@ -15,7 +15,6 @@ struct CourseCalendar: Codable {
     let courseID: String
     var isOn: Bool
     var modalPresented: Bool
-    var syncRequired: Bool = false
 }
 
 class CalendarManager: NSObject {
@@ -92,15 +91,6 @@ class CalendarManager: NSObject {
         }
         get {
             return getModalPresented()
-        }
-    }
-    
-    var syncRequired: Bool {
-        set {
-            setSyncState(state: newValue)
-        }
-        get {
-            return getSyncState()
         }
     }
     
@@ -306,26 +296,6 @@ class CalendarManager: NSObject {
         else { return false }
         
         return calendar.modalPresented
-    }
-    
-    private func setSyncState(state: Bool) {
-        guard var calendars = courseCalendars(),
-              let index = calendars.firstIndex(where: { $0.courseID == courseID })
-        else { return }
-        
-        calendars.modifyElement(atIndex: index) { element in
-            element.syncRequired = state
-        }
-        
-        saveCalendarEntry(calendars: calendars)
-    }
-    
-    private func getSyncState() -> Bool {
-        guard let calendars = courseCalendars(),
-              let calendar = calendars.first(where: { $0.courseID == courseID })
-        else { return false }
-        
-        return calendar.syncRequired
     }
     
     private func removeCalendarEntry() {

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -391,6 +391,8 @@ extension CourseDatesViewController {
         
         let alertController = UIAlertController().showAlert(withTitle: title, message: message, cancelButtonTitle: Strings.Coursedates.calendarShiftPromptRemoveCourseCalendar, onViewController: topController) { [weak self] _, _, index in
             if index == UIAlertControllerBlocksCancelButtonIndex {
+                self.trackCalendarEvent(for: .CalendarSyncRemoveCalendar, eventName: .CalendarSyncRemoveCalendar)
+                
                 self?.removeCourseCalendar { [weak self] success in
                     if success {
                         topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsRemoved)
@@ -401,6 +403,8 @@ extension CourseDatesViewController {
         }
         
         alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptUpdateNow) { [weak self] _ in
+            self.trackCalendarEvent(for: .CalendarSyncUpdateDates, eventName: .CalendarSyncUpdateDates)
+            
             self?.removeCourseCalendar { [weak self] _ in
                 self?.addCourseEvents { [weak self] success in
                     if success {

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -376,9 +376,36 @@ extension CourseDatesViewController {
     private func addCourseEventsIfNecessary() {
         if datesShifted && calendar.syncOn {
             datesShifted = false
-            removeCourseCalendar { [weak self] _ in
+            
+            if calendar.checkIfEventsShouldBeShifted(for: dateBlocks) {
+                showCalendarEventShiftAlert()
+            }
+        }
+    }
+    
+    private func showCalendarEventShiftAlert() {
+        guard let topController = UIApplication.shared.topMostController() else {
+            return
+        }
+        
+        let title = Strings.Coursedates.calendarOutOfDate
+        let message = Strings.Coursedates.calendarShiftMessage
+
+        let alertController = UIAlertController().showAlert(withTitle: title, message: message, cancelButtonTitle: Strings.Coursedates.calendarShiftPromptRemoveCourseCalendar, onViewController: topController) { [weak self] _, _, index in
+            if index == UIAlertControllerBlocksCancelButtonIndex {
+                self?.removeCourseCalendar(completion: { [weak self] success in
+                    if success {
+                        self?.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsRemoved)
+                    }
+                })
+            }
+        }
+        
+        alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptUpdateNow) { [weak self] _ in
+            self?.removeCourseCalendar { [weak self] _ in
                 self?.addCourseEvents { [weak self] success in
                     if success {
+                        self?.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsUpdated)
                         self?.trackCalendarEvent(for: .CalendarUpdateDatesSuccess, eventName: .CalendarUpdateDatesSuccess, syncReason: .direct)
                     }
                 }

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -384,20 +384,18 @@ extension CourseDatesViewController {
     }
     
     private func showCalendarEventShiftAlert() {
-        guard let topController = UIApplication.shared.topMostController() else {
-            return
-        }
+        guard let topController = UIApplication.shared.topMostController() else { return }
         
         let title = Strings.Coursedates.calendarOutOfDate
         let message = Strings.Coursedates.calendarShiftMessage
-
+        
         let alertController = UIAlertController().showAlert(withTitle: title, message: message, cancelButtonTitle: Strings.Coursedates.calendarShiftPromptRemoveCourseCalendar, onViewController: topController) { [weak self] _, _, index in
             if index == UIAlertControllerBlocksCancelButtonIndex {
-                self?.removeCourseCalendar(completion: { [weak self] success in
+                self?.removeCourseCalendar { success in
                     if success {
-                        self?.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsRemoved)
+                        topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsRemoved)
                     }
-                })
+                }
             }
         }
         
@@ -405,7 +403,7 @@ extension CourseDatesViewController {
             self?.removeCourseCalendar { [weak self] _ in
                 self?.addCourseEvents { [weak self] success in
                     if success {
-                        self?.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsUpdated)
+                        topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsUpdated)
                         self?.trackCalendarEvent(for: .CalendarUpdateDatesSuccess, eventName: .CalendarUpdateDatesSuccess, syncReason: .direct)
                     }
                 }

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -55,7 +55,6 @@ class CourseDatesViewController: UIViewController, InterfaceOrientationOverridin
     private var dateBlocksMapSortedKeys: [Date] = []
     private var isDueNextSet = false
     private var dueNextCellIndex: Int?
-    private var datesShifted = false
     
     private let courseID: String
     private let environment: Environment
@@ -165,7 +164,7 @@ class CourseDatesViewController: UIViewController, InterfaceOrientationOverridin
     
     private func addObserver() {
         NotificationCenter.default.oex_addObserver(observer: self, name: NOTIFICATION_SHIFT_COURSE_DATES) { _, observer, _ in
-            observer.datesShifted = true
+            observer.calendar.needShifting = true
             observer.loadStreams()
         }
     }
@@ -364,10 +363,11 @@ extension CourseDatesViewController {
     }
     
     private func addCourseEventsIfNecessary() {
-        if datesShifted && calendar.syncOn {
-            datesShifted = false
-            removeCourseCalendar()
-            addCourseEvents()
+        if calendar.needShifting && calendar.syncOn {
+            calendar.needShifting = false
+            removeCourseCalendar { [weak self] _ in
+                self?.addCourseEvents()
+            }
         }
     }
     
@@ -462,7 +462,7 @@ extension CourseDatesViewController: UITableViewDataSource {
             cell.timeline.bottomColor = .clear
         } else {
             cell.timeline.topColor = environment.styles.neutralXDark()
-            cell.timeline.bottomColor = environment.styles.neutralBlackT()
+            cell.timeline.bottomColor = environment.styles.neutralXDark()
         }
         
         guard let blocks = dateBlocks[key] else { return cell }

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -391,7 +391,7 @@ extension CourseDatesViewController {
         
         let alertController = UIAlertController().showAlert(withTitle: title, message: message, cancelButtonTitle: Strings.Coursedates.calendarShiftPromptRemoveCourseCalendar, onViewController: topController) { [weak self] _, _, index in
             if index == UIAlertControllerBlocksCancelButtonIndex {
-                self.trackCalendarEvent(for: .CalendarSyncRemoveCalendar, eventName: .CalendarSyncRemoveCalendar)
+                self?.trackCalendarEvent(for: .CalendarSyncRemoveCalendar, eventName: .CalendarSyncRemoveCalendar)
                 
                 self?.removeCourseCalendar { [weak self] success in
                     if success {
@@ -403,10 +403,10 @@ extension CourseDatesViewController {
         }
         
         alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptUpdateNow) { [weak self] _ in
-            self.trackCalendarEvent(for: .CalendarSyncUpdateDates, eventName: .CalendarSyncUpdateDates)
+            self?.trackCalendarEvent(for: .CalendarSyncUpdateDates, eventName: .CalendarSyncUpdateDates)
             
-            self?.removeCourseCalendar { [weak self] _ in
-                self?.addCourseEvents { [weak self] success in
+            self?.removeCourseCalendar(shouldTrackEvent: false) { [weak self] _ in
+                self?.addCourseEvents(shouldTrackEvent: false) { [weak self] success in
                     if success {
                         topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsUpdated)
                         self?.trackCalendarEvent(for: .CalendarUpdateDatesSuccess, eventName: .CalendarUpdateDatesSuccess, syncReason: .direct)
@@ -416,10 +416,12 @@ extension CourseDatesViewController {
         }
     }
     
-    private func addCourseEvents(completion: ((Bool)->())? = nil) {
+    private func addCourseEvents(shouldTrackEvent: Bool = true, completion: ((Bool)->())? = nil) {
         calendar.addEventsToCalendar(for: dateBlocks) { [weak self] success in
             if success {
-                self?.trackCalendarEvent(for: .CalendarAddDatesSuccess, eventName: .CalendarAddDatesSuccess)
+                if shouldTrackEvent {
+                    self?.trackCalendarEvent(for: .CalendarAddDatesSuccess, eventName: .CalendarAddDatesSuccess)
+                }
                 self?.calendar.syncOn = success
                 self?.eventsAddedSuccessAlert()
             }
@@ -428,9 +430,9 @@ extension CourseDatesViewController {
         }
     }
     
-    private func removeCourseCalendar(completion: ((Bool)->())? = nil) {
+    private func removeCourseCalendar(shouldTrackEvent: Bool = true, completion: ((Bool)->())? = nil) {
         calendar.removeCalendar { [weak self] success in
-            if success {
+            if success && shouldTrackEvent {
                 self?.trackCalendarEvent(for: .CalendarRemoveDatesSuccess, eventName: .CalendarRemoveDatesSuccess)
             }
             completion?(success)

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -401,7 +401,7 @@ extension CourseDatesViewController {
             self?.trackCalendarEvent(for: .CalendarSyncUpdateDates, eventName: .CalendarSyncUpdateDates)
             
             self?.removeCourseCalendar(trackAnalytics: false) { [weak self] _ in
-                self?.addCourseEvents(shouldTrackEvent: false) { [weak self] success in
+                self?.addCourseEvents(trackAnalytics: false) { [weak self] success in
                     if success {
                         topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsUpdated)
                         self?.trackCalendarEvent(for: .CalendarUpdateDatesSuccess, eventName: .CalendarUpdateDatesSuccess, syncReason: .direct)
@@ -411,10 +411,10 @@ extension CourseDatesViewController {
         }
     }
     
-    private func addCourseEvents(shouldTrackEvent: Bool = true, completion: ((Bool)->())? = nil) {
+    private func addCourseEvents(trackAnalytics: Bool = true, completion: ((Bool)->())? = nil) {
         calendar.addEventsToCalendar(for: dateBlocks) { [weak self] success in
             if success {
-                if shouldTrackEvent {
+                if trackAnalytics {
                     self?.trackCalendarEvent(for: .CalendarAddDatesSuccess, eventName: .CalendarAddDatesSuccess)
                 }
                 self?.calendar.syncOn = success

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -174,7 +174,7 @@ class CourseDatesViewController: UIViewController, InterfaceOrientationOverridin
     
     private func addObserver() {
         NotificationCenter.default.oex_addObserver(observer: self, name: NOTIFICATION_SHIFT_COURSE_DATES) { _, observer, _ in
-            observer.calendar.needShifting = true
+            observer.calendar.syncRequired = true
             observer.loadStreams()
         }
     }
@@ -372,8 +372,8 @@ extension CourseDatesViewController {
     }
     
     private func addCourseEventsIfNecessary() {
-        if calendar.needShifting && calendar.syncOn {
-            calendar.needShifting = false
+        if calendar.syncRequired && calendar.syncOn {
+            calendar.syncRequired = false
             removeCourseCalendar { [weak self] _ in
                 self?.addCourseEvents { [weak self] success in
                     if success {

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -391,9 +391,10 @@ extension CourseDatesViewController {
         
         let alertController = UIAlertController().showAlert(withTitle: title, message: message, cancelButtonTitle: Strings.Coursedates.calendarShiftPromptRemoveCourseCalendar, onViewController: topController) { [weak self] _, _, index in
             if index == UIAlertControllerBlocksCancelButtonIndex {
-                self?.removeCourseCalendar { success in
+                self?.removeCourseCalendar { [weak self] success in
                     if success {
                         topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsRemoved)
+                        self?.courseDatesHeaderView.syncState = false
                     }
                 }
             }

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -148,10 +148,6 @@ class CourseDatesViewController: UIViewController, InterfaceOrientationOverridin
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         environment.analytics.trackScreen(withName: AnalyticsScreenName.CourseDates.rawValue, courseID: courseID, value: nil)
@@ -355,12 +351,11 @@ class CourseDatesViewController: UIViewController, InterfaceOrientationOverridin
 
 extension CourseDatesViewController {
     private func showCalendarSettingsAlert() {
-        guard let topController = UIApplication.shared.topMostController(),
-            let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
             return
         }
         let message = Strings.Coursedates.calendarPermissionNotDetermined(platformName: platformName)
-        let alertController = UIAlertController().showAlert(withTitle: Strings.settings, message: message, cancelButtonTitle: Strings.cancel, onViewController: topController) { [weak self] _, _, index in
+        let alertController = UIAlertController().showAlert(withTitle: Strings.settings, message: message, cancelButtonTitle: Strings.cancel, onViewController: self) { [weak self] _, _, index in
             if index == UIAlertControllerBlocksCancelButtonIndex {
                 self?.courseDatesHeaderView.syncState = false
             }
@@ -405,7 +400,7 @@ extension CourseDatesViewController {
         alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptUpdateNow) { [weak self] _ in
             self?.trackCalendarEvent(for: .CalendarSyncUpdateDates, eventName: .CalendarSyncUpdateDates)
             
-            self?.removeCourseCalendar(shouldTrackEvent: false) { [weak self] _ in
+            self?.removeCourseCalendar(trackAnalytics: false) { [weak self] _ in
                 self?.addCourseEvents(shouldTrackEvent: false) { [weak self] success in
                     if success {
                         topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsUpdated)
@@ -430,9 +425,9 @@ extension CourseDatesViewController {
         }
     }
     
-    private func removeCourseCalendar(shouldTrackEvent: Bool = true, completion: ((Bool)->())? = nil) {
+    private func removeCourseCalendar(trackAnalytics: Bool = true, completion: ((Bool)->())? = nil) {
         calendar.removeCalendar { [weak self] success in
-            if success && shouldTrackEvent {
+            if success && trackAnalytics {
                 self?.trackCalendarEvent(for: .CalendarRemoveDatesSuccess, eventName: .CalendarRemoveDatesSuccess)
             }
             completion?(success)
@@ -440,12 +435,10 @@ extension CourseDatesViewController {
     }
     
     private func showAlertForCalendarPrompt() {
-        guard let topController = UIApplication.shared.topMostController() else { return }
-        
         let title = Strings.Coursedates.addCalendarTitle(calendarName: calendar.calendarName)
         let message = Strings.Coursedates.addCalendarPrompt(platformName: platformName, calendarName: calendar.calendarName)
         
-        let alertController = UIAlertController().showAlert(withTitle: title, message: message, cancelButtonTitle: Strings.cancel, onViewController: topController) { [weak self] _, _, index in
+        let alertController = UIAlertController().showAlert(withTitle: title, message: message, cancelButtonTitle: Strings.cancel, onViewController: self) { [weak self] _, _, index in
             if index == UIAlertControllerBlocksCancelButtonIndex {
                 self?.courseDatesHeaderView.syncState = false
                 self?.calendar.syncOn = false

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -343,7 +343,7 @@ public class CourseOutlineViewController :
     private func setCalendarShiftState() {
         guard let courseName = course?.name else { return }
         let calendar = CalendarManager(courseID: courseID, courseName: courseName)
-        calendar.needShifting = true
+        calendar.syncRequired = true
     }
     
     private func trackDatesShiftTapped() {

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -327,23 +327,15 @@ public class CourseOutlineViewController :
         
         let request = CourseDateBannerAPI.courseDatesResetRequest(courseID: courseID)
         environment.networkManager.taskForRequest(request) { [weak self] result  in
-            guard let weakSelf = self else { return }
             if let _ = result.error {
-                weakSelf.trackDatesShiftEvent(success: false)
-                weakSelf.showDateResetSnackBar(message: Strings.Coursedates.ResetDate.errorMessage)
+                self?.trackDatesShiftEvent(success: false)
+                self?.showDateResetSnackBar(message: Strings.Coursedates.ResetDate.errorMessage)
             } else {
-                weakSelf.trackDatesShiftEvent(success: true)
-                weakSelf.showSnackBar()
-                weakSelf.setCalendarShiftState()
-                weakSelf.postCourseDateResetNotification()
+                self?.trackDatesShiftEvent(success: true)
+                self?.showSnackBar()
+                self?.postCourseDateResetNotification()
             }
         }
-    }
-    
-    private func setCalendarShiftState() {
-        guard let courseName = course?.name else { return }
-        let calendar = CalendarManager(courseID: courseID, courseName: courseName)
-        calendar.syncRequired = true
     }
     
     private func trackDatesShiftTapped() {

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -61,6 +61,10 @@ public class CourseOutlineViewController :
         return courseQuerier.blockWithID(id: blockID).value
     }
     
+    private var course: OEXCourse? {
+        return environment.dataManager.enrollmentManager.enrolledCourseWithID(courseID: courseID)?.course
+    }
+    
     public init(environment: Environment, courseID : String, rootID : CourseBlockID?, forMode mode: CourseOutlineMode?) {
         self.rootID = rootID
         self.environment = environment
@@ -211,7 +215,7 @@ public class CourseOutlineViewController :
     }
     
     private func handleDatesBanner(courseBanner: CourseDateBannerModel) {
-        guard let isSelfPaced = environment.dataManager.enrollmentManager.enrolledCourseWithID(courseID: courseID)?.course.isSelfPaced else {
+        guard let isSelfPaced = course?.isSelfPaced else {
             hideCourseBannerView()
             return
         }
@@ -330,9 +334,16 @@ public class CourseOutlineViewController :
             } else {
                 weakSelf.trackDatesShiftEvent(success: true)
                 weakSelf.showSnackBar()
+                weakSelf.setCalendarShiftState()
                 weakSelf.postCourseDateResetNotification()
             }
         }
+    }
+    
+    private func setCalendarShiftState() {
+        guard let courseName = course?.name else { return }
+        let calendar = CalendarManager(courseID: courseID, courseName: courseName)
+        calendar.needShifting = true
     }
     
     private func trackDatesShiftTapped() {

--- a/Source/HTMLBlockViewController.swift
+++ b/Source/HTMLBlockViewController.swift
@@ -194,13 +194,15 @@ class HTMLBlockViewController: UIViewController, CourseBlockViewController, Prel
         trackDatesShiftTapped()
         
         let request = CourseDateBannerAPI.courseDatesResetRequest(courseID: courseID)
-        environment.networkManager.taskForRequest(request) { [weak self] result  in
+        environment.networkManager.taskForRequest(request) { [weak self] result in
             if let _ = result.error {
                 self?.trackDatesShiftEvent(success: false)
                 self?.showDateResetSnackBar(message: Strings.Coursedates.ResetDate.errorMessage)
             } else {
                 self?.trackDatesShiftEvent(success: true)
-                self?.courseDatesResetSuccess()
+                self?.setCalendarShiftState()
+                self?.showSnackBar()
+                self?.postCourseDateResetNotification()
             }
         }
     }
@@ -231,9 +233,14 @@ class HTMLBlockViewController: UIViewController, CourseBlockViewController, Prel
         }
     }
     
-    private func courseDatesResetSuccess() {
+    private func postCourseDateResetNotification() {
         NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: NOTIFICATION_SHIFT_COURSE_DATES)))
-        showSnackBar()
+    }
+    
+    private func setCalendarShiftState() {
+        guard let courseName = environment.dataManager.enrollmentManager.enrolledCourseWithID(courseID: courseID)?.course.name else { return }
+        let calendar = CalendarManager(courseID: courseID, courseName: courseName)
+        calendar.needShifting = true
     }
     
     private func markBlockAsComplete() {

--- a/Source/HTMLBlockViewController.swift
+++ b/Source/HTMLBlockViewController.swift
@@ -200,7 +200,6 @@ class HTMLBlockViewController: UIViewController, CourseBlockViewController, Prel
                 self?.showDateResetSnackBar(message: Strings.Coursedates.ResetDate.errorMessage)
             } else {
                 self?.trackDatesShiftEvent(success: true)
-                self?.setCalendarShiftState()
                 self?.showSnackBar()
                 self?.postCourseDateResetNotification()
             }
@@ -235,12 +234,6 @@ class HTMLBlockViewController: UIViewController, CourseBlockViewController, Prel
     
     private func postCourseDateResetNotification() {
         NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: NOTIFICATION_SHIFT_COURSE_DATES)))
-    }
-    
-    private func setCalendarShiftState() {
-        guard let courseName = environment.dataManager.enrollmentManager.enrolledCourseWithID(courseID: courseID)?.course.name else { return }
-        let calendar = CalendarManager(courseID: courseID, courseName: courseName)
-        calendar.syncRequired = true
     }
     
     private func markBlockAsComplete() {

--- a/Source/HTMLBlockViewController.swift
+++ b/Source/HTMLBlockViewController.swift
@@ -240,7 +240,7 @@ class HTMLBlockViewController: UIViewController, CourseBlockViewController, Prel
     private func setCalendarShiftState() {
         guard let courseName = environment.dataManager.enrollmentManager.enrolledCourseWithID(courseID: courseID)?.course.name else { return }
         let calendar = CalendarManager(courseID: courseID, courseName: courseName)
-        calendar.needShifting = true
+        calendar.syncRequired = true
     }
     
     private func markBlockAsComplete() {

--- a/Source/OEXAnalytics+Swift.swift
+++ b/Source/OEXAnalytics+Swift.swift
@@ -159,6 +159,7 @@ public enum AnalyticsEventDataKey: String {
     case Link = "link"
     case Pacing = "pacing"
     case UserType = "user_type"
+    case SyncReason = "sync_reason"
     case SpecialExamInfo = "special_exam_info"
 }
 
@@ -444,16 +445,18 @@ extension OEXAnalytics {
         trackEvent(event, forComponent: nil, withInfo: [key_course_id: courseID, OEXAnalyticsKeyBlockID: blockID])
     }
     
-    func trackCalendarEvent(displayName: AnalyticsDisplayName, eventName: AnalyticsEventName, userType: String, pacing: String, courseID: String) {
+    func trackCalendarEvent(displayName: AnalyticsDisplayName, eventName: AnalyticsEventName, userType: String, pacing: String, courseID: String, syncReason: String? = nil) {
         let event = OEXAnalyticsEvent()
         event.displayName = displayName.rawValue
         event.name = eventName.rawValue
         
-        let info = [
+        var info = [
             AnalyticsEventDataKey.UserType.rawValue: userType,
             AnalyticsEventDataKey.Pacing.rawValue: pacing,
             key_course_id: courseID
         ]
+        
+        info.setObjectOrNil(syncReason, forKey: AnalyticsEventDataKey.SyncReason.rawValue)
         
         trackEvent(event, forComponent: nil, withInfo: info)
     }

--- a/Source/OEXAnalytics+Swift.swift
+++ b/Source/OEXAnalytics+Swift.swift
@@ -58,6 +58,8 @@ public enum AnalyticsDisplayName : String {
     case CalendarAddDatesSuccess = "Dates: Calendar Add Dates Success"
     case CalendarRemoveDatesSuccess = "Dates: Calendar Remove Dates Success"
     case CalendarUpdateDatesSuccess = "Dates: Calendar Update Dates Success"
+    case CalendarSyncUpdateDates = "Dates: Calendar Sync Update Dates"
+    case CalendarSyncRemoveCalendar = "Dates: Calendar Sync Remove Calendar"
     case SubsectionViewOnWebTapped = "Subsection View On Web Tapped"
 }
 
@@ -109,6 +111,8 @@ public enum AnalyticsEventName: String {
     case CalendarAddDatesSuccess = "edx.bi.app.calendar.add_success"
     case CalendarRemoveDatesSuccess = "edx.bi.app.calendar.remove_success"
     case CalendarUpdateDatesSuccess = "edx.bi.app.calendar.update_success"
+    case CalendarSyncUpdateDates = "edx.bi.app.calendar.sync_update"
+    case CalendarSyncRemoveCalendar = "edx.bi.app.calendar.sync_remove"
     case SubsectionViewOnWebTapped = "edx.bi.app.course.subsection.view_on_web.tapped"
 }
 

--- a/Source/SnackbarViews.swift
+++ b/Source/SnackbarViews.swift
@@ -353,6 +353,7 @@ public class CalendarActionToastView: UIView {
         addSubview(container)
         
         addConstraints()
+        addButtonActions()
     }
     
     required public init?(coder aDecoder: NSCoder) {

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -350,8 +350,18 @@
 "COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
 /* Course Dates Events Removed from Calendar */
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
-/* Course Dates Open Settings */
+/* Course Dates Events Updated in Calendar */
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+/* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates Calendar Out of Date*/
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+/* Course Dates Calendar Shift Message */
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+/* Course Dates Calendar Shift Prompt Update Now */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
+/* Course Dates Calendar Shift Prompt Remove Course Calendar */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -334,8 +334,18 @@
 "COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
 /* Course Dates Events Removed from Calendar */
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
-/* Course Dates Open Settings */
+/* Course Dates Events Updated in Calendar */
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+/* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates Calendar Out of Date*/
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+/* Course Dates Calendar Shift Message */
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+/* Course Dates Calendar Shift Prompt Update Now */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
+/* Course Dates Calendar Shift Prompt Remove Course Calendar */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -334,8 +334,18 @@
 "COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
 /* Course Dates Events Removed from Calendar */
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
-/* Course Dates Open Settings */
+/* Course Dates Events Updated in Calendar */
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+/* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates Calendar Out of Date*/
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+/* Course Dates Calendar Shift Message */
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+/* Course Dates Calendar Shift Prompt Update Now */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
+/* Course Dates Calendar Shift Prompt Remove Course Calendar */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -334,8 +334,18 @@
 "COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
 /* Course Dates Events Removed from Calendar */
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
-/* Course Dates Open Settings */
+/* Course Dates Events Updated in Calendar */
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+/* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates Calendar Out of Date*/
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+/* Course Dates Calendar Shift Message */
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+/* Course Dates Calendar Shift Prompt Update Now */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
+/* Course Dates Calendar Shift Prompt Remove Course Calendar */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -334,8 +334,18 @@
 "COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
 /* Course Dates Events Removed from Calendar */
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
-/* Course Dates Open Settings */
+/* Course Dates Events Updated in Calendar */
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+/* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates Calendar Out of Date*/
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+/* Course Dates Calendar Shift Message */
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+/* Course Dates Calendar Shift Prompt Update Now */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
+/* Course Dates Calendar Shift Prompt Remove Course Calendar */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -342,8 +342,18 @@
 "COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
 /* Course Dates Events Removed from Calendar */
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
-/* Course Dates Open Settings */
+/* Course Dates Events Updated in Calendar */
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+/* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates Calendar Out of Date*/
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+/* Course Dates Calendar Shift Message */
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+/* Course Dates Calendar Shift Prompt Update Now */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
+/* Course Dates Calendar Shift Prompt Remove Course Calendar */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -330,8 +330,18 @@
 "COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
 /* Course Dates Events Removed from Calendar */
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
-/* Course Dates Open Settings */
+/* Course Dates Events Updated in Calendar */
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+/* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates Calendar Out of Date*/
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+/* Course Dates Calendar Shift Message */
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+/* Course Dates Calendar Shift Prompt Update Now */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
+/* Course Dates Calendar Shift Prompt Remove Course Calendar */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -334,8 +334,18 @@
 "COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
 /* Course Dates Events Removed from Calendar */
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
-/* Course Dates Open Settings */
+/* Course Dates Events Updated in Calendar */
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+/* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates Calendar Out of Date*/
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+/* Course Dates Calendar Shift Message */
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+/* Course Dates Calendar Shift Prompt Update Now */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
+/* Course Dates Calendar Shift Prompt Remove Course Calendar */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -334,8 +334,18 @@
 "COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
 /* Course Dates Events Removed from Calendar */
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
-/* Course Dates Open Settings */
+/* Course Dates Events Updated in Calendar */
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+/* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates Calendar Out of Date*/
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+/* Course Dates Calendar Shift Message */
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+/* Course Dates Calendar Shift Prompt Update Now */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
+/* Course Dates Calendar Shift Prompt Remove Course Calendar */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -330,8 +330,18 @@
 "COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
 /* Course Dates Events Removed from Calendar */
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
-/* Course Dates Open Settings */
+/* Course Dates Events Updated in Calendar */
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+/* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates Calendar Out of Date*/
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+/* Course Dates Calendar Shift Message */
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+/* Course Dates Calendar Shift Prompt Update Now */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
+/* Course Dates Calendar Shift Prompt Remove Course Calendar */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -330,8 +330,18 @@
 "COURSEDATES.CALENDAR_EVENTS_ADDED"="Your course calendar has been added.";
 /* Course Dates Events Removed from Calendar */
 "COURSEDATES.CALENDAR_EVENTS_REMOVED"="Your course calendar has been removed.";
-/* Course Dates Open Settings */
+/* Course Dates Events Updated in Calendar */
+"COURSEDATES.CALENDAR_EVENTS_UPDATED"="Your course calendar has been updated.";
+/* Course Dates Permission Not Determined */
 "COURSEDATES.CALENDAR_PERMISSION_NOT_DETERMINED"="{platform_name} does not have calendar permission. Please go to settings and give calender permission.";
+/* Course Dates Calendar Out of Date*/
+"COURSEDATES.CALENDAR_OUT_OF_DATE"="Your course calendar is out of date";
+/* Course Dates Calendar Shift Message */
+"COURSEDATES.CALENDAR_SHIFT_MESSAGE"="Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.";
+/* Course Dates Calendar Shift Prompt Update Now */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_UPDATE_NOW"="Update now";
+/* Course Dates Calendar Shift Prompt Remove Course Calendar */
+"COURSEDATES.CALENDAR_SHIFT_PROMPT_REMOVE_COURSE_CALENDAR"="Remove course calendar";
 /* Course Dates View Events in Calendar */
 "COURSEDATES.CALENDAR_VIEW_EVENTS"="View Events";
 /* Button text for cancelling any action */


### PR DESCRIPTION
### Description

[LEARNER-8412](https://openedx.atlassian.net/browse/LEARNER-8412)

### How to test this PR

- [x] When user shifts dues dates, calendar events must be synced with new dates when user navigates to Course Dates tab
- [x] Analytics events are being sent correctly