### PR TITLE
[Fix] Gated content component screen rendering

### DIFF
--- a/Source/CourseUnknownBlockViewController.swift
+++ b/Source/CourseUnknownBlockViewController.swift
@@ -178,7 +178,7 @@ class CourseUnknownBlockViewController: UIViewController, CourseBlockViewControl
         
         if block.specialExamInfo != nil {
             environment.analytics.trackSubsectionViewOnWebTapped(isSpecialExam: true, courseID: courseID, subsectionID: block.blockID)
-        } else if block.children.isEmpty {
+        } else if (block.type == .Section && block.children.isEmpty) {
             environment.analytics.trackSubsectionViewOnWebTapped(isSpecialExam: false, courseID: courseID, subsectionID: block.blockID)
         } else {
             environment.analytics.trackOpenInBrowser(withURL: block.blockURL?.absoluteString ?? "", courseID: courseID, blockID: block.blockID, minifiedBlockID: block.minifiedBlockID ?? "", supported: block.multiDevice)

--- a/Source/CourseUnknownBlockViewController.swift
+++ b/Source/CourseUnknownBlockViewController.swift
@@ -91,7 +91,7 @@ class CourseUnknownBlockViewController: UIViewController, CourseBlockViewControl
         
         if block.specialExamInfo != nil {
             showSpecialExamMessageView(blockID: block.blockID)
-        } else if block.children.isEmpty {
+        } else if (block.type == .Section && block.children.isEmpty) {
             showEmptySubsectionMessageView(blockID: block.blockID)
         } else if block.isGated {
             if environment.remoteConfig.valuePropEnabled {


### PR DESCRIPTION
### Description

[LEARNER-8444](https://openedx.atlassian.net/browse/LEARNER-8444)

This PR fixes the bug, the gated content component detail screen wasn't rendering.

### How to test this PR
- [ ] Access any gated content component and gated content message should appear. 