### PR TITLE
[feature] add video download qualities options

### DIFF
--- a/Source/CourseOutlineTableSource.swift
+++ b/Source/CourseOutlineTableSource.swift
@@ -178,6 +178,11 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
         showOverlay(withMessage: environment.interface?.networkErrorMessage() ?? Strings.noWifiMessage)
     }
     
+    func didTapVideoQualityButton() {
+        environment.analytics.trackVideoDownloadQualityClicked(displayName: AnalyticsDisplayName.CourseVideosDownloadQualityClicked, name: AnalyticsEventName.CourseVideosDownloadQualityClicked)
+        environment.router?.showDownloadVideoQuality(from: self, isModal: true)
+    }
+    
     private func indexPathForBlockWithID(blockID : CourseBlockID) -> NSIndexPath? {
         for (i, group) in groups.enumerated() {
             for (j, block) in group.children.enumerated() {
@@ -485,7 +490,7 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
             }
             courseVideosHeaderView?.snp.makeConstraints { make in
                 make.edges.equalTo(headerContainer)
-                make.height.equalTo(CourseVideosHeaderView.height)
+                make.height.equalTo(CourseVideosHeaderView.height * 2)
             }
             courseVideosHeaderView?.refreshView()
             tableView.setAndLayoutTableHeaderView(header: headerContainer)

--- a/Source/CourseOutlineTableSource.swift
+++ b/Source/CourseOutlineTableSource.swift
@@ -21,7 +21,7 @@ protocol CourseOutlineTableControllerDelegate: AnyObject {
     func resetCourseDate(controller: CourseOutlineTableController)
 }
 
-class CourseOutlineTableController : UITableViewController, CourseVideoTableViewCellDelegate, CourseSectionTableViewCellDelegate, CourseVideosHeaderViewDelegate {
+class CourseOutlineTableController : UITableViewController, CourseVideoTableViewCellDelegate, CourseSectionTableViewCellDelegate, CourseVideosHeaderViewDelegate, VideoDownloadQualityDelegate {
 
     typealias Environment = DataManagerProvider & OEXInterfaceProvider & NetworkManagerProvider & OEXConfigProvider & OEXRouterProvider & OEXAnalyticsProvider & OEXStylesProvider
     
@@ -178,9 +178,15 @@ class CourseOutlineTableController : UITableViewController, CourseVideoTableView
         showOverlay(withMessage: environment.interface?.networkErrorMessage() ?? Strings.noWifiMessage)
     }
     
-    func didTapVideoQualityButton() {
+    func didTapVideoQuality() {
         environment.analytics.trackVideoDownloadQualityClicked(displayName: AnalyticsDisplayName.CourseVideosDownloadQualityClicked, name: AnalyticsEventName.CourseVideosDownloadQualityClicked)
-        environment.router?.showDownloadVideoQuality(from: self, isModal: true)
+        environment.router?.showDownloadVideoQuality(from: self, delegate: self, modal: true)
+    }
+    
+    func didUpdateVideoQuality() {
+        if courseOutlineMode == .video {
+            courseVideosHeaderView?.refreshView()
+        }
     }
     
     private func indexPathForBlockWithID(blockID : CourseBlockID) -> NSIndexPath? {

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -172,6 +172,10 @@ public class CourseOutlineViewController :
         NotificationCenter.default.oex_addObserver(observer: self, name: NOTIFICATION_SHIFT_COURSE_DATES) { _, observer, _ in
             observer.refreshCourseOutlineController()
         }
+        
+        NotificationCenter.default.oex_addObserver(observer: self, name: NOTIFICATION_VIDEO_DOWNLOAD_QUALITY_CHANGED) { _, observer, _ in
+            observer.refreshCourseOutlineBlockAPI()
+        }
     }
     
     private func loadCourseOutlineStream() {
@@ -363,6 +367,12 @@ public class CourseOutlineViewController :
     
     private func refreshCourseOutlineController() {
         hideCourseBannerView()
+        courseQuerier.needsRefresh = true
+        loadBackedStreams()
+        loadCourseStream()
+    }
+    
+    private func refreshCourseOutlineBlockAPI() {
         courseQuerier.needsRefresh = true
         loadBackedStreams()
         loadCourseStream()

--- a/Source/CourseOutlineViewController.swift
+++ b/Source/CourseOutlineViewController.swift
@@ -172,10 +172,6 @@ public class CourseOutlineViewController :
         NotificationCenter.default.oex_addObserver(observer: self, name: NOTIFICATION_SHIFT_COURSE_DATES) { _, observer, _ in
             observer.refreshCourseOutlineController()
         }
-        
-        NotificationCenter.default.oex_addObserver(observer: self, name: NOTIFICATION_VIDEO_DOWNLOAD_QUALITY_CHANGED) { _, observer, _ in
-            observer.refreshCourseOutlineBlockAPI()
-        }
     }
     
     private func loadCourseOutlineStream() {
@@ -367,12 +363,6 @@ public class CourseOutlineViewController :
     
     private func refreshCourseOutlineController() {
         hideCourseBannerView()
-        courseQuerier.needsRefresh = true
-        loadBackedStreams()
-        loadCourseStream()
-    }
-    
-    private func refreshCourseOutlineBlockAPI() {
         courseQuerier.needsRefresh = true
         loadBackedStreams()
         loadCourseStream()

--- a/Source/CourseVideosHeaderView.swift
+++ b/Source/CourseVideosHeaderView.swift
@@ -140,7 +140,7 @@ class CourseVideosHeaderView: UIView {
     private lazy var bottomSubtitleLabel: UILabel = {
         let label = UILabel()
         label.accessibilityIdentifier = "CourseVideosHeader:bottom-subtitle-view"
-        label.attributedText = subTitleLabelStyle.attributedString(withText: environment.interface?.getVideoDownladQuality().value)
+        label.attributedText = subTitleLabelStyle.attributedString(withText: environment.interface?.getVideoDownladQuality().title)
         return label
     }()
     
@@ -296,7 +296,7 @@ class CourseVideosHeaderView: UIView {
         videoImageView.isHidden = state == .downloading
         titleLabel.attributedText = titleLabelStyle.attributedString(withText: title)
         subTitleLabel.attributedText = subTitleLabelStyle.attributedString(withText: subTitle)
-        bottomSubtitleLabel.attributedText = subTitleLabelStyle.attributedString(withText: environment.interface?.getVideoDownladQuality().value)
+        bottomSubtitleLabel.attributedText = subTitleLabelStyle.attributedString(withText: environment.interface?.getVideoDownladQuality().title)
         downloadProgressView.setProgress(bulkDownloadHelper.progress, animated: true)
         showDownloadsButton.isAccessibilityElement = state == .downloading
         toggleSwitch.accessibilityLabel = switchAccessibilityLabel

--- a/Source/CourseVideosHeaderView.swift
+++ b/Source/CourseVideosHeaderView.swift
@@ -141,7 +141,7 @@ class CourseVideosHeaderView: UIView {
     
     private lazy var bottomTitleLabel: UILabel = {
         let label = UILabel()
-        label.attributedText = titleLabelStyle.attributedString(withText: Strings.VideoDownloadQuality.title)
+        label.attributedText = titleLabelStyle.attributedString(withText: Strings.videoDownloadQualityTitle)
         label.accessibilityIdentifier = "CourseVideosHeader:bottom-title-view"
         return label
     }()

--- a/Source/CourseVideosHeaderView.swift
+++ b/Source/CourseVideosHeaderView.swift
@@ -141,7 +141,7 @@ class CourseVideosHeaderView: UIView {
     
     private lazy var bottomTitleLabel: UILabel = {
         let label = UILabel()
-        label.attributedText = subTitleLabelStyle.attributedString(withText: Strings.VideoDownloadQuality.title)
+        label.attributedText = titleLabelStyle.attributedString(withText: Strings.VideoDownloadQuality.title)
         label.accessibilityIdentifier = "CourseVideosHeader:bottom-title-view"
         return label
     }()
@@ -167,7 +167,7 @@ class CourseVideosHeaderView: UIView {
         return OEXTextStyle(weight: .normal, size: .base, color: environment.styles.primaryBaseColor())
     }
     private var subTitleLabelStyle : OEXTextStyle {
-        return OEXTextStyle(weight: .normal, size: .base, color : environment.styles.primaryXLightColor())
+        return OEXTextStyle(weight: .light, size: .base, color : environment.styles.primaryXLightColor())
     }
     
     // MARK: - Properties -

--- a/Source/CourseVideosHeaderView.swift
+++ b/Source/CourseVideosHeaderView.swift
@@ -264,7 +264,9 @@ class CourseVideosHeaderView: UIView {
     
     fileprivate func addObserver(notification: Notification.Name) {
         let observer = NotificationCenter.default.oex_addObserver(observer: self, name: notification.rawValue) { (notification, observer, _) -> Void in
-            observer.refreshView()
+            if observer.toggledOn {
+                observer.refreshView()
+            }
         }
         let notificationObserver = NotificationObserver(notification: notification, observer: observer)
         observers.append(notificationObserver)

--- a/Source/CourseVideosHeaderView.swift
+++ b/Source/CourseVideosHeaderView.swift
@@ -11,7 +11,7 @@ import UIKit
 protocol CourseVideosHeaderViewDelegate: AnyObject {
     func courseVideosHeaderViewTapped()
     func invalidOrNoNetworkFound()
-    func didTapVideoQualityButton()
+    func didTapVideoQuality()
 }
 
 // To remove specific observers we need reference of notification and observer as well.
@@ -36,8 +36,17 @@ class CourseVideosHeaderView: UIView {
     private var blockID: CourseBlockID?
     
     // MARK: - UI Properties -
-    private lazy var topContainer = UIView()
-    private lazy var bottomContainer = UIView()
+    private lazy var topContainer: UIView = {
+        let view = UIView()
+        view.accessibilityIdentifier = "CourseVideosHeader:top-container-view"
+        return view
+    }()
+    
+    private lazy var bottomContainer: UIView = {
+        let view = UIView()
+        view.accessibilityIdentifier = "CourseVideosHeader:bottom-container-view"
+        return view
+    }()
     
     private lazy var separator: UIView = {
         let view = UIView()
@@ -147,7 +156,7 @@ class CourseVideosHeaderView: UIView {
     private lazy var videoQualityButton: UIButton = {
         let button = UIButton()
         button.oex_addAction({ [weak self] _ in
-            self?.delegate?.didTapVideoQualityButton()
+            self?.delegate?.didTapVideoQuality()
         }, for: .touchUpInside)
         button.accessibilityIdentifier = "CourseVideosHeader:video-quality-button"
         return button
@@ -241,7 +250,6 @@ class CourseVideosHeaderView: UIView {
             NSNotification.Name.OEXDownloadStarted,
             NSNotification.Name.OEXDownloadEnded,
             NSNotification.Name.OEXDownloadDeleted,
-            NSNotification.Name(NOTIFICATION_VIDEO_DOWNLOAD_QUALITY_CHANGED)
         ] {
             addObserver(notification: notification)
         }

--- a/Source/OEXAnalytics+Swift.swift
+++ b/Source/OEXAnalytics+Swift.swift
@@ -75,7 +75,11 @@ public enum AnalyticsDisplayName : String {
     case WifiOff = "Wifi Off"
     case WifiAllow = "Wifi Allow"
     case WifiDontAllow = "Wifi Dont Allow"
-    case EmailSupportClicked = "Email Support Clicked"    
+    case EmailSupportClicked = "Email Support Clicked"
+    case ProfileVideoDownloadQualityClicked = "Profile: Video Download Quality Clicked"
+    case CourseVideosDownloadQualityClicked = "Course Videos: Video Download Quality Clicked"
+    case VideoDownloadQuality = "Video Download Quality"
+    case VideoDownloadQualityChanged = "Video Download Quality Changed"
 }
 
 public enum AnalyticsEventName: String {
@@ -142,7 +146,10 @@ public enum AnalyticsEventName: String {
     case WifiOff = "edx.bi.app.profile.wifi.switch.off"
     case WifiAllow = "edx.bi.app.profile.wifi.allow"
     case WifiDontAllow = "edx.bi.app.profile.wifi.dont_allow"
-    case EmailSupportClicked = "edx.bi.app.profile.email_support.clicked"    
+    case EmailSupportClicked = "edx.bi.app.profile.email_support.clicked"
+    case ProfileVideoDownloadQualityClicked = "edx.bi.app.profile.video_download_quality.clicked"
+    case CourseVideosDownloadQualityClicked = "edx.bi.app.course_videos.video_download_quality.clicked"
+    case VideoDownloadQualityChanged = "edx.bi.app.video_download_quality.changed"
 }
 
 public enum AnalyticsScreenName: String {
@@ -168,6 +175,7 @@ public enum AnalyticsScreenName: String {
     case SpecialExamBlockedScreen = "Special Exam Blocked Screen"
     case EmptySectionOutline = "Empty Section Outline"
     case Profile = "profile"
+    case VideoDownloadQuality = "Video Download Quality"
 }
 
 public enum AnalyticsEventDataKey: String {
@@ -198,6 +206,8 @@ public enum AnalyticsEventDataKey: String {
     case ComponentID = "component_id"
     case ComponentType = "component_type"
     case OpenedURL = "opened_url"
+    case Value = "value"
+    case OldValue = "old_value"
 }
 
 
@@ -578,6 +588,27 @@ extension OEXAnalytics {
         event.name = allowed ? AnalyticsEventName.WifiAllow.rawValue : AnalyticsEventName.WifiDontAllow.rawValue
         
         trackEvent(event, forComponent: nil, withInfo: nil)
+    }
+    
+    func trackVideoDownloadQualityClicked(displayName: AnalyticsDisplayName, name: AnalyticsEventName) {
+        let event = OEXAnalyticsEvent()
+        event.displayName = displayName.rawValue
+        event.name = name.rawValue
+                
+        trackEvent(event, forComponent: nil, withInfo: nil)
+    }
+    
+    func trackVideoDownloadQualityChanged(value: String, oldValue: String) {
+        let event = OEXAnalyticsEvent()
+        event.displayName = AnalyticsDisplayName.VideoDownloadQualityChanged.rawValue
+        event.name = AnalyticsEventName.VideoDownloadQualityChanged.rawValue
+        
+        let info = [
+            AnalyticsEventDataKey.Value.rawValue: value,
+            AnalyticsEventDataKey.OldValue.rawValue: oldValue
+        ]
+        
+        trackEvent(event, forComponent: nil, withInfo: info)
     }
 }
 

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -435,7 +435,17 @@ extension OEXRouter {
         let editController = UserProfileEditViewController(profile: profile, environment: environment)
         controller.navigationController?.pushViewController(editController, animated: true)
     }
-
+    
+    func showDownloadVideoQuality(from controller: UIViewController, isModal: Bool = false) {
+        let videoQualityController = VideoDownloadQualityViewController(environment: environment)
+        if isModal {
+            controller.present(ForwardingNavigationController(rootViewController: videoQualityController), animated: true, completion: nil)
+        } else {
+            controller.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+            controller.navigationController?.pushViewController(videoQualityController, animated: true)
+        }
+    }
+    
     func showCertificate(url: NSURL, title: String?, fromController controller: UIViewController) {
         let c = CertificateViewController(environment: environment)
         c.title = title

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -436,9 +436,9 @@ extension OEXRouter {
         controller.navigationController?.pushViewController(editController, animated: true)
     }
     
-    func showDownloadVideoQuality(from controller: UIViewController, isModal: Bool = false) {
-        let videoQualityController = VideoDownloadQualityViewController(environment: environment)
-        if isModal {
+    func showDownloadVideoQuality(from controller: UIViewController, delegate: VideoDownloadQualityDelegate?, modal: Bool = false) {
+        let videoQualityController = VideoDownloadQualityViewController.init(environment: environment, delegate: delegate)
+        if modal {
             controller.present(ForwardingNavigationController(rootViewController: videoQualityController), animated: true, completion: nil)
         } else {
             controller.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)

--- a/Source/OEXVideoEncoding.h
+++ b/Source/OEXVideoEncoding.h
@@ -14,6 +14,7 @@ extern NSString* const OEXVideoEncodingYoutube;
 extern NSString* const OEXVideoEncodingFallback;
 extern NSString* const OEXVideoEncodingMobileHigh;
 extern NSString* const OEXVideoEncodingMobileLow;
+extern NSString* const OEXVideoEncodingDesktopMP4;
 extern NSString* const OEXVideoEncodingHLS;
 
 @interface OEXVideoEncoding : NSObject

--- a/Source/OEXVideoEncoding.m
+++ b/Source/OEXVideoEncoding.m
@@ -11,6 +11,7 @@
 NSString* const OEXVideoEncodingYoutube = @"youtube";
 NSString* const OEXVideoEncodingMobileHigh = @"mobile_high";
 NSString* const OEXVideoEncodingMobileLow = @"mobile_low";
+NSString* const OEXVideoEncodingDesktopMP4 = @"desktop_mp4";
 NSString* const OEXVideoEncodingFallback = @"fallback";
 NSString* const OEXVideoEncodingHLS = @"hls";
 
@@ -25,7 +26,14 @@ NSString* const OEXVideoEncodingHLS = @"hls";
 @implementation OEXVideoEncoding
 
 + (NSArray*)knownEncodingNames {
-    return @[OEXVideoEncodingHLS, OEXVideoEncodingMobileLow, OEXVideoEncodingMobileHigh, OEXVideoEncodingFallback, OEXVideoEncodingYoutube];
+    return @[
+        OEXVideoEncodingHLS,
+        OEXVideoEncodingMobileLow,
+        OEXVideoEncodingMobileHigh,
+        OEXVideoEncodingDesktopMP4,
+        OEXVideoEncodingFallback,
+        OEXVideoEncodingYoutube
+    ];
 }
 
 - (id)initWithDictionary:(NSDictionary*)dictionary name:(NSString*)name {

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -29,7 +29,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, strong, nonatomic, nullable) OEXVideoPathEntry* chapterPathEntry;
 @property (readonly, strong, nonatomic, nullable) OEXVideoPathEntry* sectionPathEntry;
 
-@property (nonatomic, strong) OEXVideoEncoding *defaultEncoding;
 @property (nonatomic, strong, nullable) OEXVideoEncoding* preferredEncoding;
 
 @property (readonly, nonatomic, copy, nullable) NSString* category;

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -22,6 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Generate a simple stub video summary. Used only for testing
 - (id)initWithVideoID:(NSString*)videoID name:(NSString*)name encodings:(NSDictionary<NSString*, OEXVideoEncoding *> *)encodings;
 
++ (BOOL) isDownloadableVideoURL:(NSString*) url;
+
 @property (readonly, nonatomic, copy, nullable) NSString* sectionURL;     // used for OPEN IN BROWSER
 
 @property (readonly, strong, nonatomic, nullable) OEXVideoPathEntry* chapterPathEntry;
@@ -47,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic, assign) BOOL hasVideoSize;
 @property (nonatomic, strong) NSDictionary* encodings;
 @property (nonatomic, copy, nullable) NSString* downloadURL;
+@property (nonatomic, strong) NSMutableArray *supportedEncodings;
 
 // For CC
 // de - German

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -29,7 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, strong, nonatomic, nullable) OEXVideoPathEntry* chapterPathEntry;
 @property (readonly, strong, nonatomic, nullable) OEXVideoPathEntry* sectionPathEntry;
 
-@property (readonly, nonatomic, strong, nullable) OEXVideoEncoding* preferredEncoding;
+@property (nonatomic, strong) OEXVideoEncoding *defaultEncoding;
+@property (nonatomic, strong, nullable) OEXVideoEncoding* preferredEncoding;
 
 @property (readonly, nonatomic, copy, nullable) NSString* category;
 // This property is deprecated. We should be reading it from the CourseBlock itself

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -49,8 +49,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic, assign) BOOL hasVideoSize;
 @property (nonatomic, strong) NSDictionary* encodings;
 @property (nonatomic, copy, nullable) NSString* downloadURL;
-@property (nonatomic, strong) NSMutableArray *supportedEncodings;
-@property (nonatomic, copy) NSArray *allSources;
 
 // For CC
 // de - German

--- a/Source/OEXVideoSummary.h
+++ b/Source/OEXVideoSummary.h
@@ -50,6 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSDictionary* encodings;
 @property (nonatomic, copy, nullable) NSString* downloadURL;
 @property (nonatomic, strong) NSMutableArray *supportedEncodings;
+@property (nonatomic, copy) NSArray *allSources;
 
 // For CC
 // de - German

--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -27,6 +27,8 @@
 @property (nonatomic, assign) BOOL onlyOnWeb;
 @property (nonatomic, strong) NSDictionary* transcripts;
 @property (nonatomic, strong) OEXVideoEncoding *defaultEncoding;
+@property (nonatomic, strong) NSMutableArray *supportedEncodings;
+@property (nonatomic, copy) NSArray *allSources;
 
 - (BOOL)isSupportedEncoding:(NSString *) encodingName;
 

--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -276,6 +276,11 @@
             break;
     }
     
+    NSMutableOrderedSet *set = [NSMutableOrderedSet new];
+    [set addObjectsFromArray:array];
+    [set addObjectsFromArray:self.supportedEncodings];
+    array = [set array];
+    
     return array;
 }
 

--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -26,7 +26,6 @@
 @property (nonatomic, copy) NSString* unitURL;
 @property (nonatomic, assign) BOOL onlyOnWeb;
 @property (nonatomic, strong) NSDictionary* transcripts;
-@property (nonatomic, strong) OEXVideoEncoding *defaultEncoding;
 
 - (BOOL)isSupportedEncoding:(NSString *) encodingName;
 
@@ -107,18 +106,6 @@
     return self;
 }
 
-- (OEXVideoEncoding*)preferredEncoding {
-    for(NSString* name in [OEXVideoEncoding knownEncodingNames]) {
-        OEXVideoEncoding* encoding = self.encodings[name];
-        if (encoding != nil) {
-            return encoding;
-        }
-    }
-    
-    // Don't have a known encoding, so return default encoding
-    return self.defaultEncoding;
-}
-
 - (BOOL) isYoutubeVideo {
     for(NSString* name in [OEXVideoEncoding knownEncodingNames]) {
         OEXVideoEncoding* encoding = self.encodings[name];
@@ -181,17 +168,6 @@
 
 - (NSString*)videoURL {
     return self.preferredEncoding.URL;
-}
-
-- (NSNumber*)size {
-    for(NSString* name in [OEXVideoEncoding knownEncodingNames]) {
-        OEXVideoEncoding* encoding = self.encodings[name];
-        if (encoding.name && ![encoding.name isEqualToString:OEXVideoEncodingHLS]) {
-            return encoding.size;
-        }
-    }
-
-    return self.preferredEncoding.size;
 }
 
 - (NSString *)videoSize {

--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -26,6 +26,7 @@
 @property (nonatomic, copy) NSString* unitURL;
 @property (nonatomic, assign) BOOL onlyOnWeb;
 @property (nonatomic, strong) NSDictionary* transcripts;
+@property (nonatomic, strong) OEXVideoEncoding *defaultEncoding;
 
 - (BOOL)isSupportedEncoding:(NSString *) encodingName;
 
@@ -74,7 +75,8 @@
             OEXVideoEncodingHLS,
             OEXVideoEncodingDesktopMP4,
             OEXVideoEncodingMobileHigh,
-            OEXVideoEncodingMobileLow]];
+            OEXVideoEncodingMobileLow
+        ]];
         if (![[OEXConfig sharedConfig] isUsingVideoPipeline] ||
             [self.preferredEncoding.name isEqualToString:OEXVideoEncodingFallback]) {
             [self.supportedEncodings addObject:OEXVideoEncodingFallback];
@@ -106,7 +108,19 @@
     return self;
 }
 
-- (BOOL) isYoutubeVideo {
+- (OEXVideoEncoding*)preferredEncoding {
+    for(NSString* name in [OEXVideoEncoding knownEncodingNames]) {
+        OEXVideoEncoding* encoding = self.encodings[name];
+        if (encoding != nil) {
+            return encoding;
+        }
+    }
+    
+    // Don't have a known encoding, so return default encoding
+    return self.defaultEncoding;
+}
+
+- (BOOL)isYoutubeVideo {
     for(NSString* name in [OEXVideoEncoding knownEncodingNames]) {
         OEXVideoEncoding* encoding = self.encodings[name];
         
@@ -122,16 +136,14 @@
 }
 
 - (BOOL)hasVideoDuration {
-    
     return (self.duration > 0.0);
 }
 
 - (BOOL)hasVideoSize {
-    
     return ([[self size] doubleValue] > 0.0);
 }
 
-- (BOOL) isSupportedVideo {
+- (BOOL)isSupportedVideo {
     BOOL isSupportedEncoding = false;
     for(NSString* name in [OEXVideoEncoding knownEncodingNames]) {
         OEXVideoEncoding* encoding = self.encodings[name];
@@ -149,7 +161,7 @@
     return !self.onlyOnWeb && isSupportedEncoding;
 }
 
-+ (BOOL) isDownloadableVideoURL:(NSString*) url {
++ (BOOL)isDownloadableVideoURL:(NSString*) url {
     BOOL canDownload = url.length && [OEXInterface isURLForVideo:url];
     if(canDownload) {
         for (NSString *extension in ONLINE_ONLY_VIDEO_URL_EXTENSIONS) {
@@ -162,7 +174,7 @@
     return canDownload;
 }
 
-- (BOOL) isDownloadableVideo {
+- (BOOL)isDownloadableVideo {
     return (BOOL)self.downloadURL;
 }
 

--- a/Source/OEXVideoSummary.m
+++ b/Source/OEXVideoSummary.m
@@ -80,8 +80,8 @@
             [self.preferredEncoding.name isEqualToString:OEXVideoEncodingFallback]) {
             [self.supportedEncodings addObject:OEXVideoEncodingFallback];
         }
-
-        self.downloadURL = [self getDownloadURLWithAllSources:[summary objectForKey:@"all_sources"]];
+        
+        self.allSources = [summary objectForKey:@"all_sources"];
     }
     
     return self;

--- a/Source/ProfileOptionsViewController.swift
+++ b/Source/ProfileOptionsViewController.swift
@@ -88,8 +88,8 @@ class ProfileOptionsViewController: UIViewController {
     private func addObserver() {
         NotificationCenter.default.oex_addObserver(observer: self, name: NOTIFICATION_VIDEO_DOWNLOAD_QUALITY_CHANGED) { _, observer, _ in
             for cell in observer.tableView.visibleCells where cell is DownloadSettingCell {
-                if let indexPath = observer.tableView.indexPath(for: cell) {
-                    observer.tableView.reloadRows(at: [indexPath], with: .none)
+                if let cell = cell as? DownloadSettingCell {
+                    cell.updateVideoDownloadQualityLabel()
                 }
             }
         }
@@ -227,6 +227,7 @@ extension ProfileOptionsViewController: UITableViewDataSource {
         let cell = tableView.dequeueReusableCell(withIdentifier: DownloadSettingCell.identifier, for: indexPath) as! DownloadSettingCell
         cell.delegate = self
         cell.wifiSwitch.isOn = environment.interface?.shouldDownloadOnlyOnWifi ?? false
+        cell.updateVideoDownloadQualityLabel()
         return cell
     }
     
@@ -381,9 +382,7 @@ class DownloadSettingCell: UITableViewCell {
     }()
     
     private lazy var videoQualitySubtitleLabel: UILabel = {
-        let label = UILabel()
-        let preferredVideoQuality = OEXInterface.shared().getVideoDownladQuality()
-        label.attributedText = titleTextStyle.attributedString(withText: preferredVideoQuality.value)
+        let label = UILabel()        
         label.accessibilityIdentifier = "DownloadsCell:video-quality-subtitle-label"
         return label
     }()
@@ -497,6 +496,10 @@ class DownloadSettingCell: UITableViewCell {
         videoQualityButton.snp.makeConstraints { make in
             make.edges.equalTo(videoQualityContainer)
         }
+    }
+    
+    func updateVideoDownloadQualityLabel() {
+        videoQualitySubtitleLabel.attributedText = titleTextStyle.attributedString(withText: OEXInterface.shared().getVideoDownladQuality().title)
     }
 }
 

--- a/Source/ProfileOptionsViewController.swift
+++ b/Source/ProfileOptionsViewController.swift
@@ -375,7 +375,7 @@ class VideoSettingCell: UITableViewCell {
     
     private lazy var videoQualityDescriptionLabel: UILabel = {
         let label = UILabel()
-        label.attributedText = subtitleTextStyle.attributedString(withText: Strings.VideoDownloadQuality.title)
+        label.attributedText = subtitleTextStyle.attributedString(withText: Strings.videoDownloadQualityTitle)
         label.accessibilityIdentifier = "VideoSettingCell:video-quality-description-label"
         return label
     }()

--- a/Source/VideoDownloadQuality.swift
+++ b/Source/VideoDownloadQuality.swift
@@ -48,7 +48,7 @@ enum VideoDownloadQuality: CaseIterable {
         }
     }
     
-    var value: String {
+    var title: String {
         switch self {
         case .auto:
             return Strings.VideoDownloadQuality.auto
@@ -102,7 +102,7 @@ extension OEXInterface {
 }
 
 extension OEXVideoSummary {
-    @objc func getDownloadURL(allSources: [String]) -> String? {
+    @objc var downloadURL: String? {
         var downloadURL: String?
         
         if OEXConfig.shared().isUsingVideoPipeline {
@@ -112,6 +112,7 @@ extension OEXVideoSummary {
                 downloadURL = videoURL
             } else {
                 // Loop through the video sources to find a downloadable video URL
+                guard let allSources = allSources as NSArray as? [String] else { return nil }
                 for url in allSources where OEXVideoSummary.isDownloadableVideoURL(url) {
                     downloadURL = url
                     break

--- a/Source/VideoDownloadQuality.swift
+++ b/Source/VideoDownloadQuality.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-let NOTIFICATION_VIDEO_DOWNLOAD_QUALITY_CHANGED = "VideoDownloadQuality"
-
 private let OEXVideoDownloadQuality = "OEXVideoDownloadQuality"
 
 enum VideoDownloadQuality: CaseIterable {
@@ -184,15 +182,11 @@ extension OEXVideoSummary {
         
         switch preferredQuality {
         case .desktop:
-            possibleEncodings = [.mobileHigh, .mobileLow]
+            possibleEncodings = VideoDownloadQuality.encodings.filter { $0 != preferredQuality }.reversed()
             break
             
-        case .mobileHigh:
-            possibleEncodings = [.mobileLow, .desktop]
-            break
-            
-        case .mobileLow:
-            possibleEncodings = [.mobileHigh, .desktop]
+        case .mobileHigh, .mobileLow:
+            possibleEncodings = VideoDownloadQuality.encodings.filter { $0 != preferredQuality }
             break
             
         default:

--- a/Source/VideoDownloadQuality.swift
+++ b/Source/VideoDownloadQuality.swift
@@ -1,0 +1,211 @@
+//
+//  VideoDownloadQuality.swift
+//  edX
+//
+//  Created by Muhammad Umer on 16/08/2021.
+//  Copyright © 2021 edX. All rights reserved.
+//
+
+import Foundation
+
+let NOTIFICATION_VIDEO_DOWNLOAD_QUALITY_CHANGED = "VideoDownloadQuality"
+
+private let OEXVideoDownloadQuality = "OEXVideoDownloadQuality"
+
+enum VideoDownloadQuality: CaseIterable {
+    case auto
+    case mobileLow // 640 x 360
+    case mobileHigh // 960 x 540
+    case desktop // 1280 x 720
+    
+    public typealias RawValue = String
+    
+    public var rawValue: RawValue {
+        switch self {
+        case .auto:
+            return "hls"
+        case .mobileLow:
+            return "mobile_low"
+        case .mobileHigh:
+            return "mobile_high"
+        case .desktop:
+            return "desktop_mp4"
+        }
+    }
+    
+    public init?(rawValue: RawValue) {
+        switch rawValue {
+        case "hls":
+            self = .auto
+        case "mobile_low":
+            self = .mobileLow
+        case "mobile_high":
+            self = .mobileHigh
+        case "desktop_mp4":
+            self = .desktop
+        default:
+            return nil
+        }
+    }
+    
+    var value: String {
+        switch self {
+        case .auto:
+            return Strings.VideoDownloadQuality.auto
+            
+        case .mobileLow:
+            return Strings.VideoDownloadQuality.low
+            
+        case .mobileHigh:
+            return Strings.VideoDownloadQuality.medium
+            
+        case .desktop:
+            return Strings.VideoDownloadQuality.high
+        }
+    }
+    
+    var analyticsValue: String {
+        switch self {
+        case .auto:
+            return "auto"
+            
+        case .mobileLow:
+            return "360p"
+            
+        case .mobileHigh:
+            return "540p"
+            
+        case .desktop:
+            return "720p"
+        }
+    }
+    
+    static var encodings: [VideoDownloadQuality] {
+        return [.mobileLow, .mobileHigh, .desktop]
+    }
+}
+
+extension OEXInterface {
+    func saveVideoDownloadQuality(quality: VideoDownloadQuality) {
+        UserDefaults.standard.set(quality.rawValue, forKey: OEXVideoDownloadQuality)
+        UserDefaults.standard.synchronize()
+    }
+    
+    func getVideoDownladQuality() -> VideoDownloadQuality {
+        if let value = UserDefaults.standard.value(forKey: OEXVideoDownloadQuality) as? String,
+           let quality = VideoDownloadQuality(rawValue: value) {
+            return quality
+        } else {
+            return .auto
+        }
+    }
+}
+
+extension OEXVideoSummary {
+    @objc func getDownloadURL(allSources: [String]) -> String? {
+        var downloadURL: String?
+        
+        if OEXConfig.shared().isUsingVideoPipeline {
+            downloadURL = getPreferredDownloadURL()
+        } else {
+            if let videoURL = videoURL, OEXVideoSummary.isDownloadableVideoURL(videoURL) {
+                downloadURL = videoURL
+            } else {
+                // Loop through the video sources to find a downloadable video URL
+                for url in allSources where OEXVideoSummary.isDownloadableVideoURL(url) {
+                    downloadURL = url
+                    break
+                }
+            }
+        }
+        
+        return downloadURL
+    }
+    
+    private func getPreferredDownloadURL() -> String? {
+        var downloadURL: String?
+        
+        let preferredQuality = OEXInterface.shared().getVideoDownladQuality()
+        
+        // Loop through the available encodings to find a downloadable video URL
+        if let supportedEncodings = supportedEncodings as NSArray as? [String],
+           let availableEncodings = encodings as? Dictionary<String, OEXVideoEncoding> {
+            
+            let filteredEncodings = availableEncodings.keys.filter { supportedEncodings.contains($0) }
+            
+            if filteredEncodings.contains(preferredQuality.rawValue) {
+                if preferredQuality == .auto {
+                    downloadURL = getAutoPreferredAvailableURL(filteredEncodings: filteredEncodings, availableEncodings: availableEncodings)
+                } else {
+                    if let encoding = availableEncodings[preferredQuality.rawValue],
+                       let url = encoding.url, OEXVideoSummary.isDownloadableVideoURL(url) {
+                        downloadURL = url
+                    } else {
+                        downloadURL = getFirstAvailableURL(preferredQuality: preferredQuality, filteredEncodings: filteredEncodings, availableEncodings: availableEncodings)
+                    }
+                }
+            } else {
+                downloadURL = getFirstAvailableURL(preferredQuality: preferredQuality, filteredEncodings: filteredEncodings, availableEncodings: availableEncodings)
+            }
+        }
+        
+        return downloadURL
+    }
+    
+    private func url(with availableEncodings: [String : OEXVideoEncoding], quality: VideoDownloadQuality) -> String? {
+        if let encoding = availableEncodings[quality.rawValue],
+           let url = encoding.url, OEXVideoSummary.isDownloadableVideoURL(url) {
+            return url
+        } else {
+            return nil
+        }
+    }
+    
+    private func getAutoPreferredAvailableURL(filteredEncodings: [Dictionary<String, OEXVideoEncoding>.Keys.Element], availableEncodings: [String : OEXVideoEncoding]) -> String? {
+        
+        var downloadURL: String?
+        
+        for encoding in VideoDownloadQuality.encodings where filteredEncodings.contains(encoding.rawValue) {
+            if let url = url(with: availableEncodings, quality: encoding) {
+                downloadURL = url
+                break
+            }
+        }
+        
+        return downloadURL
+    }
+    
+    private func getFirstAvailableURL(preferredQuality: VideoDownloadQuality, filteredEncodings: [Dictionary<String, OEXVideoEncoding>.Keys.Element], availableEncodings: [String: OEXVideoEncoding]) -> String? {
+        
+        var downloadURL: String?
+        
+        var possibleEncodings: [VideoDownloadQuality] = []
+        
+        switch preferredQuality {
+        case .desktop:
+            possibleEncodings = [.mobileHigh, .mobileLow]
+            break
+            
+        case .mobileHigh:
+            possibleEncodings = [.mobileLow, .desktop]
+            break
+            
+        case .mobileLow:
+            possibleEncodings = [.mobileHigh, .desktop]
+            break
+            
+        default:
+            possibleEncodings = VideoDownloadQuality.encodings
+            break
+        }
+        
+        for encoding in possibleEncodings where filteredEncodings.contains(encoding.rawValue) {
+            if let url = url(with: availableEncodings, quality: encoding) {
+                downloadURL = url
+                break
+            }
+        }
+        
+        return downloadURL
+    }
+}

--- a/Source/VideoDownloadQuality.swift
+++ b/Source/VideoDownloadQuality.swift
@@ -12,9 +12,9 @@ private let VideoDownloadQualityKey = "OEXVideoDownloadQuality"
 
 @objc public enum VideoDownloadQuality: Int {
     case auto
-    case mobileLow // 640 x 360 - 360p
-    case mobileHigh // 960 x 540 - 540p
-    case desktop // 1280 x 720 - 720p
+    case mobileLow // OEXVideoEncodingMobileLow 640 x 360 - 360p
+    case mobileHigh // OEXVideoEncodingMobileHigh 960 x 540 - 540p
+    case desktop // OEXVideoEncodingDesktopMP4 1280 x 720 - 720p
     
     public typealias RawValue = String
     

--- a/Source/VideoDownloadQuality.swift
+++ b/Source/VideoDownloadQuality.swift
@@ -14,37 +14,37 @@ private let OEXVideoDownloadQuality = "OEXVideoDownloadQuality"
 
 enum VideoDownloadQuality: CaseIterable {
     case auto
-    case mobileLow // 640 x 360
-    case mobileHigh // 960 x 540
-    case desktop // 1280 x 720
+    case mobileLow // 640 x 360 - 360p
+    case mobileHigh // 960 x 540 - 540p
+    case desktop // 1280 x 720 - 720p
     
     public typealias RawValue = String
     
     public var rawValue: RawValue {
         switch self {
         case .auto:
-            return "hls"
+            return OEXVideoEncodingHLS
         case .mobileLow:
-            return "mobile_low"
+            return OEXVideoEncodingMobileLow
         case .mobileHigh:
-            return "mobile_high"
+            return OEXVideoEncodingMobileHigh
         case .desktop:
-            return "desktop_mp4"
+            return OEXVideoEncodingDesktopMP4
         }
     }
     
     public init?(rawValue: RawValue) {
         switch rawValue {
-        case "hls":
+        case OEXVideoEncodingHLS:
             self = .auto
-        case "mobile_low":
+        case OEXVideoEncodingMobileLow:
             self = .mobileLow
-        case "mobile_high":
+        case OEXVideoEncodingMobileHigh:
             self = .mobileHigh
-        case "desktop_mp4":
+        case OEXVideoEncodingDesktopMP4:
             self = .desktop
         default:
-            return nil
+            self = .auto
         }
     }
     

--- a/Source/VideoDownloadQualityViewController.swift
+++ b/Source/VideoDownloadQualityViewController.swift
@@ -1,0 +1,186 @@
+//
+//  VideoDownloadQualityViewController.swift
+//  edX
+//
+//  Created by Muhammad Umer on 13/08/2021.
+//  Copyright © 2021 edX. All rights reserved.
+//
+
+import UIKit
+
+fileprivate let buttonSize: CGFloat = 20
+
+class VideoDownloadQualityViewController: UIViewController {
+    
+    typealias Environment = OEXInterfaceProvider & OEXAnalyticsProvider & OEXConfigProvider
+    
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.rowHeight = StandardVerticalMargin * 7
+        tableView.estimatedRowHeight = StandardVerticalMargin * 7
+        tableView.alwaysBounceVertical = false
+        tableView.separatorInset = .zero
+        tableView.tableFooterView = UIView()
+        tableView.register(VideoQualityCell.self, forCellReuseIdentifier: VideoQualityCell.identifier)
+        tableView.accessibilityIdentifier = "VideoDownloadQualityViewController:table-view"
+        
+        return tableView
+    }()
+    
+    private let environment: Environment
+    
+    init(environment: Environment) {
+        self.environment = environment
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        navigationItem.largeTitleDisplayMode = .never
+        
+        title = "Video download quality"
+        
+        setupViews()
+        addCloseButton()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(true)
+        
+        environment.analytics.trackScreen(withName: AnalyticsScreenName.VideoDownloadQuality.rawValue)
+    }
+    
+    private func setupViews() {
+        view.addSubview(tableView)
+        
+        tableView.snp.makeConstraints { make in
+            make.edges.equalTo(view)
+        }
+                
+        tableView.reloadData()
+    }
+    
+    private func addCloseButton() {
+        let closeButton = UIBarButtonItem(image: Icon.Close.imageWithFontSize(size: buttonSize), style: .plain, target: nil, action: nil)
+        closeButton.accessibilityLabel = Strings.Accessibility.closeLabel
+        closeButton.accessibilityHint = Strings.Accessibility.closeHint
+        closeButton.accessibilityIdentifier = "VideoDownloadQualityViewController:close-button"
+        navigationItem.rightBarButtonItem = closeButton
+        
+        closeButton.oex_setAction { [weak self] in
+            self?.dismiss(animated: true, completion: nil)
+        }
+    }
+}
+
+extension VideoDownloadQualityViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return VideoDownloadQuality.allCases.count + 1
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: VideoQualityCell.identifier, for: indexPath) as! VideoQualityCell
+        
+        if indexPath.row == 0 {
+            let textStyle = OEXMutableTextStyle(weight: .normal, size: .small, color: OEXStyles.shared().neutralBlackT())
+            cell.titleLabel.attributedText = textStyle.attributedString(withText: Strings.VideoDownloadQuality.message(platformName: environment.config.platformName()))
+        } else {
+            let item = VideoDownloadQuality.allCases[indexPath.row - 1]
+            
+            let textStyle = OEXMutableTextStyle(weight: .normal, size: .base, color: OEXStyles.shared().primaryDarkColor())
+            cell.titleLabel.attributedText = textStyle.attributedString(withText: item.value)
+                        
+            if let quality = environment.interface?.getVideoDownladQuality(),
+               quality == item {
+                cell.showCheckmark(show: true)
+            } else {
+                cell.showCheckmark(show: false)
+            }
+        }
+        
+        return cell
+    }
+}
+
+extension VideoDownloadQualityViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if indexPath.row > 0 {
+            let oldQuality = environment.interface?.getVideoDownladQuality()
+            let quality = VideoDownloadQuality.allCases[indexPath.row - 1]
+            environment.interface?.saveVideoDownloadQuality(quality: quality)
+            tableView.reloadData()
+            
+            NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: NOTIFICATION_VIDEO_DOWNLOAD_QUALITY_CHANGED)))
+            
+            environment.analytics.trackVideoDownloadQualityChanged(value: quality.analyticsValue, oldValue: oldQuality?.analyticsValue ?? "" )
+        }
+    }
+}
+
+class VideoQualityCell: UITableViewCell {
+    static let identifier = "VideoQualityCell"
+    
+    lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        
+        return label
+    }()
+    
+    private lazy var checkmarkImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = Icon.Check.imageWithFontSize(size: buttonSize).image(with: OEXStyles.shared().neutralBlackT())
+        return imageView
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        selectionStyle = .none
+        accessibilityIdentifier = "VideoDownloadQualityViewController:video-quality-cell"
+        
+        setupView()
+        setupConstrains()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupView() {
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(checkmarkImageView)
+    }
+    
+    private func setupConstrains() {
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(contentView).offset(StandardVerticalMargin)
+            make.leading.equalTo(contentView).offset(StandardVerticalMargin * 2)
+            make.trailing.equalTo(contentView).inset(StandardVerticalMargin * 2)
+            make.bottom.equalTo(contentView).inset(StandardVerticalMargin)
+        }
+        
+        checkmarkImageView.snp.makeConstraints { make in
+            make.width.equalTo(buttonSize)
+            make.height.equalTo(buttonSize)
+            make.trailing.equalTo(contentView).inset(StandardVerticalMargin * 2)
+            make.centerY.equalTo(contentView)
+        }
+        
+        checkmarkImageView.isHidden = true
+    }
+    
+    func showCheckmark(show: Bool) {
+        checkmarkImageView.isHidden = !show
+    }
+}

--- a/Source/VideoDownloadQualityViewController.swift
+++ b/Source/VideoDownloadQualityViewController.swift
@@ -16,14 +16,16 @@ protocol VideoDownloadQualityDelegate: AnyObject {
 
 class VideoDownloadQualityViewController: UIViewController {
     
-    typealias Environment = OEXInterfaceProvider & OEXAnalyticsProvider & OEXConfigProvider & OEXStylesProvider
+    typealias Environment = OEXInterfaceProvider & OEXAnalyticsProvider & OEXConfigProvider
+    
+    private lazy var headerView = VideoDownloadQualityHeaderView()
     
     private lazy var tableView: UITableView = {
         let tableView = UITableView()
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.rowHeight = StandardVerticalMargin * 7
-        tableView.estimatedRowHeight = StandardVerticalMargin * 7
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 20
         tableView.alwaysBounceVertical = false
         tableView.separatorInset = .zero
         tableView.tableFooterView = UIView()
@@ -33,28 +35,7 @@ class VideoDownloadQualityViewController: UIViewController {
         return tableView
     }()
     
-    private lazy var headerView: UIView = {
-        let view = UIView()
-        view.accessibilityIdentifier = "VideoDownloadQualityViewController:header-view"
-        return view
-    }()
-    
-    private lazy var titleLabel: UILabel = {
-        let label = UILabel()
-        let textStyle = OEXMutableTextStyle(weight: .normal, size: .small, color: environment.styles.neutralBlackT())
-        label.attributedText = textStyle.attributedString(withText: Strings.VideoDownloadQuality.message(platformName: environment.config.platformName()))
-        label.accessibilityIdentifier = "VideoDownloadQualityViewController:title-view"
-        return label
-    }()
-    
-    private lazy var separator: UIView = {
-        let view = UIView()
-        view.backgroundColor = environment.styles.neutralXLight()
-        view.accessibilityIdentifier = "VideoDownloadQualityViewController:seperator-view"
-        return view
-    }()
-    
-    weak var delegate: VideoDownloadQualityDelegate?
+    private weak var delegate: VideoDownloadQualityDelegate?
     
     private let environment: Environment
     
@@ -88,29 +69,11 @@ class VideoDownloadQualityViewController: UIViewController {
     private func setupViews() {
         view.addSubview(tableView)
         
-        headerView.addSubview(titleLabel)
-        headerView.addSubview(separator)
-        
         tableView.tableHeaderView = headerView
-        
-        titleLabel.snp.makeConstraints { make in
-            make.leading.equalTo(headerView).offset(StandardVerticalMargin * 2)
-            make.trailing.equalTo(headerView).inset(StandardVerticalMargin * 2)
-            make.top.equalTo(headerView).offset(StandardVerticalMargin)
-            make.bottom.equalTo(headerView).inset(StandardVerticalMargin)
-        }
-        
-        separator.snp.makeConstraints { make in
-            make.leading.equalTo(headerView)
-            make.trailing.equalTo(headerView)
-            make.bottom.equalTo(headerView)
-            make.height.equalTo(1)
-        }
         
         headerView.snp.makeConstraints { make in
             make.leading.equalTo(view)
             make.trailing.equalTo(view)
-            make.height.equalTo(44)
         }
         
         tableView.snp.makeConstraints { make in
@@ -171,6 +134,63 @@ extension VideoDownloadQualityViewController: UITableViewDelegate {
     }
 }
 
+class VideoDownloadQualityHeaderView: UITableViewHeaderFooterView {
+    
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        let textStyle = OEXMutableTextStyle(weight: .normal, size: .small, color: OEXStyles.shared().neutralBlackT())
+        label.attributedText = textStyle.attributedString(withText: Strings.VideoDownloadQuality.message(platformName: OEXConfig.shared().platformName()))
+        label.accessibilityIdentifier = "VideoDownloadQualityHeaderView:title-view"
+        return label
+    }()
+    
+    private lazy var separator: UIView = {
+        let view = UIView()
+        view.backgroundColor = OEXStyles.shared().neutralXLight()
+        view.accessibilityIdentifier = "VideoDownloadQualityHeaderView:seperator-view"
+        return view
+    }()
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        
+        accessibilityIdentifier = "VideoDownloadQualityHeaderView"
+        
+        setupViews()
+        setupConstrains()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        accessibilityIdentifier = "VideoDownloadQualityHeaderView"
+        
+        setupViews()
+        setupConstrains()
+    }
+    
+    private func setupViews() {
+        addSubview(titleLabel)
+        addSubview(separator)
+    }
+    
+    private func setupConstrains() {
+        titleLabel.snp.makeConstraints { make in
+            make.leading.equalTo(self).offset(StandardVerticalMargin * 2)
+            make.trailing.equalTo(self).inset(StandardVerticalMargin * 2)
+            make.top.equalTo(self).offset(StandardVerticalMargin * 2)
+            make.bottom.equalTo(self).inset(StandardVerticalMargin * 2)
+        }
+        
+        separator.snp.makeConstraints { make in
+            make.leading.equalTo(self)
+            make.trailing.equalTo(self)
+            make.bottom.equalTo(self)
+            make.height.equalTo(1)
+        }
+    }
+}
+
 class VideoQualityCell: UITableViewCell {
     static let identifier = "VideoQualityCell"
     
@@ -211,10 +231,10 @@ class VideoQualityCell: UITableViewCell {
     
     private func setupConstrains() {
         titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(contentView).offset(StandardVerticalMargin)
+            make.top.equalTo(contentView).offset(StandardVerticalMargin * 2)
             make.leading.equalTo(contentView).offset(StandardVerticalMargin * 2)
             make.trailing.equalTo(contentView).inset(StandardVerticalMargin * 2)
-            make.bottom.equalTo(contentView).inset(StandardVerticalMargin)
+            make.bottom.equalTo(contentView).inset(StandardVerticalMargin * 2)
         }
         
         checkmarkImageView.snp.makeConstraints { make in

--- a/Source/VideoDownloadQualityViewController.swift
+++ b/Source/VideoDownloadQualityViewController.swift
@@ -162,11 +162,6 @@ class VideoDownloadQualityHeaderView: UITableViewHeaderFooterView {
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        
-        accessibilityIdentifier = "VideoDownloadQualityHeaderView"
-        
-        setupViews()
-        setupConstrains()
     }
     
     private func setupViews() {
@@ -245,10 +240,6 @@ class VideoQualityCell: UITableViewCell {
         }
         
         checkmarkImageView.isHidden = true
-    }
-    
-    func showCheckmark(show: Bool) {
-        checkmarkImageView.isHidden = !show
     }
     
     func update(title: String, selected: Bool) {

--- a/Source/VideoDownloadQualityViewController.swift
+++ b/Source/VideoDownloadQualityViewController.swift
@@ -99,7 +99,7 @@ extension VideoDownloadQualityViewController: UITableViewDataSource {
             let item = VideoDownloadQuality.allCases[indexPath.row - 1]
             
             let textStyle = OEXMutableTextStyle(weight: .normal, size: .base, color: OEXStyles.shared().primaryDarkColor())
-            cell.titleLabel.attributedText = textStyle.attributedString(withText: item.value)
+            cell.titleLabel.attributedText = textStyle.attributedString(withText: item.title)
                         
             if let quality = environment.interface?.getVideoDownladQuality(),
                quality == item {
@@ -118,12 +118,10 @@ extension VideoDownloadQualityViewController: UITableViewDelegate {
         if indexPath.row > 0 {
             let oldQuality = environment.interface?.getVideoDownladQuality()
             let quality = VideoDownloadQuality.allCases[indexPath.row - 1]
-            environment.interface?.saveVideoDownloadQuality(quality: quality)
             tableView.reloadData()
-            
-            NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: NOTIFICATION_VIDEO_DOWNLOAD_QUALITY_CHANGED)))
-            
+            environment.interface?.saveVideoDownloadQuality(quality: quality)
             environment.analytics.trackVideoDownloadQualityChanged(value: quality.analyticsValue, oldValue: oldQuality?.analyticsValue ?? "" )
+            NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: NOTIFICATION_VIDEO_DOWNLOAD_QUALITY_CHANGED)))
         }
     }
 }

--- a/Source/VideoDownloadQualityViewController.swift
+++ b/Source/VideoDownloadQualityViewController.swift
@@ -54,7 +54,7 @@ class VideoDownloadQualityViewController: UIViewController {
         
         navigationItem.largeTitleDisplayMode = .never
         
-        title = Strings.VideoDownloadQuality.title
+        title = Strings.videoDownloadQualityTitle
         
         setupViews()
         addCloseButton()
@@ -139,7 +139,7 @@ class VideoDownloadQualityHeaderView: UITableViewHeaderFooterView {
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         let textStyle = OEXMutableTextStyle(weight: .normal, size: .small, color: OEXStyles.shared().neutralBlackT())
-        label.attributedText = textStyle.attributedString(withText: Strings.VideoDownloadQuality.message(platformName: OEXConfig.shared().platformName()))
+        label.attributedText = textStyle.attributedString(withText: Strings.videoDownloadQualityMessage(platformName: OEXConfig.shared().platformName()))
         label.accessibilityIdentifier = "VideoDownloadQualityHeaderView:title-view"
         return label
     }()

--- a/Source/VideoDownloadQualityViewController.swift
+++ b/Source/VideoDownloadQualityViewController.swift
@@ -45,7 +45,7 @@ class VideoDownloadQualityViewController: UIViewController {
         
         navigationItem.largeTitleDisplayMode = .never
         
-        title = "Video download quality"
+        title = Strings.VideoDownloadQuality.title
         
         setupViews()
         addCloseButton()
@@ -129,11 +129,7 @@ extension VideoDownloadQualityViewController: UITableViewDelegate {
 class VideoQualityCell: UITableViewCell {
     static let identifier = "VideoQualityCell"
     
-    lazy var titleLabel: UILabel = {
-        let label = UILabel()
-        
-        return label
-    }()
+    lazy var titleLabel = UILabel()
     
     private lazy var checkmarkImageView: UIImageView = {
         let imageView = UIImageView()

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -923,6 +923,18 @@
 "CELEBRATION.EARNED_IT_TEXT"="You earned it!";
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
+/* Settigs message for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+/* Settigs title for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+/* Settigs message for Video Download Quality Auto */
+"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+/* Settigs message for Video Download Quality High */
+"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -924,17 +924,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+"VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -863,6 +863,18 @@
 "CELEBRATION.EARNED_IT_TEXT"="You earned it!";
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
+/* Settigs message for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+/* Settigs title for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+/* Settigs message for Video Download Quality Auto */
+"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+/* Settigs message for Video Download Quality High */
+"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -864,17 +864,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+"VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -863,6 +863,18 @@
 "CELEBRATION.EARNED_IT_TEXT"="You earned it!";
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
+/* Settigs message for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+/* Settigs title for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+/* Settigs message for Video Download Quality Auto */
+"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+/* Settigs message for Video Download Quality High */
+"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -864,17 +864,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+"VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -861,6 +861,18 @@
 "CELEBRATION.EARNED_IT_TEXT"="You earned it!";
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
+/* Settigs message for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+/* Settigs title for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+/* Settigs message for Video Download Quality Auto */
+"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+/* Settigs message for Video Download Quality High */
+"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -862,17 +862,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+"VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -863,6 +863,18 @@
 "CELEBRATION.EARNED_IT_TEXT"="You earned it!";
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
+/* Settigs message for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+/* Settigs title for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+/* Settigs message for Video Download Quality Auto */
+"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+/* Settigs message for Video Download Quality High */
+"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -864,17 +864,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+"VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -887,6 +887,18 @@
 "CELEBRATION.EARNED_IT_TEXT"="You earned it!";
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
+/* Settigs message for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+/* Settigs title for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+/* Settigs message for Video Download Quality Auto */
+"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+/* Settigs message for Video Download Quality High */
+"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -888,17 +888,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+"VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -848,6 +848,18 @@
 "CELEBRATION.EARNED_IT_TEXT"="You earned it!";
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
+/* Settigs message for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+/* Settigs title for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+/* Settigs message for Video Download Quality Auto */
+"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+/* Settigs message for Video Download Quality High */
+"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -849,17 +849,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+"VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -863,6 +863,18 @@
 "CELEBRATION.EARNED_IT_TEXT"="You earned it!";
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
+/* Settigs message for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+/* Settigs title for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+/* Settigs message for Video Download Quality Auto */
+"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+/* Settigs message for Video Download Quality High */
+"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -864,17 +864,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+"VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -861,6 +861,18 @@
 "CELEBRATION.EARNED_IT_TEXT"="You earned it!";
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
+/* Settigs message for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+/* Settigs title for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+/* Settigs message for Video Download Quality Auto */
+"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+/* Settigs message for Video Download Quality High */
+"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -862,17 +862,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+"VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -848,6 +848,18 @@
 "CELEBRATION.EARNED_IT_TEXT"="You earned it!";
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
+/* Settigs message for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+/* Settigs title for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+/* Settigs message for Video Download Quality Auto */
+"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+/* Settigs message for Video Download Quality High */
+"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -849,17 +849,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+"VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -848,6 +848,18 @@
 "CELEBRATION.EARNED_IT_TEXT"="You earned it!";
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
+/* Settigs message for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+/* Settigs title for Video Download Quality */
+"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+/* Settigs message for Video Download Quality Auto */
+"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+/* Settigs message for Video Download Quality Low */
+"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+/* Settigs message for Video Download Quality High */
+"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -849,17 +849,17 @@
 /*Button title for celebratory modal*/
 "CELEBRATION.KEEP_GOING_BUTTON_TITLE"="Keep going";
 /* Settigs message for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
+"VIDEO_DOWNLOAD_QUALITY_MESSAGE" = "This setting is for all video downloads in the {platform_name} app.";
 /* Settigs title for Video Download Quality */
-"VIDEO_DOWNLOAD_QUALITY.TITLE" = "Video download quality";
+"VIDEO_DOWNLOAD_QUALITY_TITLE" = "Video download quality";
 /* Settigs message for Video Download Quality Auto */
-"VIDEO_DOWNLOAD_QUALITY.AUTO" = "Auto (Recommended)";
+"VIDEO_DOWNLOAD_QUALITY_AUTO" = "Auto (Recommended)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.LOW" = "360p (Smallest file size)";
+"VIDEO_DOWNLOAD_QUALITY_LOW" = "360p (Smallest file size)";
 /* Settigs message for Video Download Quality Low */
-"VIDEO_DOWNLOAD_QUALITY.MEDIUM" = "540p";
+"VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
-"VIDEO_DOWNLOAD_QUALITY.HIGH" = "720p (Best quality)";
+"VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
 /* Settings title for wifi */
 "PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
 /* Settings heading for wifi */

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		5DEA47D71B62F64300831EC9 /* DiscussionObjectModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DEA47D61B62F64300831EC9 /* DiscussionObjectModel.swift */; };
 		5F0248C624AC9ED8000AF1FF /* CourseDates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0248C524AC9ED8000AF1FF /* CourseDates.swift */; };
 		5F0248C824AC9F09000AF1FF /* CourseDatesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0248C724AC9F09000AF1FF /* CourseDatesAPI.swift */; };
+		5F1E03FC26CA64B9004F8139 /* VideoDownloadQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1E03FB26CA64B9004F8139 /* VideoDownloadQuality.swift */; };
 		5F28980A25074D5A00BF76DF /* CourseDateBannerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F28980925074D5A00BF76DF /* CourseDateBannerModel.swift */; };
 		5F28980C2507B19400BF76DF /* CourseDateBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F28980B2507B19400BF76DF /* CourseDateBannerView.swift */; };
 		5F2C5A19242C99EE00FBF986 /* CollectionPaginationManipulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2C5A18242C99EE00FBF986 /* CollectionPaginationManipulator.swift */; };
@@ -210,6 +211,7 @@
 		5F7C0C642534520200A344B9 /* FillBackgroundTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7C0C632534520200A344B9 /* FillBackgroundTextStorage.swift */; };
 		5F7C0C6A2534521300A344B9 /* FillBackgroundLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7C0C692534521300A344B9 /* FillBackgroundLayoutManager.swift */; };
 		5F903AF4255020D7006365DE /* UIDeviceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F903AF3255020D7006365DE /* UIDeviceExtension.swift */; };
+		5F99F3BD26C68308000605B4 /* VideoDownloadQualityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F99F3BC26C68308000605B4 /* VideoDownloadQualityViewController.swift */; };
 		5FAE055324EA647D00A29B1D /* CourseDates.json in Resources */ = {isa = PBXBuildFile; fileRef = 5FAE055124EA618000A29B1D /* CourseDates.json */; };
 		5FAE055524EA866900A29B1D /* CourseDatesModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FAE055424EA866900A29B1D /* CourseDatesModelTests.swift */; };
 		5FB44C1324978EFB00C59DD0 /* RegistrationSelectOptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB44C1224978EFB00C59DD0 /* RegistrationSelectOptionViewController.swift */; };
@@ -1226,6 +1228,7 @@
 		5DEA47D61B62F64300831EC9 /* DiscussionObjectModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiscussionObjectModel.swift; sourceTree = "<group>"; };
 		5F0248C524AC9ED8000AF1FF /* CourseDates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDates.swift; sourceTree = "<group>"; };
 		5F0248C724AC9F09000AF1FF /* CourseDatesAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDatesAPI.swift; sourceTree = "<group>"; };
+		5F1E03FB26CA64B9004F8139 /* VideoDownloadQuality.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoDownloadQuality.swift; sourceTree = "<group>"; };
 		5F28980925074D5A00BF76DF /* CourseDateBannerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDateBannerModel.swift; sourceTree = "<group>"; };
 		5F28980B2507B19400BF76DF /* CourseDateBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDateBannerView.swift; sourceTree = "<group>"; };
 		5F2C5A18242C99EE00FBF986 /* CollectionPaginationManipulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionPaginationManipulator.swift; sourceTree = "<group>"; };
@@ -1259,6 +1262,7 @@
 		5F7C0C632534520200A344B9 /* FillBackgroundTextStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillBackgroundTextStorage.swift; sourceTree = "<group>"; };
 		5F7C0C692534521300A344B9 /* FillBackgroundLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillBackgroundLayoutManager.swift; sourceTree = "<group>"; };
 		5F903AF3255020D7006365DE /* UIDeviceExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDeviceExtension.swift; sourceTree = "<group>"; };
+		5F99F3BC26C68308000605B4 /* VideoDownloadQualityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoDownloadQualityViewController.swift; sourceTree = "<group>"; };
 		5FAE055124EA618000A29B1D /* CourseDates.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CourseDates.json; sourceTree = "<group>"; };
 		5FAE055424EA866900A29B1D /* CourseDatesModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDatesModelTests.swift; sourceTree = "<group>"; };
 		5FB44C1224978EFB00C59DD0 /* RegistrationSelectOptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationSelectOptionViewController.swift; sourceTree = "<group>"; };
@@ -2542,12 +2546,14 @@
 			name = SwiftDate;
 			sourceTree = "<group>";
 		};
-		5F59B3FE26AFF59900D6CA3E /* ProfileView */ = {
+		5F59B3FE26AFF59900D6CA3E /* Settings */ = {
 			isa = PBXGroup;
 			children = (
 				5F59B3FF26AFF5B000D6CA3E /* ProfileOptionsViewController.swift */,
+				5F99F3BC26C68308000605B4 /* VideoDownloadQualityViewController.swift */,
+				5F1E03FB26CA64B9004F8139 /* VideoDownloadQuality.swift */,
 			);
-			name = ProfileView;
+			name = Settings;
 			sourceTree = "<group>";
 		};
 		5F5FC009269DA8AE00F92B8F /* ValueProp */ = {
@@ -3945,7 +3951,7 @@
 		BECB7B141924C0C3009C77F1 /* Source */ = {
 			isa = PBXGroup;
 			children = (
-				5F59B3FE26AFF59900D6CA3E /* ProfileView */,
+				5F59B3FE26AFF59900D6CA3E /* Settings */,
 				0D157631235EDA5B0007B0B7 /* ChromeCast */,
 				2271C54621634A5F001EA1E6 /* Deep Linking */,
 				B70BCFDC20B41C38005F0D19 /* SubjectsDiscovery */,
@@ -5117,6 +5123,7 @@
 				1AB539FC1C0396770065501F /* OEXAnayltics+Certificates.swift in Sources */,
 				1A6E86241BB9C6500039A216 /* OEXStyles+Profile.swift in Sources */,
 				193B504519459C2F0038E11C /* OEXCustomButton.m in Sources */,
+				5F1E03FC26CA64B9004F8139 /* VideoDownloadQuality.swift in Sources */,
 				1A2CCDAB1BDE6F6500D03022 /* OEXAnalytics+Profiles.swift in Sources */,
 				B4B6D6001A949EFC000F44E8 /* OEXRegistrationDescription.m in Sources */,
 				5DEA47D71B62F64300831EC9 /* DiscussionObjectModel.swift in Sources */,
@@ -5486,6 +5493,7 @@
 				E40AEA73218D074700049C39 /* YoutubeVideoConfig.swift in Sources */,
 				B7CCC730209B16B100A66923 /* ConstraintOffsetTarget.swift in Sources */,
 				E076A5C21C7DB624008A99C6 /* DiscussionResponsesDataController.swift in Sources */,
+				5F99F3BD26C68308000605B4 /* VideoDownloadQualityViewController.swift in Sources */,
 				1A5AC5801B94ED0D00885187 /* CourseCardViewModel.swift in Sources */,
 				77FFA2CC1AC35CE800B4D69B /* OEXRegistrationStyles.m in Sources */,
 				77567B771AC9FC1400877A7B /* NSNotificationCenter+OEXSafeAccess.m in Sources */,


### PR DESCRIPTION
### Description

[LEARNER-8503](https://openedx.atlassian.net/browse/LEARNER-8503)

Give learners the choice to download whichever video quality they want to download.

### How to test this PR
- [x] UI: Settings Page

-  Add the video download quality selection option on the Settings screen

- 4 options to select the download quality are available when the user taps into the video download quality selection option

- mobile_low_360p, mobile_high _540p, desktop_mp4 (720p):  all the mappings

- [ ]  UI: Videos Page

- A new section will be added to the video downloads page where the user can see the currently selected download quality option

- Tapping on this section will deeplink to the quality selector (1.b.)

- The download size will be calculated based on the selected download quality option

 - [ ] Defaults & Persistence 

- The default selection will be ‘Auto’

- Current ‘Auto' behavior is mobile_low → mobile_high → fallback downloads firsts

- Keep this behavior the same for the “auto” selection

- Once the user selects an option, it will persist until the user selects another option. 

- The selected option will be applicable to all courses for that user on that device.

- If the selected quality is not available for a video, the next lower quality will be used to download. If the user has already selected the lowest quality, then we will select the quality that’s closest to that.

- Download videos according to the selected video option

- [ ]  Analytics

- Tap on video download quality selection on the settings page

- Quality option selected

- Tap on the quality settings on videos page

# Screenshots

<img src="https://user-images.githubusercontent.com/960241/130201950-59fdf6a9-7018-46bd-aca8-9a6f9abd414a.png" width="320" height="640">

<img src="https://user-images.githubusercontent.com/960241/130201962-cd955e3d-4106-4433-9d3c-bb01a4573e9c.png" width="320" height="640">

