### PR TITLE
chore: remove chevron button, change title to Video Settings

### DIFF
--- a/Source/CourseVideosHeaderView.swift
+++ b/Source/CourseVideosHeaderView.swift
@@ -130,15 +130,6 @@ class CourseVideosHeaderView: UIView {
         return imageView
     }()
     
-    private lazy var chevronImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = Icon.ChevronRight.imageWithFontSize(size: imageSize + (imageSize / 2))
-        imageView.tintColor = environment.styles.primaryBaseColor()
-        imageView.isAccessibilityElement = false
-        imageView.accessibilityIdentifier = "CourseVideosHeader:chevron-image-view"
-        return imageView
-    }()
-    
     private lazy var bottomTitleLabel: UILabel = {
         let label = UILabel()
         label.attributedText = titleLabelStyle.attributedString(withText: Strings.videoDownloadQualityTitle)
@@ -383,7 +374,6 @@ class CourseVideosHeaderView: UIView {
         bottomContainer.addSubview(bottomTitleLabel)
         bottomContainer.addSubview(bottomSubtitleLabel)
         bottomContainer.addSubview(settingImageView)
-        bottomContainer.addSubview(chevronImageView)
         bottomContainer.addSubview(videoQualityButton)
         
         videoQualityButton.superview?.bringSubviewToFront(videoQualityButton)
@@ -463,16 +453,9 @@ class CourseVideosHeaderView: UIView {
             make.width.equalTo(imageSize)
         }
         
-        chevronImageView.snp.makeConstraints { make in
-            make.trailing.equalTo(bottomContainer).inset(StandardHorizontalMargin)
-            make.centerY.equalTo(bottomContainer)
-            make.height.equalTo(imageSize + (imageSize / 2))
-            make.width.equalTo(imageSize + (imageSize / 2))
-        }
-        
         bottomTitleLabel.snp.makeConstraints { make in
             make.leading.equalTo(settingImageView.snp.trailing).offset(StandardHorizontalMargin)
-            make.trailing.equalTo(chevronImageView.snp.leading).inset(StandardHorizontalMargin)
+            make.trailing.equalTo(self).inset(StandardHorizontalMargin)
             make.bottom.equalTo(bottomContainer.snp.centerY).inset(StandardVerticalMargin / 2)
         }
         

--- a/Source/ProfileOptionsViewController.swift
+++ b/Source/ProfileOptionsViewController.swift
@@ -342,22 +342,22 @@ class VideoSettingCell: UITableViewCell {
     
     private lazy var optionLabel: UILabel = {
         let label = UILabel()
-        label.attributedText = titleTextStyle.attributedString(withText: Strings.ProfileOptions.Wifi.title)
+        label.attributedText = titleTextStyle.attributedString(withText: Strings.ProfileOptions.VideoSettings.title)
         label.accessibilityIdentifier = "VideoSettingCell:option-label"
         return label
     }()
     
-    private lazy var wifiDescriptionLabel: UILabel = {
+    private lazy var videoSettingDescriptionLabel: UILabel = {
         let label = UILabel()
-        label.attributedText = subtitleTextStyle.attributedString(withText: Strings.ProfileOptions.Wifi.heading)
-        label.accessibilityIdentifier = "VideoSettingCell:wifi-description-label"
+        label.attributedText = subtitleTextStyle.attributedString(withText: Strings.ProfileOptions.VideoSettings.heading)
+        label.accessibilityIdentifier = "VideoSettingCell:video-setting-description-label"
         return label
     }()
     
-    private lazy var wifiSubtitleLabel: UILabel = {
+    private lazy var videoSettingSubtitleLabel: UILabel = {
         let label = UILabel()
-        label.attributedText = titleTextStyle.attributedString(withText: Strings.ProfileOptions.Wifi.message)
-        label.accessibilityIdentifier = "VideoSettingCell:wifi-subtitle-label"
+        label.attributedText = titleTextStyle.attributedString(withText: Strings.ProfileOptions.VideoSettings.message)
+        label.accessibilityIdentifier = "VideoSettingCell:video-setting-subtitle-label"
         return label
     }()
         
@@ -421,9 +421,9 @@ class VideoSettingCell: UITableViewCell {
     private func setupViews() {
         contentView.addSubview(optionLabel)
         contentView.addSubview(wifiContainer)
-        wifiContainer.addSubview(wifiDescriptionLabel)
+        wifiContainer.addSubview(videoSettingDescriptionLabel)
         wifiContainer.addSubview(wifiSwitch)
-        wifiContainer.addSubview(wifiSubtitleLabel)
+        wifiContainer.addSubview(videoSettingSubtitleLabel)
         contentView.addSubview(videoQualityContainer)
         videoQualityContainer.addSubview(videoQualityDescriptionLabel)
         videoQualityContainer.addSubview(videoQualitySubtitleLabel)
@@ -442,22 +442,22 @@ class VideoSettingCell: UITableViewCell {
             make.top.equalTo(optionLabel.snp.bottom).offset(StandardVerticalMargin)
             make.leading.equalTo(contentView).offset(StandardVerticalMargin)
             make.trailing.equalTo(contentView).inset(StandardVerticalMargin)
-            make.bottom.equalTo(wifiDescriptionLabel.snp.bottom).offset(StandardVerticalMargin)
+            make.bottom.equalTo(videoSettingDescriptionLabel.snp.bottom).offset(StandardVerticalMargin)
         }
         
         wifiSwitch.snp.makeConstraints { make in
             make.trailing.equalTo(wifiContainer).inset(StandardVerticalMargin)
-            make.centerY.equalTo(wifiDescriptionLabel)
+            make.centerY.equalTo(videoSettingDescriptionLabel)
         }
         
-        wifiDescriptionLabel.snp.makeConstraints { make in
+        videoSettingDescriptionLabel.snp.makeConstraints { make in
             make.top.equalTo(wifiContainer)
             make.leading.equalTo(wifiContainer).offset(StandardVerticalMargin)
             make.trailing.equalTo(wifiSwitch.snp.leading)
         }
         
-        wifiSubtitleLabel.snp.makeConstraints { make in
-            make.top.equalTo(wifiDescriptionLabel.snp.bottom).offset(StandardVerticalMargin)
+        videoSettingSubtitleLabel.snp.makeConstraints { make in
+            make.top.equalTo(videoSettingDescriptionLabel.snp.bottom).offset(StandardVerticalMargin)
             make.leading.equalTo(wifiContainer).offset(StandardVerticalMargin)
             make.trailing.equalTo(wifiContainer)
             make.height.equalTo(StandardVerticalMargin * 2)

--- a/Source/ar.lproj/Localizable.strings
+++ b/Source/ar.lproj/Localizable.strings
@@ -935,12 +935,12 @@
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
 "VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
-/* Settings title for wifi */
-"PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
-/* Settings heading for wifi */
-"PROFILE_OPTIONS.WIFI.HEADING" = "Wifi only download";
-/* Settings message for wifi */
-"PROFILE_OPTIONS.WIFI.MESSAGE" = "Only download content when wi-fi is turned on";
+/* Settings title for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+/* Settings heading for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+/* Settings message for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
 /* Settings user profile email */

--- a/Source/de.lproj/Localizable.strings
+++ b/Source/de.lproj/Localizable.strings
@@ -875,12 +875,12 @@
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
 "VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
-/* Settings title for wifi */
-"PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
-/* Settings heading for wifi */
-"PROFILE_OPTIONS.WIFI.HEADING" = "Wifi only download";
-/* Settings message for wifi */
-"PROFILE_OPTIONS.WIFI.MESSAGE" = "Only download content when wi-fi is turned on";
+/* Settings title for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+/* Settings heading for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+/* Settings message for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
 /* Settings user profile email */

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -875,12 +875,12 @@
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
 "VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
-/* Settings title for wifi */
-"PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
-/* Settings heading for wifi */
-"PROFILE_OPTIONS.WIFI.HEADING" = "Wifi only download";
-/* Settings message for wifi */
-"PROFILE_OPTIONS.WIFI.MESSAGE" = "Only download content when wi-fi is turned on";
+/* Settings title for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+/* Settings heading for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+/* Settings message for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
 /* Settings user profile email */

--- a/Source/es-419.lproj/Localizable.strings
+++ b/Source/es-419.lproj/Localizable.strings
@@ -873,12 +873,12 @@
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
 "VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
-/* Settings title for wifi */
-"PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
-/* Settings heading for wifi */
-"PROFILE_OPTIONS.WIFI.HEADING" = "Wifi only download";
-/* Settings message for wifi */
-"PROFILE_OPTIONS.WIFI.MESSAGE" = "Only download content when wi-fi is turned on";
+/* Settings title for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+/* Settings heading for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+/* Settings message for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
 /* Settings user profile email */

--- a/Source/fr.lproj/Localizable.strings
+++ b/Source/fr.lproj/Localizable.strings
@@ -875,12 +875,12 @@
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
 "VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
-/* Settings title for wifi */
-"PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
-/* Settings heading for wifi */
-"PROFILE_OPTIONS.WIFI.HEADING" = "Wifi only download";
-/* Settings message for wifi */
-"PROFILE_OPTIONS.WIFI.MESSAGE" = "Only download content when wi-fi is turned on";
+/* Settings title for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+/* Settings heading for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+/* Settings message for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
 /* Settings user profile email */

--- a/Source/he.lproj/Localizable.strings
+++ b/Source/he.lproj/Localizable.strings
@@ -899,12 +899,12 @@
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
 "VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
-/* Settings title for wifi */
-"PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
-/* Settings heading for wifi */
-"PROFILE_OPTIONS.WIFI.HEADING" = "Wifi only download";
-/* Settings message for wifi */
-"PROFILE_OPTIONS.WIFI.MESSAGE" = "Only download content when wi-fi is turned on";
+/* Settings title for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+/* Settings heading for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+/* Settings message for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
 /* Settings user profile email */

--- a/Source/ja.lproj/Localizable.strings
+++ b/Source/ja.lproj/Localizable.strings
@@ -860,12 +860,12 @@
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
 "VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
-/* Settings title for wifi */
-"PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
-/* Settings heading for wifi */
-"PROFILE_OPTIONS.WIFI.HEADING" = "Wifi only download";
-/* Settings message for wifi */
-"PROFILE_OPTIONS.WIFI.MESSAGE" = "Only download content when wi-fi is turned on";
+/* Settings title for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+/* Settings heading for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+/* Settings message for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
 /* Settings user profile email */

--- a/Source/pt-BR.lproj/Localizable.strings
+++ b/Source/pt-BR.lproj/Localizable.strings
@@ -875,12 +875,12 @@
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
 "VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
-/* Settings title for wifi */
-"PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
-/* Settings heading for wifi */
-"PROFILE_OPTIONS.WIFI.HEADING" = "Wifi only download";
-/* Settings message for wifi */
-"PROFILE_OPTIONS.WIFI.MESSAGE" = "Only download content when wi-fi is turned on";
+/* Settings title for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+/* Settings heading for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+/* Settings message for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
 /* Settings user profile email */

--- a/Source/tr.lproj/Localizable.strings
+++ b/Source/tr.lproj/Localizable.strings
@@ -873,12 +873,12 @@
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
 "VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
-/* Settings title for wifi */
-"PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
-/* Settings heading for wifi */
-"PROFILE_OPTIONS.WIFI.HEADING" = "Wifi only download";
-/* Settings message for wifi */
-"PROFILE_OPTIONS.WIFI.MESSAGE" = "Only download content when wi-fi is turned on";
+/* Settings title for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+/* Settings heading for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+/* Settings message for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
 /* Settings user profile email */

--- a/Source/vi.lproj/Localizable.strings
+++ b/Source/vi.lproj/Localizable.strings
@@ -860,12 +860,12 @@
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
 "VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
-/* Settings title for wifi */
-"PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
-/* Settings heading for wifi */
-"PROFILE_OPTIONS.WIFI.HEADING" = "Wifi only download";
-/* Settings message for wifi */
-"PROFILE_OPTIONS.WIFI.MESSAGE" = "Only download content when wi-fi is turned on";
+/* Settings title for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+/* Settings heading for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+/* Settings message for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
 /* Settings user profile email */

--- a/Source/zh-Hans.lproj/Localizable.strings
+++ b/Source/zh-Hans.lproj/Localizable.strings
@@ -860,12 +860,12 @@
 "VIDEO_DOWNLOAD_QUALITY_MEDIUM" = "540p";
 /* Settigs message for Video Download Quality High */
 "VIDEO_DOWNLOAD_QUALITY_HIGH" = "720p (Best quality)";
-/* Settings title for wifi */
-"PROFILE_OPTIONS.WIFI.TITLE" = "WIFI";
-/* Settings heading for wifi */
-"PROFILE_OPTIONS.WIFI.HEADING" = "Wifi only download";
-/* Settings message for wifi */
-"PROFILE_OPTIONS.WIFI.MESSAGE" = "Only download content when wi-fi is turned on";
+/* Settings title for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.TITLE" = "VIDEO SETTINGS";
+/* Settings heading for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.HEADING" = "Wifi only download";
+/* Settings message for video settings */
+"PROFILE_OPTIONS.VIDEO_SETTINGS.MESSAGE" = "Only download content when wi-fi is turned on";
 /* Settings title for profile information */
 "PROFILE_OPTIONS.USER_PROFILE.TITLE" = "PERSONAL INFORMATION";
 /* Settings user profile email */


### PR DESCRIPTION

### Description

[LEARNER-8530](https://openedx.atlassian.net/browse/LEARNER-8530)

Remove chevron button from the videos tab – Video download quality header
Rename section title from WIFI to “VIDEO SETTINGS” – Profile screen

### How to test this PR

- [x] remove chevron button
- [x] Rename section title from WIFI to “VIDEO SETTINGS” in Profile screen
