### PR TITLE
[fix] iPad native videos are not working properly

### DIFF
--- a/Source/CourseContentPageViewController.swift
+++ b/Source/CourseContentPageViewController.swift
@@ -436,6 +436,7 @@ public class CourseContentPageViewController : UIPageViewController, UIPageViewC
     }
 
     public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
         DispatchQueue.main.async {[weak self] in
             self?.updateNavigationBars()
         }


### PR DESCRIPTION
### Description

[LEARNER-8616](https://openedx.atlassian.net/browse/LEARNER-8616)

In `VideoBlockViewController`, `viewWillTransition` is not being called, as `super` is not being called inside `CourseContentPageViewController`, thus iPad native videos have issue with rotation as it is not being rotated properly.
This PR solves this issue.

### How to test this PR

- [ ] Rotate iPad while video is being played, it should rotate correctly.