### PR TITLE
[chore] shift course calendar events if course dates were shifted outside app

### DIFF
--- a/Source/CalendarManager.swift
+++ b/Source/CalendarManager.swift
@@ -144,7 +144,7 @@ class CalendarManager: NSObject {
     }
     
     func checkIfEventsShouldBeShifted(for dateBlocks: [Date : [CourseDateBlock]]) -> Bool {
-        guard let _ = calendarEntry else { return false }
+        guard let _ = calendarEntry else { return true }
         
         let events = generateEvents(for: dateBlocks)
         let allEvents = events.allSatisfy { alreadyExist(event: $0) }

--- a/Source/CalendarManager.swift
+++ b/Source/CalendarManager.swift
@@ -163,8 +163,9 @@ class CalendarManager: NSObject {
                 }
             } else {
                 if let block = blocks.first {
-                    let generatedEvent = calendarEvent(for: block)
-                    events.append(generatedEvent)
+                    if let generatedEvent = calendarEvent(for: block) {
+                        events.append(generatedEvent)
+                    }
                 }
             }
         }
@@ -206,7 +207,9 @@ class CalendarManager: NSObject {
         }
     }
     
-    private func calendarEvent(for block: CourseDateBlock) -> EKEvent {
+    private func calendarEvent(for block: CourseDateBlock) -> EKEvent? {
+        guard !block.title.isEmpty else { return nil }
+        
         let title = block.title + ": " + courseName
         // startDate is the start date and time for the event,
         // it is also being used as first alert for the event
@@ -219,7 +222,7 @@ class CalendarManager: NSObject {
     }
     
     private func calendarEvent(for blocks: [CourseDateBlock]) -> EKEvent? {
-        guard let block = blocks.first else { return nil }
+        guard let block = blocks.first, !block.title.isEmpty else { return nil }
         
         let title = block.title + ": " + courseName
         // startDate is the start date and time for the event,

--- a/Source/CourseDatesHeaderView.swift
+++ b/Source/CourseDatesHeaderView.swift
@@ -199,6 +199,8 @@ class CourseDatesHeaderView: UITableViewHeaderFooterView {
                 make.width.greaterThanOrEqualTo(buttonMinWidth)
                 make.height.equalTo(buttonHeight)
             }
+        } else {
+            shiftDatesButton.removeFromSuperview()
         }
     }
     

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -383,8 +383,8 @@ extension CourseDatesViewController {
         
         alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptUpdateNow) { [weak self] _ in
             self?.trackCalendarEvent(for: .CalendarSyncUpdateDates, eventName: .CalendarSyncUpdateDates)
-            self?.removeCourseCalendar(trackAnalytics: false) { [weak self] _ in
-                self?.addCourseEvents(trackAnalytics: false) { [weak self] success in
+            self?.removeCourseCalendar(trackAnalytics: false) { _ in
+                self?.addCourseEvents(trackAnalytics: false) { success in
                     if success {
                         topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsUpdated)
                         let syncReason: SyncReason = self?.datesShifted ?? false ? .direct : .background
@@ -397,7 +397,7 @@ extension CourseDatesViewController {
         
         alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptRemoveCourseCalendar, style: .destructive) { [weak self] _ in
             self?.trackCalendarEvent(for: .CalendarSyncRemoveCalendar, eventName: .CalendarSyncRemoveCalendar)
-            self?.removeCourseCalendar { [weak self] success in
+            self?.removeCourseCalendar { success in
                 if success {
                     topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsRemoved)
                     self?.courseDatesHeaderView.syncState = false

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -401,8 +401,8 @@ extension CourseDatesViewController {
                 self?.addCourseEvents(trackAnalytics: false) { [weak self] success in
                     if success {
                         topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsUpdated)
-                        let syncReason: SyncReason = datesShifted ? .direct : .background
-                        datesShifted = false
+                        let syncReason: SyncReason = self?.datesShifted == true ? .direct : .background
+                        self?.datesShifted = false
                         self?.trackCalendarEvent(for: .CalendarUpdateDatesSuccess, eventName: .CalendarUpdateDatesSuccess, syncReason: syncReason)
                     }
                 }

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -377,24 +377,9 @@ extension CourseDatesViewController {
     private func showCalendarEventShiftAlert() {
         guard let topController = UIApplication.shared.topMostController() else { return }
         
-        let title = Strings.Coursedates.calendarOutOfDate
-        let message = Strings.Coursedates.calendarShiftMessage
+        let alertController = UIAlertController(title: Strings.Coursedates.calendarOutOfDate, message: Strings.Coursedates.calendarShiftMessage, preferredStyle: .alert)
         
-        let alertController = UIAlertController().showAlert(withTitle: title, message: message, cancelButtonTitle: Strings.Coursedates.calendarShiftPromptRemoveCourseCalendar, onViewController: topController) { [weak self] alertController, _, index in
-            
-            if index == alertController.cancelButtonIndex {
-                self?.trackCalendarEvent(for: .CalendarSyncRemoveCalendar, eventName: .CalendarSyncRemoveCalendar)
-                
-                self?.removeCourseCalendar { [weak self] success in
-                    if success {
-                        topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsRemoved)
-                        self?.courseDatesHeaderView.syncState = false
-                    }
-                }
-            }
-        }
-        
-        alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptUpdateNow) { [weak self] _ in
+        let updateAction = UIAlertAction(title: Strings.Coursedates.calendarShiftPromptUpdateNow, style: .default) { [weak self] _ in
             self?.trackCalendarEvent(for: .CalendarSyncUpdateDates, eventName: .CalendarSyncUpdateDates)
             
             self?.removeCourseCalendar(trackAnalytics: false) { [weak self] _ in
@@ -408,6 +393,23 @@ extension CourseDatesViewController {
                 }
             }
         }
+        
+        let removeAction = UIAlertAction(title: Strings.Coursedates.calendarShiftPromptRemoveCourseCalendar, style: .destructive) { [weak self] _ in
+            self?.trackCalendarEvent(for: .CalendarSyncRemoveCalendar, eventName: .CalendarSyncRemoveCalendar)
+            
+            self?.removeCourseCalendar { [weak self] success in
+                if success {
+                    topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsRemoved)
+                    self?.courseDatesHeaderView.syncState = false
+                }
+            }
+        }
+        
+        alertController.addAction(updateAction)
+        alertController.addAction(removeAction)
+        alertController.view.tintColor = .systemBlue
+        
+        topController.present(alertController, animated: true, completion: nil)
     }
     
     private func addCourseEvents(trackAnalytics: Bool = true, completion: ((Bool)->())? = nil) {

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -381,7 +381,7 @@ extension CourseDatesViewController {
         
         let alertController = UIAlertController().showAlert(withTitle: Strings.Coursedates.calendarOutOfDate, message: Strings.Coursedates.calendarShiftMessage, cancelButtonTitle: nil, onViewController: topController)
         
-        alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptUpdateNow) { [weak self] action in
+        alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptUpdateNow) { [weak self] _ in
             self?.trackCalendarEvent(for: .CalendarSyncUpdateDates, eventName: .CalendarSyncUpdateDates)
             self?.removeCourseCalendar(trackAnalytics: false) { [weak self] _ in
                 self?.addCourseEvents(trackAnalytics: false) { [weak self] success in
@@ -395,7 +395,7 @@ extension CourseDatesViewController {
             }
         }
         
-        alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptRemoveCourseCalendar, style: .destructive) { [weak self] action in
+        alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptRemoveCourseCalendar, style: .destructive) { [weak self] _ in
             self?.trackCalendarEvent(for: .CalendarSyncRemoveCalendar, eventName: .CalendarSyncRemoveCalendar)
             self?.removeCourseCalendar { [weak self] success in
                 if success {

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -379,11 +379,10 @@ extension CourseDatesViewController {
     private func showCalendarEventShiftAlert() {
         guard let topController = UIApplication.shared.topMostController() else { return }
         
-        let alertController = UIAlertController(title: Strings.Coursedates.calendarOutOfDate, message: Strings.Coursedates.calendarShiftMessage, preferredStyle: .alert)
+        let alertController = UIAlertController().showAlert(withTitle: Strings.Coursedates.calendarOutOfDate, message: Strings.Coursedates.calendarShiftMessage, cancelButtonTitle: nil, onViewController: topController)
         
-        let updateAction = UIAlertAction(title: Strings.Coursedates.calendarShiftPromptUpdateNow, style: .default) { [weak self] _ in
+        alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptUpdateNow) { [weak self] action in
             self?.trackCalendarEvent(for: .CalendarSyncUpdateDates, eventName: .CalendarSyncUpdateDates)
-            
             self?.removeCourseCalendar(trackAnalytics: false) { [weak self] _ in
                 self?.addCourseEvents(trackAnalytics: false) { [weak self] success in
                     if success {
@@ -396,9 +395,8 @@ extension CourseDatesViewController {
             }
         }
         
-        let removeAction = UIAlertAction(title: Strings.Coursedates.calendarShiftPromptRemoveCourseCalendar, style: .destructive) { [weak self] _ in
+        alertController.addButton(withTitle: Strings.Coursedates.calendarShiftPromptRemoveCourseCalendar, style: .destructive) { [weak self] action in
             self?.trackCalendarEvent(for: .CalendarSyncRemoveCalendar, eventName: .CalendarSyncRemoveCalendar)
-            
             self?.removeCourseCalendar { [weak self] success in
                 if success {
                     topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsRemoved)
@@ -406,12 +404,6 @@ extension CourseDatesViewController {
                 }
             }
         }
-        
-        alertController.addAction(updateAction)
-        alertController.addAction(removeAction)
-        alertController.view.tintColor = .systemBlue
-        
-        topController.present(alertController, animated: true, completion: nil)
     }
     
     private func addCourseEvents(trackAnalytics: Bool = true, completion: ((Bool)->())? = nil) {

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -369,12 +369,8 @@ extension CourseDatesViewController {
     }
     
     private func addCourseEventsIfNecessary() {
-        if datesShifted && calendar.syncOn {
-            datesShifted = false
-            
-            if calendar.checkIfEventsShouldBeShifted(for: dateBlocks) {
-                showCalendarEventShiftAlert()
-            }
+        if calendar.syncOn && calendar.checkIfEventsShouldBeShifted(for: dateBlocks) {
+            showCalendarEventShiftAlert()
         }
     }
     
@@ -405,7 +401,9 @@ extension CourseDatesViewController {
                 self?.addCourseEvents(trackAnalytics: false) { [weak self] success in
                     if success {
                         topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsUpdated)
-                        self?.trackCalendarEvent(for: .CalendarUpdateDatesSuccess, eventName: .CalendarUpdateDatesSuccess, syncReason: .direct)
+                        let syncReason: SyncReason = datesShifted ? .direct : .background
+                        datesShifted = false
+                        self?.trackCalendarEvent(for: .CalendarUpdateDatesSuccess, eventName: .CalendarUpdateDatesSuccess, syncReason: syncReason)
                     }
                 }
             }

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -401,7 +401,7 @@ extension CourseDatesViewController {
                 self?.addCourseEvents(trackAnalytics: false) { [weak self] success in
                     if success {
                         topController.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsUpdated)
-                        let syncReason: SyncReason = self?.datesShifted == true ? .direct : .background
+                        let syncReason: SyncReason = self?.datesShifted ?? false ? .direct : .background
                         self?.datesShifted = false
                         self?.trackCalendarEvent(for: .CalendarUpdateDatesSuccess, eventName: .CalendarUpdateDatesSuccess, syncReason: syncReason)
                     }
@@ -411,10 +411,6 @@ extension CourseDatesViewController {
     }
     
     private func addCourseEvents(trackAnalytics: Bool = true, completion: ((Bool)->())? = nil) {
-        if !calendar.checkIfEventsShouldBeShifted(for: dateBlocks) {
-            return
-        }
-        
         calendar.addEventsToCalendar(for: dateBlocks) { [weak self] success in
             if success {
                 if trackAnalytics {

--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -464,7 +464,7 @@ extension CourseDatesViewController {
         
         let removeAction = UIAlertAction(title: Strings.remove, style: .destructive) { [weak self] _ in
             self?.trackCalendarEvent(for: .CalendarRemoveDatesOK, eventName: .CalendarRemoveDatesOK)
-            self?.removeCourseCalendar { [weak self] success in
+            self?.removeCourseCalendar { success in
                 if success {
                     self?.showCalendarActionSnackBar(message: Strings.Coursedates.calendarEventsRemoved)
                 }


### PR DESCRIPTION
### Description

[LEARNER-8304](https://openedx.atlassian.net/browse/LEARNER-8304)

As a user, I want my device calendar to update if course dates are changed outside the mobile app

### How to test this PR
- [x] If syncing is on and course access is not expired, after opening the app and being authenticated, if course dates do not match what is the user's calendar, the app presents a native alert to confirm modifying the calendar events, or to remove the calendar and stop syncing.  (See Figma link below.)
```
Title: Your course calendar is out of date
Description: Your course dates have been shifted and your course calendar is no longer up to date with your new schedule.
Buttons: Update now | Remove course calendar
```
- [x] Confirming modifying course events edits the dates/times of the calendar events to reflect the new dates/times on the Course Dates page.  Event changes are visible in the calendar.
- [x] Choosing the remove calendar/stop syncing option is equivalent to turning the sync toggle off (removes the calendar and stops syncing)
- [x] Confirmation toast is displayed on the course dashboard if modifying the calendar is successful.  Same toast we already show, but with different copy: `Your course calendar has been updated.`
- [x] Confirmation toast is displayed on the course dashboard if removing the calendar is successful.  Same toast we already show, with the same copy: `Your course calendar has been removed.` (No Shift Dates toast will be displayed)
- [x] If syncing is off or course access is expired, no alert is presented and no events are updated.

