### PR TITLE
Video Player Controls are not visible for Youtube videos on iPad

### DIFF
--- a/Source/CutomePlayer/YoutubeVideoPlayer.swift
+++ b/Source/CutomePlayer/YoutubeVideoPlayer.swift
@@ -93,7 +93,7 @@ class YoutubeVideoPlayer: VideoPlayer {
             if isiPad() {
                 //Ideally the heightOffset should be the size of toolbar but with frame it's not working properly
                 // And required more height as offset to display the youtube player controls
-                viewHeightOffset = 120;
+                viewHeightOffset = 120
             }
             playerView.frame = CGRect(x: 0, y: 0, width: screenSize.width - widthOffset, height: screenSize.height - viewHeightOffset)
         }

--- a/Source/CutomePlayer/YoutubeVideoPlayer.swift
+++ b/Source/CutomePlayer/YoutubeVideoPlayer.swift
@@ -13,6 +13,7 @@ class YoutubeVideoPlayer: VideoPlayer {
     let playerView: WKYTPlayerView
     var videoID: String = ""
     private var videoCurrentTime: Float = 0.0
+    var viewHeightOffset: CGFloat = 90
 
     private lazy var errorMessageLabel: UILabel = {
         let label = UILabel()
@@ -88,14 +89,13 @@ class YoutubeVideoPlayer: VideoPlayer {
             playerView.frame = CGRect(x: 0, y: 0, width: screenSize.width, height: screenSize.width * CGFloat(STANDARD_VIDEO_ASPECT_RATIO))
         }
         else {
-            var heightOffset: CGFloat = 90
             let widthOffset: CGFloat = UIDevice.current.hasNotch ? 88 : 0
             if isiPad() {
                 //Ideally the heightOffset should be the size of toolbar but with frame it's not working properly
                 // And required more height as offset to display the youtube player controls
-                heightOffset = 120;
+                viewHeightOffset = 120;
             }
-            playerView.frame = CGRect(x: 0, y: 0, width: screenSize.width - widthOffset, height: screenSize.height - heightOffset)
+            playerView.frame = CGRect(x: 0, y: 0, width: screenSize.width - widthOffset, height: screenSize.height - viewHeightOffset)
         }
     }
 

--- a/Source/CutomePlayer/YoutubeVideoPlayer.swift
+++ b/Source/CutomePlayer/YoutubeVideoPlayer.swift
@@ -88,7 +88,14 @@ class YoutubeVideoPlayer: VideoPlayer {
             playerView.frame = CGRect(x: 0, y: 0, width: screenSize.width, height: screenSize.width * CGFloat(STANDARD_VIDEO_ASPECT_RATIO))
         }
         else {
-            playerView.frame = CGRect(x: 0, y: 0, width: screenSize.width, height: screenSize.height)
+            var heightOffset: CGFloat = 90
+            let widthOffset: CGFloat = UIDevice.current.hasNotch ? 88 : 0
+            if isiPad() {
+                //Ideally the heightOffset should be the size of toolbar but with frame it's not working properly
+                // And required more height as offset to display the youtube player controls
+                heightOffset = 120;
+            }
+            playerView.frame = CGRect(x: 0, y: 0, width: screenSize.width - widthOffset, height: screenSize.height - heightOffset)
         }
     }
 
@@ -190,4 +197,10 @@ extension YoutubeVideoPlayer: WKYTPlayerViewDelegate {
         }
     }
 
+}
+
+extension UIDevice {
+    var hasNotch: Bool {
+        return UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0 > 0
+    }
 }

--- a/Test/YoutubeVideoPlayerTests.swift
+++ b/Test/YoutubeVideoPlayerTests.swift
@@ -40,7 +40,7 @@ class YoutubeVideoPlayerTests: XCTestCase {
     func testVideoPlayerProtraitView() {
         let screenSize: CGRect = UIScreen.main.bounds
         youtubeVideoPlayer?.setVideoPlayerMode(isPortrait: false)
-        var landScapeSize = CGRect(x: 0, y: 0, width: screenSize.width, height: screenSize.height)
+        var landScapeSize = CGRect(x: 0, y: 0, width: screenSize.width, height: screenSize.height - (youtubeVideoPlayer?.viewHeightOffset ?? 0))
         
         XCTAssertEqual(landScapeSize, youtubeVideoPlayer?.playerView.frame)
         


### PR DESCRIPTION
### Description

[LEARNER-8411](https://openedx.atlassian.net/browse/LEARNER-8411)

Youtube video player controls are not visible to take action like stop/pause, seek on the iPad in the landscape mode. 

### Dev Notes

On the iPhone, in landscape mode, the video is playing in fullscreen mode because we are passing `inline:0` to the SDK but in the case of the iPad the behavior isn't consistent and I didn't find anything in the documentation related to it.  But the controls are functional in portrait and landscape mode.
