### PR TITLE
[chore] Hide value prop for ended/archived courses

### DIFF
--- a/Source/CoursesContainerViewController.swift
+++ b/Source/CoursesContainerViewController.swift
@@ -255,7 +255,7 @@ class CoursesContainerViewController: UICollectionViewController {
     
     private func shouldShowValueProp(for course: OEXCourse) -> Bool {
         let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id)
-        return enrollment?.mode == EnrollmentMode.audit.rawValue && environment.remoteConfig.valuePropEnabled
+        return enrollment?.mode == EnrollmentMode.audit.rawValue && environment.remoteConfig.valuePropEnabled && !course.isEndDateOld
     }
     
     private func calculateValuePropHeight(for indexPath: IndexPath) -> CGFloat {


### PR DESCRIPTION
### Description

[LEARNER-8246](https://openedx.atlassian.net/browse/LEARNER-8246)

This PR hides the value prop from the course cards on the courses enrollments screen from the ended/archived courses.


### How to test this PR
- [x]  Ended courses should not show value prop on the course card