### PR TITLE
[feature] Open Unit URL in a In-App Webview' from the Open in Browser Banner

### DIFF
--- a/Source/BrowserViewController.swift
+++ b/Source/BrowserViewController.swift
@@ -1,0 +1,65 @@
+//
+//  BrowserViewController.swift
+//  edX
+//
+//  Created by Muhammad Umer on 04/06/2021.
+//  Copyright © 2021 edX. All rights reserved.
+//
+
+import UIKit
+
+class BrowserViewController: UIViewController {
+    
+    typealias Environment = OEXAnalyticsProvider & OEXConfigProvider & OEXSessionProvider & ReachabilityProvider
+    
+    private lazy var webController = AuthenticatedWebViewController(environment: environment)
+    
+    private let url: URL
+    private let environment: Environment
+    
+    init(url: URL, environment: Environment) {
+        self.url = url
+        self.environment = environment
+        super.init(nibName: nil, bundle :nil)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureSubview()
+        loadRequest()
+    }
+    
+    private func loadRequest() {
+        let request = NSURLRequest(url: url)
+        webController.loadRequest(request: request)
+    }
+    
+    private func configureSubview() {
+        addSubviews()
+        addCloseButton()
+    }
+    
+    private func addSubviews() {
+        addChild(webController)
+        webController.didMove(toParent: self)
+        view.addSubview(webController.view)
+        
+        webController.view.snp.remakeConstraints { make in
+            make.edges.equalTo(view)
+        }
+    }
+    
+    private func addCloseButton() {
+        let closeButton = UIBarButtonItem(image: Icon.Close.imageWithFontSize(size: 20), style: .plain, target: nil, action: nil)
+        navigationItem.rightBarButtonItem = closeButton
+        
+        closeButton.oex_setAction { [weak self] in
+            self?.dismiss(animated: true, completion: nil)
+        }
+    }
+}

--- a/Source/BrowserViewController.swift
+++ b/Source/BrowserViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol BrowserViewControllerDelegate: AnyObject {
-    func didDissmissBrowser()
+    func didDismissBrowser()
 }
 
 class BrowserViewController: UIViewController, InterfaceOrientationOverriding {
@@ -69,9 +69,9 @@ class BrowserViewController: UIViewController, InterfaceOrientationOverriding {
         navigationItem.rightBarButtonItem = closeButton
         
         closeButton.oex_setAction { [weak self] in
-            self?.dismiss(animated: true, completion: {
-                self?.delegate?.didDissmissBrowser()
-            })
+            self?.dismiss(animated: true) {
+                self?.delegate?.didDismissBrowser()
+            }
         }
     }
 

--- a/Source/HTMLBlockViewController.swift
+++ b/Source/HTMLBlockViewController.swift
@@ -112,8 +112,8 @@ class HTMLBlockViewController: UIViewController, CourseBlockViewController, Prel
         }
     }
     
