### PR TITLE
[fix] Fix the wifi-only Download Functionality

### DIFF
--- a/Source/ProfileOptionsViewController.swift
+++ b/Source/ProfileOptionsViewController.swift
@@ -287,17 +287,17 @@ extension ProfileOptionsViewController: DownloadCellDelagete {
     func didTapWifiSwitch(isOn: Bool, wifiSwitch: UISwitch) {
         environment.analytics.trackWifi(isOn: isOn)
         if isOn {
+            environment.interface?.setDownloadOnlyOnWifiPref(isOn)
+        } else {
             let alertController = UIAlertController().showAlert(withTitle: Strings.cellularDownloadEnabledTitle, message: Strings.cellularDownloadEnabledMessage, cancelButtonTitle: nil, onViewController: self) { _, _, _ in }
             alertController.addButton(withTitle: Strings.doNotAllow) { [weak self] _ in
                 self?.environment.analytics.trackWifi(allowed: false)
-                wifiSwitch.setOn(false, animated: true)
+                wifiSwitch.setOn(true, animated: true)
             }
             alertController.addButton(withTitle: Strings.allow) { [weak self] _ in
                 self?.environment.interface?.setDownloadOnlyOnWifiPref(isOn)
                 self?.environment.analytics.trackWifi(allowed: true)
             }
-        } else {
-            environment.interface?.setDownloadOnlyOnWifiPref(isOn)
         }
     }
     


### PR DESCRIPTION
### Description

[LEARNER-8614](https://openedx.atlassian.net/browse/LEARNER-8614)

Fix the wifi-only download functionality that got inverted while porting the feature to the new profile screen. Although, the functionality was working fine but the alert was showing while turning on the wi-fi only switch instead of turning off.
