### PR TITLE
[feat] Added deep link support to the profile screen & improve the de…

### DIFF
--- a/Source/Deep Linking/DeepLink.swift
+++ b/Source/Deep Linking/DeepLink.swift
@@ -26,7 +26,7 @@ enum DeepLinkType: String {
     case courseDetail = "course_detail"
     case program = "program"
     case programDetail = "program_detail"
-    case account = "account"
+    case userProfile = "user_profile"
     case profile = "profile"
     case none = "none"
 }

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -105,9 +105,9 @@ typealias DismissCompletion = () -> Void
         } else if controller is DiscussionTopicsViewController {
             return .discussions
         } else if controller is ProfileOptionsViewController {
-            return .account
-        } else if controller is UserProfileViewController {
             return .profile
+        } else if controller is UserProfileViewController {
+            return .userProfile
         }
         
         return .none
@@ -270,34 +270,49 @@ typealias DismissCompletion = () -> Void
             }
         }
     }
-    
-    private func showAccountViewController(with link: DeepLink) {
+
+    // Profile screen having different options like video settings, faq, support email
+    private func showProfile(with link: DeepLink, completion: (() -> ())? = nil) {
         guard !controllerAlreadyDisplayed(for: link.type) else { return}
-        
-        dismiss() { [weak self] in
-            if let topViewController = self?.topMostViewController {
-                self?.environment?.router?.showProfile(controller: topViewController)
+        guard let topViewController = topMostViewController else { return }
+
+        if topViewController is UserProfileViewController || topViewController is UserProfileEditViewController || topViewController is JSONFormViewController<String> || topViewController is JSONFormBuilderTextEditorViewController {
+            if let viewController = topViewController.navigationController?.viewControllers.first(where: {$0 is ProfileOptionsViewController}) {
+                topViewController.navigationController?.popToViewController(viewController, animated: true)
+                topViewController.navigationController?.navigationBar.applyDefaultNavbarColorScheme()
+                completion?()
+            }
+        }
+        else {
+            dismiss() { [weak self] in
+                if let topViewController = self?.topMostViewController {
+                    self?.environment?.router?.showProfile(controller: topViewController)
+                    completion?()
+                }
             }
         }
     }
     
-    private func showProfile(with link: DeepLink) {
+    private func showUserProfile(with link: DeepLink) {
+        guard !controllerAlreadyDisplayed(for: link.type) else { return}
         guard let topViewController = topMostViewController, let username = environment?.session.currentUser?.username else { return }
         
         func showView(modal: Bool) {
             environment?.router?.showProfileForUsername(controller: topMostViewController, username: username, editable: false, modal: modal)
         }
         
-        if (topViewController as? ForwardingNavigationController)?.visibleViewController is ProfileOptionsViewController {
+        if topViewController is ProfileOptionsViewController {
             showView(modal: false)
         } else if topViewController is UserProfileEditViewController || topViewController is JSONFormViewController<String> || topViewController is JSONFormBuilderTextEditorViewController {
             if let viewController = topViewController.navigationController?.viewControllers.first(where: {$0 is UserProfileViewController}) {
                 topViewController.navigationController?.popToViewController(viewController, animated: true)
             }
         }
-        else if !controllerAlreadyDisplayed(for: link.type) {
-            dismiss() {
-                showView(modal: true)
+        else {
+            dismiss() { [weak self] in
+                self?.showProfile(with: link) {
+                    self?.showUserProfile(with: link)
+                }
             }
         }
     }
@@ -510,11 +525,11 @@ typealias DismissCompletion = () -> Void
             guard environment?.config.programConfig.enabled ?? false else { return }
             showProgramDetail(with: link)
             break
-        case .account:
-            showAccountViewController(with: link)
-            break
         case .profile:
             showProfile(with: link)
+            break
+        case .userProfile:
+            showUserProfile(with: link)
             break
         case .discussionTopic:
             showDiscussionTopic(with: link)

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -291,6 +291,7 @@ typealias DismissCompletion = () -> Void
             if let viewController = topViewController.navigationController?.viewControllers.first(where: {$0 is ProfileOptionsViewController}) {
                 topViewController.navigationController?.popToViewController(viewController, animated: true)
                 topViewController.navigationController?.navigationBar.applyDefaultNavbarColorScheme()
+                completion?(true)
             }
             else {
                 environment?.router?.showProfile(controller: topViewController, completion: completion)

--- a/Source/Deep Linking/DeepLinkManager.swift
+++ b/Source/Deep Linking/DeepLinkManager.swift
@@ -273,15 +273,15 @@ typealias DismissCompletion = () -> Void
 
     // Profile screen having different options like video settings, faq, support email
     private func showProfile(with link: DeepLink, completion: ((_ success: Bool) -> ())? = nil) {
-        guard let topViewController = topMostViewController else
-        {
+        guard let topViewController = topMostViewController else {
             completion?(false)
             return
         }
 
-        // We can't use controllerAlreadyDisplayed here user the UserProfileViewController can be on the screen from forums
-        // In the forums UserProfileViewController will be for a different user so we need to show the logged in user profile
-        // stackController is ProfileOptionsViewController means the profile opens from new profile (settings) screen
+        // We can't use the controllerAlreadyDisplayed method here to check either the user is already on the user profile screen or not
+        // Because the user could have accessed the UserProfileViewController screen from the discussion forums
+        // From the discussion forums, the UserProfileViewController screen will be for a different user so we need to show the profile screen of the logged-in user
+        // if the stackController is equals to the ProfileOptionsViewController, it means the user profile screen opens from new profile (settings) screen
         if topViewController is ProfileOptionsViewController {
             completion?(true)
             return
@@ -310,9 +310,10 @@ typealias DismissCompletion = () -> Void
         guard let topViewController = topMostViewController,
               let username = environment?.session.currentUser?.username else { return }
 
-        // We can't use controllerAlreadyDisplayed here user the UserProfileViewController can be on the screen from forums
-        // In the forums UserProfileViewController will be for a different user so we need to show the logged in user profile
-        // stackController is ProfileOptionsViewController means the profile opens from new profile (settings) screen
+        // We can't use the controllerAlreadyDisplayed method here to check either the user is already on the user profile screen or not
+        // Because the user could have accessed the UserProfileViewController screen from the discussion forums
+        // From the discussion forums, the UserProfileViewController screen will be for a different user so we need to show the profile screen of the logged-in user
+        // if the stackController is equals to the ProfileOptionsViewController, it means the user profile screen opens from new profile (settings) screen
         let stackController = topViewController.navigationController?.viewControllers.first
         if topViewController is UserProfileViewController && stackController is ProfileOptionsViewController {
             return

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -403,9 +403,9 @@ extension OEXRouter {
         let profileViewController = ProfileOptionsViewController(environment: environment)
         let navigationController = ForwardingNavigationController(rootViewController: profileViewController)
         navigationController.navigationBar.prefersLargeTitles = true
-        controller?.navigationController?.present(navigationController, animated: true, completion: {
+        controller?.navigationController?.present(navigationController, animated: true) {
             completion?(true)
-        })
+        }
     }
     
     func showValuePropDetailView(from controller: UIViewController? = nil, type: ValuePropModalType, course: OEXCourse, completion: (() -> Void)? = nil) {

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -399,11 +399,13 @@ extension OEXRouter {
         controller.navigationController?.pushViewController(handoutsViewController, animated: true)
     }
     
-    func showProfile(controller: UIViewController? = nil) {        
+    func showProfile(controller: UIViewController? = nil, completion: ((_ success: Bool) -> ())? = nil) {
         let profileViewController = ProfileOptionsViewController(environment: environment)
         let navigationController = ForwardingNavigationController(rootViewController: profileViewController)
         navigationController.navigationBar.prefersLargeTitles = true
-        controller?.navigationController?.present(navigationController, animated: true, completion: nil)
+        controller?.navigationController?.present(navigationController, animated: true, completion: {
+            completion?(true)
+        })
     }
     
     func showValuePropDetailView(from controller: UIViewController? = nil, type: ValuePropModalType, course: OEXCourse, completion: (() -> Void)? = nil) {


### PR DESCRIPTION
### Description

[LEARNER-](https://openedx.atlassian.net/browse/LEARNER-)

This PR adds the support of deep-link to the profile screen & improve the deep link flow for learner profile.

Following deep links can be used to test the PR.
[Profile](https://edx.app.link/profiletest)
[Learner Profile](https://edx.app.link/learnerprofiletest)


### Testing
- [ ] Users should be navigated to the New profile screen when the deep link with screen_name: profile opens the app.
- [ ] Users should be navigated to the user profile screen when the deep link with screen_name: user_profile opens the app. The user profile should open from the new profile screen stack.
