### PR TITLE
[feat] Add support of lti_consumer xblocks

### DIFF
--- a/Source/AuthenticatedWebViewController.swift
+++ b/Source/AuthenticatedWebViewController.swift
@@ -313,7 +313,7 @@ public class AuthenticatedWebViewController: UIViewController, WKUIDelegate, WKN
             decisionHandler(.cancel)
         } else {
             switch navigationAction.navigationType {
-            case .linkActivated, .formSubmitted, .formResubmitted:
+            case .linkActivated:
                 if let url = navigationAction.request.url, UIApplication.shared.canOpenURL(url) {
                     UIApplication.shared.open(url, options: [:], completionHandler: nil)
                 }

--- a/Source/CourseOutline.swift
+++ b/Source/CourseOutline.swift
@@ -111,6 +111,8 @@ public struct CourseOutline {
                             let discussionModel = DiscussionModel(dictionary: bodyData ?? [:])
                             type = .Discussion(discussionModel)
                         }
+                    case .LTIConsumer:
+                        type = .LTIConsumer
                     }
                 }
                 else {
@@ -161,6 +163,7 @@ public enum CourseBlockType: Equatable {
     case DragAndDrop
     case WordCloud
     case HTML
+    case LTIConsumer
     case Discussion(DiscussionModel)
     
     public var asVideo : OEXVideoSummary? {
@@ -188,6 +191,7 @@ public class CourseBlock {
         case Unit = "vertical"
         case Video = "video"
         case Discussion = "discussion"
+        case LTIConsumer = "lti_consumer"
     }
     
     public enum AuthorizationDenialReason : String {

--- a/Source/CourseOutlineTableSource.swift
+++ b/Source/CourseOutlineTableSource.swift
@@ -271,7 +271,7 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
             cell.delegate = self
             cell.swipeCellViewDelegate = (courseOutlineMode == .video) ? cell : nil
             return cell
-        case .HTML(.Base), .HTML(.DragAndDrop), .HTML(.WordCloud):
+        case .HTML(.Base), .HTML(.DragAndDrop), .HTML(.WordCloud), .HTML(.LTIConsumer):
             let cell = tableView.dequeueReusableCell(withIdentifier: CourseHTMLTableViewCell.identifier, for: indexPath) as! CourseHTMLTableViewCell
             cell.isSectionOutline = isSectionOutline
             cell.block = block

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -21,6 +21,7 @@ public enum CourseHTMLBlockSubkind {
     case OpenAssesment
     case DragAndDrop
     case WordCloud
+    case LTIConsumer
 }
 
 enum CourseBlockDisplayType {
@@ -48,6 +49,7 @@ extension CourseBlock {
         case .OpenAssesment: return multiDevice ? .HTML(.OpenAssesment) : .Unknown
         case .DragAndDrop: return multiDevice ? .HTML(.DragAndDrop) : .Unknown
         case .WordCloud: return multiDevice ? .HTML(.WordCloud) : .Unknown
+        case .LTIConsumer: return multiDevice ? .HTML(.LTIConsumer) : .Unknown
         case .Course: return .Outline
         case .Chapter: return .Outline
         case .Section: return .Outline


### PR DESCRIPTION
### Description

[LEARNER-8410](https://openedx.atlassian.net/browse/LEARNER-8410)

This PR adds support of `lti_consumer` xbloxks. Previously `lti_consumer` xblocks were not rendered within the apps and considered as unsupported xblocks. Now the learner will be able to see the `lti_consumer` xblocks in the app.

### Notes
We won’t be able to add the full support of lti_consumer xblocks that requires cookies support like zoom lti_consumer xblock as the cookies are not supported by safari.

### How to test this PR
Go to any lti_consumer xblock and it will be rendered within the app.
