### PR TITLE
[fix] fix user login event tracking

### DIFF
--- a/Source/OEXLoginViewController.m
+++ b/Source/OEXLoginViewController.m
@@ -564,12 +564,13 @@
         // Set the language to blank
         [OEXInterface setCCSelectedLanguage:@""];
         [[NSUserDefaults standardUserDefaults] setObject:_tf_EmailID.text forKey:USER_EMAIL];
-        // Analytics User Login
-        [[OEXAnalytics sharedAnalytics] trackUserLogin:[self.authProvider backendName] ?: @"Password"];
     }
     [self tappedToDismiss];
     [self.activityIndicator stopAnimating];
 
+    // Analytics User Login
+    [[OEXAnalytics sharedAnalytics] trackUserLogin:[self.authProvider backendName] ?: @"Password"];
+    
     //Launch next view
     [self didLogin];
 }

--- a/Source/StartupViewController.swift
+++ b/Source/StartupViewController.swift
@@ -319,10 +319,9 @@ public class BottomBarView: UIView, NSCopying {
         
         let signinTextStyle = OEXTextStyle(weight: .semiBold, size: .large, color: environment?.styles.secondaryBaseColor())
         signInButton.setAttributedTitle(signinTextStyle.attributedString(withText: Strings.signInText), for: .normal)
-        let signInEvent = OEXAnalytics.loginEvent()
         signInButton.oex_addAction({ [weak self] _ in
             self?.showLogin()
-            }, for: .touchUpInside, analyticsEvent: signInEvent)
+        }, for: .touchUpInside)
 
         registerButton.backgroundColor = environment?.styles.secondaryBaseColor()
         registerButton.applyBorderStyle(style: BorderStyle(cornerRadius: .Size(CornerRadius), width: .Size(0), color: environment?.styles.secondaryBaseColor()))


### PR DESCRIPTION
### Description

[LEARNER-8525](https://openedx.atlassian.net/browse/LEARNER-8525)

Fix `User Login` analytic tracking. The app was tracking `User Login` analytic on the login button click on the startup screen and on the successful login as well but only in case of username/password login. The event was not tracking in the case of third-party logins.

