### PR TITLE
[chore] Add 10 second delay to notices api for push notifications

### DIFF
--- a/Source/EnrolledCoursesViewController+Banner.swift
+++ b/Source/EnrolledCoursesViewController+Banner.swift
@@ -24,8 +24,8 @@ extension EnrolledCoursesViewController: BannerViewControllerDelegate {
         }
 
         let delegate = UIApplication.shared.delegate as? OEXAppDelegate
-        let delay: Double = delegate?.openedFromDeeplink == true ? DeeplinkDelayTime : 0
-        delegate?.openedFromDeeplink = false
+        let delay: Double = delegate?.appOpenedFromExternalLink == true ? DeeplinkDelayTime : 0
+        delegate?.appOpenedFromExternalLink = false
 
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
             self?.fetchBanner()

--- a/Source/OEXAppDelegate.h
+++ b/Source/OEXAppDelegate.h
@@ -16,8 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface OEXAppDelegate : UIResponder
 
 @property (nonatomic, strong) id <Reachability> reachability;
-/// This will be used to figure out either the app was opened from the deep link or not. This will be used to perform app banner functionality
-@property (nonatomic, assign) BOOL openedFromDeeplink;
+/// This will be used to figure out either the app was opened from the deep link, push notification or not. This will be used to perform app banner functionality
+@property (nonatomic, assign) BOOL appOpenedFromExternalLink;
 
 - (void)callCompletionHandlerForSession:(NSString*)identifier;
 

--- a/Source/OEXAppDelegate.m
+++ b/Source/OEXAppDelegate.m
@@ -109,7 +109,7 @@
     if (self.environment.config.branchConfig.enabled) {
         handled = [[Branch getInstance] application:app openURL:url options:options];
         if (handled) {
-            _openedFromDeeplink = true;
+            _appOpenedFromExternalLink = true;
             return handled;
         }
     }
@@ -136,7 +136,7 @@
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void(^)(NSArray<id<UIUserActivityRestoring>> * __nullable restorableObjects))restorationHandler {
 
     if ([userActivity.activityType isEqual:NSUserActivityTypeBrowsingWeb]) {
-        _openedFromDeeplink = true;
+        _appOpenedFromExternalLink = true;
     }
 
     if (self.environment.config.branchConfig.enabled) {
@@ -148,6 +148,11 @@
 #pragma mark Push Notifications
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    if ([[UIApplication sharedApplication] applicationState] != UIApplicationStateActive) {
+        // add delay in banner call feteching if the app opened from notifcation centre
+        _appOpenedFromExternalLink = true;
+    }
+
     [self.environment.pushNotificationManager didReceiveRemoteNotificationWithUserInfo:userInfo];
     completionHandler(UIBackgroundFetchResultNewData);
 }


### PR DESCRIPTION
### Description

[LEARNER-8600](https://openedx.atlassian.net/browse/LEARNER-8600)

We have implemented a 10 sec delay for fetching the `/notices/api/v1/unacknowledged?mobile=true` API when the app is opened/resumed from the deep link for a better user experience. We have to implement the same logic (10 sec delay) when the app opened/resumed from a push notification because the navigation flow is shared between deep link and push notification.


### Testing
- [ ] Add a 10 sec delay to for fetching the `/notices/api/v1/unacknowledged?mobile=true` API when the app is opened/resumed from push notification.
