### PR TITLE
[fix] app update messages are not working

### DIFF
--- a/Libraries/Alamofire/Alamofire.swift
+++ b/Libraries/Alamofire/Alamofire.swift
@@ -261,7 +261,7 @@ open class Manager {
             if let info = Bundle.main.infoDictionary {
                 let executable: AnyObject = info[kCFBundleExecutableKey as String] as AnyObject? ?? "Unknown" as AnyObject
                 let bundle: AnyObject = info[kCFBundleIdentifierKey as String] as AnyObject? ?? "Unknown" as AnyObject
-                let version: AnyObject = info[kCFBundleVersionKey as String] as AnyObject? ?? "Unknown" as AnyObject
+                let version: AnyObject = info["CFBundleShortVersionString"] as AnyObject? ?? "Unknown" as AnyObject
                 let os: AnyObject = ProcessInfo.processInfo.operatingSystemVersionString as AnyObject
 
                 var mutableUserAgent = NSMutableString(string: "\(executable)/\(bundle) (\(version); OS \(os))") as CFMutableString


### PR DESCRIPTION
### Description

[LEARNER-8638](https://openedx.atlassian.net/browse/LEARNER-8638)

After the update of the version handling the soft and the force app upgrade messages are not working. 

### How to test this PR
To test the PR change the version number in the settings 

- To see a soft upgrade message update the version number to 2.26.2 
- To see a force upgrade message update the version to 2.20.0
