### PR TITLE
[fix] handle calendar after app is reinstalled

### DIFF
--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -369,15 +369,11 @@ extension CourseDatesViewController {
     }
     
     private func addCourseEventsIfNecessary() {
-        if calendar.syncOn {
-            if datesShifted {
-                datesShifted = false
-                
-                if calendar.checkIfEventsShouldBeShifted(for: dateBlocks) {
-                    showCalendarEventShiftAlert()
-                }
-            } else {
-                addCourseEvents()
+        if datesShifted && calendar.syncOn {
+            datesShifted = false
+            
+            if calendar.checkIfEventsShouldBeShifted(for: dateBlocks) {
+                showCalendarEventShiftAlert()
             }
         }
     }
@@ -416,9 +412,8 @@ extension CourseDatesViewController {
     }
     
     private func addCourseEvents(trackAnalytics: Bool = true, completion: ((Bool)->())? = nil) {
-        if calendar.checkIfEventsShouldBeShifted(for: dateBlocks) {
-            trackCalendarEvent(for: .CalendarUpdateDatesSuccess, eventName: .CalendarUpdateDatesSuccess, syncReason: .background)
-            removeCourseCalendar(trackAnalytics: true)
+        if !calendar.checkIfEventsShouldBeShifted(for: dateBlocks) {
+            return
         }
         
         calendar.addEventsToCalendar(for: dateBlocks) { [weak self] success in

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -442,6 +442,7 @@ extension CourseDatesViewController {
             if index == UIAlertControllerBlocksCancelButtonIndex {
                 self?.courseDatesHeaderView.syncState = false
                 self?.calendar.syncOn = false
+                self?.removeCourseCalendar()
                 self?.trackCalendarEvent(for: .CalendarAddCancelled, eventName: .CalendarAddCancelled)
             }
         }

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -369,11 +369,15 @@ extension CourseDatesViewController {
     }
     
     private func addCourseEventsIfNecessary() {
-        if datesShifted && calendar.syncOn {
-            datesShifted = false
-            
-            if calendar.checkIfEventsShouldBeShifted(for: dateBlocks) {
-                showCalendarEventShiftAlert()
+        if calendar.syncOn {
+            if datesShifted {
+                datesShifted = false
+                
+                if calendar.checkIfEventsShouldBeShifted(for: dateBlocks) {
+                    showCalendarEventShiftAlert()
+                }
+            } else {
+                addCourseEvents()
             }
         }
     }
@@ -412,6 +416,11 @@ extension CourseDatesViewController {
     }
     
     private func addCourseEvents(trackAnalytics: Bool = true, completion: ((Bool)->())? = nil) {
+        if calendar.checkIfEventsShouldBeShifted(for: dateBlocks) {
+            trackCalendarEvent(for: .CalendarUpdateDatesSuccess, eventName: .CalendarUpdateDatesSuccess, syncReason: .background)
+            removeCourseCalendar(trackAnalytics: true)
+        }
+        
         calendar.addEventsToCalendar(for: dateBlocks) { [weak self] success in
             if success {
                 if trackAnalytics {


### PR DESCRIPTION
### Description

[LEARNER-8430](https://openedx.atlassian.net/browse/LEARNER-8430)

When app is uninstalled, course calendar is not removed and user reinstalls the app, goes to dates screen, turns on the calendar, goes to previous screen and navigates back to course dates screen, calendar switch is turned off, it should be in on state as user turned on the calendar for this course.

### How to test this PR

- [ ] Turn on calendar sync for a course
- [ ] Uninstall app
- [ ] Reinstall app
- [ ] Navigate to that course on Dates Tab
- [ ] Turn on the calendar sync
- [ ] Calendar sync should be successful
- [ ] Sync switch should maintain state
