### PR TITLE
[fix] adjust the navigation bottom bar button width

### DIFF
--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -434,6 +434,12 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return [.portrait , .landscapeLeft , .landscapeRight]
     }
+
+    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        DispatchQueue.main.async {[weak self] in
+            self?.updateNavigationBars()
+        }
+    }
     
     private func preloadBlock(block: CourseBlock) {
         guard !cacheManager.cacheHitForBlockID(blockID: block.blockID) else {

--- a/Source/DetailToolbarButton.swift
+++ b/Source/DetailToolbarButton.swift
@@ -55,6 +55,7 @@ class DetailToolbarButton: UIView {
             make.trailing.equalTo(self)
             make.top.equalTo(self)
             make.bottom.equalTo(self)
+            make.width.equalTo(UIScreen.main.bounds.width / 2 - 20)
         }
     }
 


### PR DESCRIPTION
### Description

[LEARNER-8417](https://openedx.atlassian.net/browse/LEARNER-8417)

### How to test this PR
[ ] Subtext of `Next` shouldn't take more than half of the screen.
[ ] Subtext of `Previous` shouldn't take more than half of the screen.
[ ] On changing the device orientation subtext should repopulate it to use the available space.