-    private func loadWebviewStream() {
-        if !loader.hasBacking {
+    private func loadWebviewStream(_ forceLoad: Bool = false) {
+        if !loader.hasBacking || forceLoad {
             let courseQuerierStream = courseQuerier.blockWithID(id: self.blockID).firstSuccess()
             loader.addBackingStream(courseQuerierStream)
             
@@ -292,11 +292,18 @@ extension HTMLBlockViewController: AJAXCompletionCallbackDelegate {
     }
 }
 
-extension HTMLBlockViewController: OpenInExternalBrowserViewDelegate {
+extension HTMLBlockViewController: OpenInExternalBrowserViewDelegate, BrowserViewControllerDelegate {
     func openInExternalBrower() {
-        guard let webURL = block?.webURL as URL? else { return }
+        guard let blockID = block?.blockID else { return }
+        let parent = courseQuerier.parentOfBlockWith(id: blockID).firstSuccess().value
+        guard let unitURL = parent?.blockURL as URL? else { return }
+
         trackOpenInBrowserBannerEvent(displayName: AnalyticsDisplayName.OpenInBrowserBannerTapped, eventName: AnalyticsEventName.OpenInBrowserBannerTapped)
-        
-        environment.router?.showLocalBrowserViewController(from: self, url: webURL)
+
+        environment.router?.showLocalBrowserViewController(from: self, title: parent?.displayName, url: unitURL)
+    }
+
+    func didDissmissBrowser() {
+        loadWebviewStream(true)
     }
 }

--- a/Source/HTMLBlockViewController.swift
+++ b/Source/HTMLBlockViewController.swift
@@ -294,16 +294,17 @@ extension HTMLBlockViewController: AJAXCompletionCallbackDelegate {
 
 extension HTMLBlockViewController: OpenInExternalBrowserViewDelegate, BrowserViewControllerDelegate {
     func openInExternalBrower() {
-        guard let blockID = block?.blockID else { return }
-        let parent = courseQuerier.parentOfBlockWith(id: blockID).firstSuccess().value
-        guard let unitURL = parent?.blockURL as URL? else { return }
+        guard let blockID = block?.blockID,
+              let parent = courseQuerier.parentOfBlockWith(id: blockID).firstSuccess().value,
+              let unitURL = parent.blockURL as URL? else { return }
 
         trackOpenInBrowserBannerEvent(displayName: AnalyticsDisplayName.OpenInBrowserBannerTapped, eventName: AnalyticsEventName.OpenInBrowserBannerTapped)
-
-        environment.router?.showLocalBrowserViewController(from: self, title: parent?.displayName, url: unitURL)
+        environment.router?.showBrowserViewController(from: self, title: parent.displayName, url: unitURL)
     }
 
-    func didDissmissBrowser() {
+    // We want to force reload the component screen because if the learner has taken any action
+    // on the in-app browser screen, the learner get updated experience on the component as well
+    func didDismissBrowser() {
         loadWebviewStream(true)
     }
 }

--- a/Source/HTMLBlockViewController.swift
+++ b/Source/HTMLBlockViewController.swift
@@ -296,8 +296,7 @@ extension HTMLBlockViewController: OpenInExternalBrowserViewDelegate {
     func openInExternalBrower() {
         guard let webURL = block?.webURL as URL? else { return }
         trackOpenInBrowserBannerEvent(displayName: AnalyticsDisplayName.OpenInBrowserBannerTapped, eventName: AnalyticsEventName.OpenInBrowserBannerTapped)
-        if UIApplication.shared.canOpenURL(webURL) {
-            UIApplication.shared.open(webURL, options: [:], completionHandler: nil)
-        }
+        
+        environment.router?.showLocalBrowserViewController(from: self, url: webURL)
     }
 }

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -411,8 +411,11 @@ extension OEXRouter {
         controller?.present(ForwardingNavigationController(rootViewController: upgradeDetailController), animated: true, completion: completion)
     }
     
-    func showLocalBrowserViewController(from controller: UIViewController, url: URL, completion: (() -> Void)? = nil) {
-        let browserViewController = BrowserViewController(url: url, environment: environment)
+    func showLocalBrowserViewController(from controller: UIViewController, title: String?,  url: URL, completion: (() -> Void)? = nil) {
+        let browserViewController = BrowserViewController(title: title, url: url, environment: environment)
+        if let controller = controller as? BrowserViewControllerDelegate {
+            browserViewController.delegate = controller
+        }
         let navController = ForwardingNavigationController(rootViewController: browserViewController)
         navController.modalPresentationStyle = .fullScreen
         controller.present(navController, animated: true, completion: completion)

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -411,6 +411,13 @@ extension OEXRouter {
         controller?.present(ForwardingNavigationController(rootViewController: upgradeDetailController), animated: true, completion: completion)
     }
     
+    func showLocalBrowserViewController(from controller: UIViewController, url: URL, completion: (() -> Void)? = nil) {
+        let browserViewController = BrowserViewController(url: url, environment: environment)
+        let navController = ForwardingNavigationController(rootViewController: browserViewController)
+        navController.modalPresentationStyle = .fullScreen
+        controller.present(navController, animated: true, completion: completion)
+    }
+    
     func showProfileForUsername(controller: UIViewController? = nil, username : String, editable: Bool = true, modal: Bool = false) {
         OEXAnalytics.shared().trackProfileViewed(username: username)
         let editable = self.environment.session.currentUser?.username == username

--- a/Source/OEXRouter+Swift.swift
+++ b/Source/OEXRouter+Swift.swift
@@ -411,7 +411,7 @@ extension OEXRouter {
         controller?.present(ForwardingNavigationController(rootViewController: upgradeDetailController), animated: true, completion: completion)
     }
     
-    func showLocalBrowserViewController(from controller: UIViewController, title: String?,  url: URL, completion: (() -> Void)? = nil) {
+    func showBrowserViewController(from controller: UIViewController, title: String?,  url: URL, completion: (() -> Void)? = nil) {
         let browserViewController = BrowserViewController(title: title, url: url, environment: environment)
         if let controller = controller as? BrowserViewControllerDelegate {
             browserViewController.delegate = controller

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		5F7C0C6A2534521300A344B9 /* FillBackgroundLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7C0C692534521300A344B9 /* FillBackgroundLayoutManager.swift */; };
 		5F903AF4255020D7006365DE /* UIDeviceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F903AF3255020D7006365DE /* UIDeviceExtension.swift */; };
 		5F99F3BD26C68308000605B4 /* VideoDownloadQualityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F99F3BC26C68308000605B4 /* VideoDownloadQualityViewController.swift */; };
+		5FA7FEB1266A2BE5006286B6 /* BrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA7FEB0266A2BE5006286B6 /* BrowserViewController.swift */; };
 		5FAE055324EA647D00A29B1D /* CourseDates.json in Resources */ = {isa = PBXBuildFile; fileRef = 5FAE055124EA618000A29B1D /* CourseDates.json */; };
 		5FAE055524EA866900A29B1D /* CourseDatesModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FAE055424EA866900A29B1D /* CourseDatesModelTests.swift */; };
 		5FB44C1324978EFB00C59DD0 /* RegistrationSelectOptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FB44C1224978EFB00C59DD0 /* RegistrationSelectOptionViewController.swift */; };
@@ -1263,6 +1264,7 @@
 		5F7C0C692534521300A344B9 /* FillBackgroundLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillBackgroundLayoutManager.swift; sourceTree = "<group>"; };
 		5F903AF3255020D7006365DE /* UIDeviceExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIDeviceExtension.swift; sourceTree = "<group>"; };
 		5F99F3BC26C68308000605B4 /* VideoDownloadQualityViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoDownloadQualityViewController.swift; sourceTree = "<group>"; };
+		5FA7FEB0266A2BE5006286B6 /* BrowserViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserViewController.swift; sourceTree = "<group>"; };
 		5FAE055124EA618000A29B1D /* CourseDates.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = CourseDates.json; sourceTree = "<group>"; };
 		5FAE055424EA866900A29B1D /* CourseDatesModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDatesModelTests.swift; sourceTree = "<group>"; };
 		5FB44C1224978EFB00C59DD0 /* RegistrationSelectOptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationSelectOptionViewController.swift; sourceTree = "<group>"; };
@@ -3855,6 +3857,7 @@
 				B760E5552010DD6800ECACAB /* BulkDownloadHelper.swift */,
 				5F5FC009269DA8AE00F92B8F /* ValueProp */,
 				225E9FDB25BAF79E000D6332 /* CelebratoryModalViewController.swift */,
+				5FA7FEB0266A2BE5006286B6 /* BrowserViewController.swift */,
 			);
 			name = Course;
 			sourceTree = "<group>";
@@ -5321,6 +5324,7 @@
 				199B9B751935E35D00081A09 /* OEXHelperVideoDownload.m in Sources */,
 				BECB7B1F1924C0C3009C77F1 /* OEXAppDelegate.m in Sources */,
 				B7CCC722209B16B100A66923 /* ConstraintViewDSL.swift in Sources */,
+				5FA7FEB1266A2BE5006286B6 /* BrowserViewController.swift in Sources */,
 				1904A14F1A1386C2006A5524 /* ResourceData.m in Sources */,
 				B7CCC721209B16B100A66923 /* ConstraintAttributes.swift in Sources */,
 				1940D8CB1A230E25000318A3 /* OEXAnalytics.m in Sources */,

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -5997,7 +5997,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CONFIGURATION_BUILD_DIR = "$PODS_BUILD_DIR/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-				CURRENT_PROJECT_VERSION = 2.26.2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				EXCLUDED_ARCHS = "$(inherited)";
@@ -6057,7 +6057,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Libraries/OCMock",
 				);
-				MARKETING_VERSION = 2.26;
+				MARKETING_VERSION = 2.26.101;
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = org.edx.mobile;
@@ -6503,7 +6503,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CONFIGURATION_BUILD_DIR = "$PODS_BUILD_DIR/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-				CURRENT_PROJECT_VERSION = 2.26.2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				EXCLUDED_ARCHS = "$(inherited)";
@@ -6562,7 +6562,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Libraries/OCMock",
 				);
-				MARKETING_VERSION = 2.26;
+				MARKETING_VERSION = 2.26.101;
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = org.edx.mobile;
@@ -6590,7 +6590,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CONFIGURATION_BUILD_DIR = "$PODS_BUILD_DIR/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-				CURRENT_PROJECT_VERSION = 2.26.2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				EXCLUDED_ARCHS = "$(inherited)";
@@ -6650,7 +6650,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Libraries/OCMock",
 				);
-				MARKETING_VERSION = 2.26;
+				MARKETING_VERSION = 2.26.101;
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = org.edx.mobile;


### PR DESCRIPTION
### Description

[LEARNER-8498](https://openedx.atlassian.net/browse/LEARNER-8498)

This PR adds the functionality of opening the URL inside the app web browser. Previously, we were redirecting the learner to the external web browser where the learner has to log in again.  But with this PR, the learner will be automatically logged in to the fullscreen browser and the Unit URL of the component will be opped for a better learning experience. 


### How to test this PR
- [ ] Open the unit URL from a component screen when learner click `Open in Browser` webview.
- [ ] Learner should be automatically logged in before opening the unit URL. 
