### PR TITLE
[feat] hide upgrade after course purchase success

### DIFF
--- a/Source/CourseDatesViewController.swift
+++ b/Source/CourseDatesViewController.swift
@@ -95,8 +95,7 @@ class CourseDatesViewController: UIViewController, InterfaceOrientationOverridin
     }
     
     private var userEnrollment: EnrollmentMode {
-        let mode = environment.interface?.enrollmentForCourse(withID: courseID)?.mode ?? ""
-        return EnrollmentMode(rawValue: mode) ?? .none
+        return environment.interface?.enrollmentForCourse(withID: courseID)?.type ?? .none
     }
     
     private var calendarState: Bool {

--- a/Source/CoursePurchaseIDManager.swift
+++ b/Source/CoursePurchaseIDManager.swift
@@ -1,0 +1,33 @@
+//
+//  CoursePurchaseIDManager.swift
+//  edX
+//
+//  Created by Muhammad Umer on 22/12/2021.
+//  Copyright © 2021 edX. All rights reserved.
+//
+
+import Foundation
+
+class CoursePurchaseIDManager {
+    static let shared = CoursePurchaseIDManager()
+    
+    private lazy var courseMappings: [String : String] = {
+        return [
+            "course-v1:edX+DemoX+Demo_Course": "org.edx.mobile.integrationtest",
+            "course-v1:DemoX+PERF101+course": "org.edx.mobile.test_product1",
+            "course-v1:edX+Test101+course": "org.edx.mobile.test_product2",
+            "course-v1:test2+2+2": "org.edx.mobile.test_product3",
+            "course-v1:test3+test3+3": "org.edx.mobile.test_product4"
+        ]
+    }()
+    
+    private init() { }
+    
+    func purchaseID(for course: OEXCourse) -> String? {
+        guard let courseID = course.course_id,
+              courseMappings.keys.contains(courseID),
+              let coursePurchaseID = courseMappings[courseID] else { return nil }
+        
+        return coursePurchaseID
+    }
+}

--- a/Source/CourseUnknownBlockViewController.swift
+++ b/Source/CourseUnknownBlockViewController.swift
@@ -196,7 +196,7 @@ class CourseUnknownBlockViewController: UIViewController, CourseBlockViewControl
 extension CourseUnknownBlockViewController: ValuePropMessageViewDelegate {
     func didTapUpgradeCourse(upgradeView: ValuePropComponentView) {
         guard let course = environment.interface?.enrollmentForCourse(withID: courseID)?.course,
-            let courseSku = UpgradeSKUManager.shared.purchaseID(for: course)else { return }
+            let courseSku = UpgradeSKUManager.shared.courseSku(for: course)else { return }
         
         disableAppTouchs()
         

--- a/Source/CourseUnknownBlockViewController.swift
+++ b/Source/CourseUnknownBlockViewController.swift
@@ -196,12 +196,12 @@ class CourseUnknownBlockViewController: UIViewController, CourseBlockViewControl
 extension CourseUnknownBlockViewController: ValuePropMessageViewDelegate {
     func didTapUpgradeCourse(upgradeView: ValuePropComponentView) {
         guard let course = environment.interface?.enrollmentForCourse(withID: courseID)?.course,
-            let coursePurchaseID = CoursePurchaseIDManager.shared.purchaseID(for: course)else { return }
+            let courseSku = UpgradeSKUManager.shared.purchaseID(for: course)else { return }
         
         disableAppTouchs()
         
         let pacing = course.isSelfPaced ? "self" : "instructor"
-        environment.analytics.trackUpgradeNow(with: course.course_id ?? "", blockID: coursePurchaseID, pacing: pacing)
+        environment.analytics.trackUpgradeNow(with: course.course_id ?? "", blockID: courseSku, pacing: pacing)
         
         CourseUpgradeHandler.shared.upgradeCourse(course, environment: environment) { [weak self] status in
             switch status {

--- a/Source/CourseUnknownBlockViewController.swift
+++ b/Source/CourseUnknownBlockViewController.swift
@@ -195,13 +195,12 @@ class CourseUnknownBlockViewController: UIViewController, CourseBlockViewControl
 
 extension CourseUnknownBlockViewController: ValuePropMessageViewDelegate {
     func didTapUpgradeCourse(upgradeView: ValuePropComponentView) {
-        guard let course = environment.interface?.enrollmentForCourse(withID: courseID)?.course,
-            let courseSku = UpgradeSKUManager.shared.courseSku(for: course)else { return }
+        guard let course = environment.interface?.enrollmentForCourse(withID: courseID)?.course else { return }
         
         disableAppTouchs()
         
         let pacing = course.isSelfPaced ? "self" : "instructor"
-        environment.analytics.trackUpgradeNow(with: course.course_id ?? "", blockID: courseSku, pacing: pacing)
+        environment.analytics.trackUpgradeNow(with: course.course_id ?? "", blockID: self.blockID ?? "", pacing: pacing)
         
         CourseUpgradeHandler.shared.upgradeCourse(course, environment: environment) { [weak self] status in
             switch status {

--- a/Source/CourseUnknownBlockViewController.swift
+++ b/Source/CourseUnknownBlockViewController.swift
@@ -202,11 +202,6 @@ extension CourseUnknownBlockViewController: ValuePropMessageViewDelegate {
         environment.analytics.trackUpgradeNow(with: course.course_id ?? "", blockID: TestInAppPurchaseID, pacing: pacing)
         
         CourseUpgradeHandler.shared.upgradeCourse(course, environment: environment) { [weak self] status in
-            guard let topController = UIApplication.shared.topMostController() else {
-                self?.enableAppTouches()
-                return
-            }
-            
             switch status {
             case .payment:
                 upgradeView.stopAnimating()
@@ -214,21 +209,20 @@ extension CourseUnknownBlockViewController: ValuePropMessageViewDelegate {
             case .complete:
                 self?.enableAppTouches()
                 upgradeView.updateUpgradeButtonVisibility(visible: false)
-                let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.successAlertTitle, message: Strings.CourseUpgrade.successAlertMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
-                alertController.addButton(withTitle: Strings.CourseUpgrade.successAlertContinue, style: .cancel) { action in
-                    // TODO: continue button handling
+                
+                self?.dismiss(animated: true) {
+                    CourseUpgradeCompletion.shared.handleCompletion(state: .success(course.course_id ?? "", nil))
                 }
+                
                 break
             case .error:
                 self?.enableAppTouches()
                 upgradeView.stopAnimating()
-                let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.failureAlertTitle, message: Strings.CourseUpgrade.failureAlertMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
-                alertController.addButton(withTitle: Strings.CourseUpgrade.failureAlertGetHelp) { action in
-                    // TODO: Add option to send email
+                
+                self?.dismiss(animated: true) {
+                    CourseUpgradeCompletion.shared.handleCompletion(state: .error)
                 }
-                alertController.addButton(withTitle: Strings.close, style: .default) { action in
-                    // TODO: Close button handling
-                }
+                
                 break
             default:
                 break

--- a/Source/CourseUnknownBlockViewController.swift
+++ b/Source/CourseUnknownBlockViewController.swift
@@ -195,11 +195,13 @@ class CourseUnknownBlockViewController: UIViewController, CourseBlockViewControl
 
 extension CourseUnknownBlockViewController: ValuePropMessageViewDelegate {
     func didTapUpgradeCourse(upgradeView: ValuePropComponentView) {
-        guard let course = environment.interface?.enrollmentForCourse(withID: courseID)?.course else { return }
+        guard let course = environment.interface?.enrollmentForCourse(withID: courseID)?.course,
+            let coursePurchaseID = CoursePurchaseIDManager.shared.purchaseID(for: course)else { return }
+        
         disableAppTouchs()
         
         let pacing = course.isSelfPaced ? "self" : "instructor"
-        environment.analytics.trackUpgradeNow(with: course.course_id ?? "", blockID: TestInAppPurchaseID, pacing: pacing)
+        environment.analytics.trackUpgradeNow(with: course.course_id ?? "", blockID: coursePurchaseID, pacing: pacing)
         
         CourseUpgradeHandler.shared.upgradeCourse(course, environment: environment) { [weak self] status in
             switch status {

--- a/Source/CourseUnknownBlockViewController.swift
+++ b/Source/CourseUnknownBlockViewController.swift
@@ -211,7 +211,7 @@ extension CourseUnknownBlockViewController: ValuePropMessageViewDelegate {
                 upgradeView.updateUpgradeButtonVisibility(visible: false)
                 
                 self?.dismiss(animated: true) {
-                    CourseUpgradeCompletion.shared.handleCompletion(state: .success(course.course_id ?? "", nil))
+                    CourseUpgradeCompletion.shared.handleCompletion(state: .success(course.course_id ?? "", self?.blockID))
                 }
                 
                 break

--- a/Source/CourseUpgradeCompletion.swift
+++ b/Source/CourseUpgradeCompletion.swift
@@ -12,21 +12,24 @@ let CourseUpgradeCompletionNotification = "CourseUpgradeCompletionNotification"
 
 class CourseUpgradeCompletion {
     
+    static let courseID = "CourseID"
+    static let blockID = "BlockID"
+    
     static let shared = CourseUpgradeCompletion()
     
-    enum CourseUpgradeCompletionState {
+    enum CompletionState {
         case success(_ courseID: String, _ componentID: String?)
         case error
     }
     
     private init() { }
     
-    func handleCompletion(state: CourseUpgradeCompletionState) {
+    func handleCompletion(state: CompletionState) {
         switch state {
         case .success(let courseID, let blockID):
             let dictionary = [
-                "CourseID": courseID,
-                "BlockID": blockID
+                CourseUpgradeCompletion.courseID: courseID,
+                CourseUpgradeCompletion.blockID: blockID
             ]
             NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: CourseUpgradeCompletionNotification), object: dictionary))
             showSuccess()

--- a/Source/CourseUpgradeCompletion.swift
+++ b/Source/CourseUpgradeCompletion.swift
@@ -1,0 +1,56 @@
+//
+//  CourseUpgradeCompletion.swift
+//  edX
+//
+//  Created by Muhammad Umer on 16/12/2021.
+//  Copyright © 2021 edX. All rights reserved.
+//
+
+import Foundation
+
+let CourseUpgradeCompletionNotification = "CourseUpgradeCompletionNotification"
+
+class CourseUpgradeCompletion {
+    
+    static let shared = CourseUpgradeCompletion()
+    
+    enum CourseUpgradeCompletionState {
+        case success(_ courseID: String, _ componentID: String?)
+        case error
+    }
+    
+    private init() { }
+    
+    func handleCompletion(state: CourseUpgradeCompletionState) {
+        switch state {
+        case .success(let courseID, let blockID):
+            let dictionary = [
+                "CourseID": courseID,
+                "BlockID": blockID
+            ]
+            NotificationCenter.default.post(Notification(name: Notification.Name(rawValue: CourseUpgradeCompletionNotification), object: dictionary))
+            showSuccess()
+        case .error:
+            showError()
+        }
+    }
+    
+    private func showSuccess() {
+        guard let topController = UIApplication.shared.topMostController() else { return }
+        let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.successAlertTitle, message: Strings.CourseUpgrade.successAlertMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
+        alertController.addButton(withTitle: Strings.CourseUpgrade.successAlertContinue, style: .cancel) { action in
+            
+        }
+    }
+    
+    private func showError() {
+        guard let topController = UIApplication.shared.topMostController() else { return }
+        let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.failureAlertTitle, message: Strings.CourseUpgrade.failureAlertMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
+        alertController.addButton(withTitle: Strings.CourseUpgrade.failureAlertGetHelp) { action in
+            
+        }
+        alertController.addButton(withTitle: Strings.close, style: .default) { action in
+            
+        }
+    }
+}

--- a/Source/CourseUpgradeHandler.swift
+++ b/Source/CourseUpgradeHandler.swift
@@ -27,6 +27,7 @@ class CourseUpgradeHandler: NSObject {
     private var completion: UpgradeCompletionHandler?
     private var course: OEXCourse?
     private var basketID: Int = 0
+    private var coursePurchaseID: String = ""
     private var state: CourseUpgradeState = .initial {
         didSet {
             completion?(state)
@@ -41,6 +42,13 @@ class CourseUpgradeHandler: NSObject {
         self.course = course
         
         state = .initial
+        
+        if let purchaseID = CoursePurchaseIDManager.shared.purchaseID(for: course) {
+            coursePurchaseID = purchaseID
+        } else {
+            state = .error(.generalError)
+            return
+        }
         
         addToBasket { [weak self] orderBasket in
             if let basketID = orderBasket?.basketID {
@@ -65,7 +73,7 @@ class CourseUpgradeHandler: NSObject {
         state = .basket
         
         let baseURL = CourseUpgradeAPI.baseURL
-        let request = CourseUpgradeAPI.basketAPI(with: TestInAppPurchaseID)
+        let request = CourseUpgradeAPI.basketAPI(with: coursePurchaseID)
         
         environment?.networkManager.taskForRequest(base: baseURL, request) { response in
             completion(response.data)
@@ -96,7 +104,7 @@ class CourseUpgradeHandler: NSObject {
     
     private func makePayment() {
         state = .payment
-        PaymentManager.shared.purchaseProduct(TestInAppPurchaseID) { [weak self] (success: Bool, receipt: String?, error: PurchaseError?) in
+        PaymentManager.shared.purchaseProduct(coursePurchaseID) { [weak self] (success: Bool, receipt: String?, error: PurchaseError?) in
             if let receipt = receipt, success {
                 self?.verifyPayment(receipt)
             } else {
@@ -110,7 +118,7 @@ class CourseUpgradeHandler: NSObject {
         
         // Execute API, pass the payment receipt to complete the course upgrade
         let baseURL = CourseUpgradeAPI.baseURL
-        let request = CourseUpgradeAPI.executeAPI(basketID: basketID, productID: TestInAppPurchaseID, receipt: receipt)
+        let request = CourseUpgradeAPI.executeAPI(basketID: basketID, productID: coursePurchaseID, receipt: receipt)
         
         environment?.networkManager.taskForRequest(base: baseURL, request){ [weak self] response in
             if response.error == nil {

--- a/Source/CourseUpgradeHandler.swift
+++ b/Source/CourseUpgradeHandler.swift
@@ -43,12 +43,12 @@ class CourseUpgradeHandler: NSObject {
         
         state = .initial
         
-        if let coursePurchaseSku = UpgradeSKUManager.shared.courseSku(for: course) {
-            courseSku = coursePurchaseSku
-        } else {
+        guard let coursePurchaseSku = UpgradeSKUManager.shared.courseSku(for: course) else {
             state = .error(.generalError)
             return
         }
+        
+        courseSku = coursePurchaseSku
         
         addToBasket { [weak self] orderBasket in
             if let basketID = orderBasket?.basketID {

--- a/Source/CourseUpgradeHandler.swift
+++ b/Source/CourseUpgradeHandler.swift
@@ -43,7 +43,7 @@ class CourseUpgradeHandler: NSObject {
         
         state = .initial
         
-        if let coursePurchaseSku = UpgradeSKUManager.shared.purchaseID(for: course) {
+        if let coursePurchaseSku = UpgradeSKUManager.shared.courseSku(for: course) {
             courseSku = coursePurchaseSku
         } else {
             state = .error(.generalError)

--- a/Source/CoursesContainerViewController.swift
+++ b/Source/CoursesContainerViewController.swift
@@ -122,22 +122,25 @@ class CoursesContainerViewController: UICollectionViewController {
     
     private let environment : Environment
     private let context: Context
-    weak var delegate : CoursesContainerViewControllerDelegate?
-    var isAuditModeCourseAvailable: Bool = false
-    var courses:[OEXCourse] = [] {
+    weak var delegate: CoursesContainerViewControllerDelegate?
+    
+    private var isAuditModeCourseAvailable: Bool = false
+    
+    var courses: [OEXCourse] = [] {
         didSet {
             if isiPad() {
                 let auditModeCourses = courses.filter { course -> Bool in
-                    let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id)
-                    if enrollment?.type == .audit && environment.remoteConfig.valuePropEnabled {
-                        return true
-                    }
-                    return false
+                    guard let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id),
+                          enrollment.type == .audit,
+                          environment.remoteConfig.valuePropEnabled,
+                          UpgradeSKUManager.shared.courseSku(for: course) != nil else { return false}
+                    return true
                 }
                 isAuditModeCourseAvailable = !auditModeCourses.isEmpty
             }
         }
     }
+    
     private let insetsController = ContentInsetsController()
   
     private var isCourseDiscoveryEnabled: Bool {

--- a/Source/CoursesContainerViewController.swift
+++ b/Source/CoursesContainerViewController.swift
@@ -130,11 +130,11 @@ class CoursesContainerViewController: UICollectionViewController {
         didSet {
             if isiPad() {
                 let auditModeCourses = courses.filter { course -> Bool in
-                    guard let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id),
-                          enrollment.type == .audit,
-                          environment.remoteConfig.valuePropEnabled,
-                          UpgradeSKUManager.shared.courseSku(for: course) != nil else { return false}
-                    return true
+                    let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id)
+                    if enrollment?.type == .audit && environment.remoteConfig.valuePropEnabled {
+                        return true
+                    }
+                    return false
                 }
                 isAuditModeCourseAvailable = !auditModeCourses.isEmpty
             }

--- a/Source/CoursesContainerViewController.swift
+++ b/Source/CoursesContainerViewController.swift
@@ -244,7 +244,7 @@ class CoursesContainerViewController: UICollectionViewController {
     
     private func shouldShowValueProp(for course: OEXCourse) -> Bool {
         guard let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id),
-              CoursePurchaseIDManager.shared.purchaseID(for: course) != nil else { return false }
+              UpgradeSKUManager.shared.purchaseID(for: course) != nil else { return false }
         
         return enrollment.type == .audit && environment.remoteConfig.valuePropEnabled && !course.isEndDateOld
     }

--- a/Source/CoursesContainerViewController.swift
+++ b/Source/CoursesContainerViewController.swift
@@ -243,8 +243,10 @@ class CoursesContainerViewController: UICollectionViewController {
     }
     
     private func shouldShowValueProp(for course: OEXCourse) -> Bool {
-        let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id)
-        return enrollment?.type == .audit && environment.remoteConfig.valuePropEnabled && !course.isEndDateOld
+        guard let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id),
+              CoursePurchaseIDManager.shared.purchaseID(for: course) != nil else { return false }
+        
+        return enrollment.type == .audit && environment.remoteConfig.valuePropEnabled && !course.isEndDateOld
     }
     
     private func calculateValuePropHeight(for indexPath: IndexPath) -> CGFloat {

--- a/Source/CoursesContainerViewController.swift
+++ b/Source/CoursesContainerViewController.swift
@@ -244,7 +244,7 @@ class CoursesContainerViewController: UICollectionViewController {
     
     private func shouldShowValueProp(for course: OEXCourse) -> Bool {
         guard let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id),
-              UpgradeSKUManager.shared.purchaseID(for: course) != nil else { return false }
+              UpgradeSKUManager.shared.courseSku(for: course) != nil else { return false }
         
         return enrollment.type == .audit && environment.remoteConfig.valuePropEnabled && !course.isEndDateOld
     }

--- a/Source/CoursesContainerViewController.swift
+++ b/Source/CoursesContainerViewController.swift
@@ -244,7 +244,7 @@ class CoursesContainerViewController: UICollectionViewController {
     
     private func shouldShowValueProp(for course: OEXCourse) -> Bool {
         let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id)
-        return enrollment?.mode == enrollment?.type.rawValue && environment.remoteConfig.valuePropEnabled && !course.isEndDateOld
+        return enrollment?.type == .audit && environment.remoteConfig.valuePropEnabled && !course.isEndDateOld
     }
     
     private func calculateValuePropHeight(for indexPath: IndexPath) -> CGFloat {

--- a/Source/CoursesContainerViewController.swift
+++ b/Source/CoursesContainerViewController.swift
@@ -111,17 +111,6 @@ extension CoursesContainerViewControllerDelegate {
     func showValuePropDetailView(with course: OEXCourse) {}
 }
 
-enum EnrollmentMode: String {
-    case audit = "audit"
-    case verified = "verified"
-    case honor = "honor"
-    case noIDProfessional = "no-id-professional"
-    case professional = "professional"
-    case credit = "credit"
-    case masters = "masters"
-    case none = "none"
-}
-
 class CoursesContainerViewController: UICollectionViewController {
     
     enum Context {
@@ -140,7 +129,7 @@ class CoursesContainerViewController: UICollectionViewController {
             if isiPad() {
                 let auditModeCourses = courses.filter { course -> Bool in
                     let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id)
-                    if enrollment?.mode == EnrollmentMode.audit.rawValue && environment.remoteConfig.valuePropEnabled {
+                    if enrollment?.type == .audit && environment.remoteConfig.valuePropEnabled {
                         return true
                     }
                     return false
@@ -255,7 +244,7 @@ class CoursesContainerViewController: UICollectionViewController {
     
     private func shouldShowValueProp(for course: OEXCourse) -> Bool {
         let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id)
-        return enrollment?.mode == EnrollmentMode.audit.rawValue && environment.remoteConfig.valuePropEnabled && !course.isEndDateOld
+        return enrollment?.mode == enrollment?.type.rawValue && environment.remoteConfig.valuePropEnabled && !course.isEndDateOld
     }
     
     private func calculateValuePropHeight(for indexPath: IndexPath) -> CGFloat {

--- a/Source/EnrolledCoursesViewController.swift
+++ b/Source/EnrolledCoursesViewController.swift
@@ -167,6 +167,27 @@ class EnrolledCoursesViewController : OfflineSupportViewController, CoursesConta
         NotificationCenter.default.oex_addObserver(observer: self, name: UIApplication.didBecomeActiveNotification.rawValue) { _, observer, _ in
             observer.handleBanner()
         }
+        
+        NotificationCenter.default.oex_addObserver(observer: self, name: CourseUpgradeCompletionNotification) { notification, observer, _ in
+            if let dictionary = notification.object as? NSDictionary, let courseID = dictionary["CourseID"] as? String {
+                observer.updateCourseEnrolmentMode(courseID: courseID)
+            }
+        }
+    }
+    
+    func updateCourseEnrolmentMode(courseID: String) {
+        coursesContainer.courses = coursesContainer.courses.map { course in
+            if course.course_id == courseID {
+                let enrollment = environment.interface?.enrollmentForCourse(withID: course.course_id)
+                enrollment?.type = .verified
+            }
+            
+            return course
+        }
+        
+        coursesContainer.collectionView.reloadData()
+        
+        refreshIfNecessary()
     }
     
     func refreshIfNecessary() {

--- a/Source/EnrolledCoursesViewController.swift
+++ b/Source/EnrolledCoursesViewController.swift
@@ -169,7 +169,8 @@ class EnrolledCoursesViewController : OfflineSupportViewController, CoursesConta
         }
         
         NotificationCenter.default.oex_addObserver(observer: self, name: CourseUpgradeCompletionNotification) { notification, observer, _ in
-            if let dictionary = notification.object as? NSDictionary, let courseID = dictionary["CourseID"] as? String {
+            if let dictionary = notification.object as? NSDictionary,
+                let courseID = dictionary[CourseUpgradeCompletion.courseID] as? String {
                 observer.updateCourseEnrolmentMode(courseID: courseID)
             }
         }

--- a/Source/EnrolledCoursesViewController.swift
+++ b/Source/EnrolledCoursesViewController.swift
@@ -188,7 +188,7 @@ class EnrolledCoursesViewController : OfflineSupportViewController, CoursesConta
         
         coursesContainer.collectionView.reloadData()
         
-        refreshIfNecessary()
+        enrollmentFeed.refresh()
     }
     
     func refreshIfNecessary() {

--- a/Source/HTMLBlockViewController.swift
+++ b/Source/HTMLBlockViewController.swift
@@ -235,9 +235,8 @@ class HTMLBlockViewController: UIViewController, CourseBlockViewController, Prel
     }
 
     private func trackOpenInBrowserBannerEvent(displayName: AnalyticsDisplayName, eventName: AnalyticsEventName) {
-        let mode = environment.interface?.enrollmentForCourse(withID: courseID)?.mode ?? ""
-        let enrollment = EnrollmentMode(rawValue: mode) ?? .none
-
+        let enrollment = environment.interface?.enrollmentForCourse(withID: courseID)?.type ?? .none
+        
         environment.analytics.trackOpenInBrowserBannerEvent(displayName: displayName, eventName: eventName, userType: enrollment.rawValue, courseID: courseID, componentID: blockID ?? "", componentType: block?.typeName ?? "", openURL: block?.webURL?.absoluteString ?? "")
     }
     

--- a/Source/PaymentManager.swift
+++ b/Source/PaymentManager.swift
@@ -10,7 +10,7 @@ import Foundation
 import SwiftyStoreKit
 
 let TestInAppPurchaseID = "org.edx.mobile.integrationtest"
-private let CourseUpgradeCompleteNotification: String = "CourseUpgradeCompleteNotification"
+let CourseUpgradeCompleteNotification: String = "CourseUpgradeCompleteNotification"
 
 
 // In case of completeTransctions SDK returns SwiftyStoreKit.Purchase

--- a/Source/PaymentManager.swift
+++ b/Source/PaymentManager.swift
@@ -9,9 +9,7 @@
 import Foundation
 import SwiftyStoreKit
 
-let TestInAppPurchaseID = "org.edx.mobile.integrationtest"
 let CourseUpgradeCompleteNotification: String = "CourseUpgradeCompleteNotification"
-
 
 // In case of completeTransctions SDK returns SwiftyStoreKit.Purchase
 // And on the in-app purchase SDK returns SwiftyStoreKit.PurchaseDetails

--- a/Source/UpgradeSKUManager.swift
+++ b/Source/UpgradeSKUManager.swift
@@ -1,5 +1,5 @@
 //
-//  CoursePurchaseIDManager.swift
+//  UpgradeSKUManager.swift
 //  edX
 //
 //  Created by Muhammad Umer on 22/12/2021.
@@ -8,10 +8,10 @@
 
 import Foundation
 
-class CoursePurchaseIDManager {
-    static let shared = CoursePurchaseIDManager()
+class UpgradeSKUManager {
+    static let shared = UpgradeSKUManager()
     
-    private lazy var courseMappings: [String : String] = {
+    private lazy var skuMappings: [String : String] = {
         return [
             "course-v1:edX+DemoX+Demo_Course": "org.edx.mobile.integrationtest",
             "course-v1:DemoX+PERF101+course": "org.edx.mobile.test_product1",
@@ -23,11 +23,11 @@ class CoursePurchaseIDManager {
     
     private init() { }
     
-    func purchaseID(for course: OEXCourse) -> String? {
+    func courseSku(for course: OEXCourse) -> String? {
         guard let courseID = course.course_id,
-              courseMappings.keys.contains(courseID),
-              let coursePurchaseID = courseMappings[courseID] else { return nil }
+              skuMappings.keys.contains(courseID),
+              let courseSku = skuMappings[courseID] else { return nil }
         
-        return coursePurchaseID
+        return courseSku
     }
 }

--- a/Source/UpgradeSKUManager.swift
+++ b/Source/UpgradeSKUManager.swift
@@ -11,6 +11,8 @@ import Foundation
 class UpgradeSKUManager {
     static let shared = UpgradeSKUManager()
     
+    /// TODO: Test mapping for course ID to map with registered sku on AppStoreConnect,
+    /// it will be updated with the updated mappings in future
     private lazy var skuMappings: [String : String] = {
         return [
             "course-v1:edX+DemoX+Demo_Course": "org.edx.mobile.integrationtest",
@@ -27,7 +29,6 @@ class UpgradeSKUManager {
         guard let courseID = course.course_id,
               skuMappings.keys.contains(courseID),
               let courseSku = skuMappings[courseID] else { return nil }
-        
         return courseSku
     }
 }

--- a/Source/UserCourseEnrollment.swift
+++ b/Source/UserCourseEnrollment.swift
@@ -9,13 +9,26 @@
 import Foundation
 import edXCore
 
+public enum EnrollmentMode: String {
+    case audit = "audit"
+    case verified = "verified"
+    case honor = "honor"
+    case noIDProfessional = "no-id-professional"
+    case professional = "professional"
+    case credit = "credit"
+    case masters = "masters"
+    case none = "none"
+}
+
 //TODO: remove NSObject when done with @objc
 public class UserCourseEnrollment : NSObject {
     let created: String?
     let mode: String?
     @objc let isActive: Bool
     @objc let course: OEXCourse
-
+    
+    var type: EnrollmentMode
+    
     /** Url if the user has completed a certificate */
     let certificateUrl: String?
 
@@ -23,8 +36,12 @@ public class UserCourseEnrollment : NSObject {
         created = dictionary["created"] as? String
         mode = dictionary["mode"] as? String
         isActive = (dictionary["is_active"] as? NSNumber)?.boolValue ?? false
-
-
+        if let mode = mode {
+            type = EnrollmentMode(rawValue: mode) ?? .audit
+        } else {
+            type = .audit
+        }
+        
         if let certificatesInfo = dictionary["certificate"] as? [String: Any] {
             certificateUrl = certificatesInfo["url"] as? String
         } else {
@@ -42,12 +59,17 @@ public class UserCourseEnrollment : NSObject {
         super.init()
     }
     
-    init(course: OEXCourse, created: String? = nil, mode: String? = nil, isActive: Bool = true, certificateURL: String? = nil) {
+    init(course: OEXCourse, created: String? = nil, mode: String? = nil, isActive: Bool = true, certificateURL: String? = nil, type: EnrollmentMode = .audit) {
         self.created = created
         self.mode = mode
         self.course = course
         self.isActive = isActive
         self.certificateUrl = certificateURL
+        if let mode = mode {
+            self.type = EnrollmentMode(rawValue: mode) ?? .audit
+        } else {
+            self.type = .audit
+        }
     }
     
     convenience init?(json: JSON) {

--- a/Source/UserCourseEnrollment.swift
+++ b/Source/UserCourseEnrollment.swift
@@ -32,14 +32,14 @@ public class UserCourseEnrollment : NSObject {
     /** Url if the user has completed a certificate */
     let certificateUrl: String?
 
-    @objc init?(dictionary: [String: Any]) {
+    @objc init?(dictionary: [String : Any]) {
         created = dictionary["created"] as? String
         mode = dictionary["mode"] as? String
         isActive = (dictionary["is_active"] as? NSNumber)?.boolValue ?? false
         if let mode = mode {
-            type = EnrollmentMode(rawValue: mode) ?? .audit
+            type = EnrollmentMode(rawValue: mode) ?? .none
         } else {
-            type = .audit
+            type = .none
         }
         
         if let certificatesInfo = dictionary["certificate"] as? [String: Any] {
@@ -59,16 +59,16 @@ public class UserCourseEnrollment : NSObject {
         super.init()
     }
     
-    init(course: OEXCourse, created: String? = nil, mode: String? = nil, isActive: Bool = true, certificateURL: String? = nil, type: EnrollmentMode = .audit) {
+    init(course: OEXCourse, created: String? = nil, mode: String? = nil, isActive: Bool = true, certificateURL: String? = nil) {
         self.created = created
         self.mode = mode
         self.course = course
         self.isActive = isActive
         self.certificateUrl = certificateURL
         if let mode = mode {
-            self.type = EnrollmentMode(rawValue: mode) ?? .audit
+            self.type = EnrollmentMode(rawValue: mode) ?? .none
         } else {
-            self.type = .audit
+            self.type = .none
         }
     }
     

--- a/Source/UserCourseEnrollment.swift
+++ b/Source/UserCourseEnrollment.swift
@@ -27,7 +27,7 @@ public class UserCourseEnrollment : NSObject {
     @objc let isActive: Bool
     @objc let course: OEXCourse
     
-    var type: EnrollmentMode
+    var type: EnrollmentMode = .none
     
     /** Url if the user has completed a certificate */
     let certificateUrl: String?
@@ -38,8 +38,6 @@ public class UserCourseEnrollment : NSObject {
         isActive = (dictionary["is_active"] as? NSNumber)?.boolValue ?? false
         if let mode = mode {
             type = EnrollmentMode(rawValue: mode) ?? .none
-        } else {
-            type = .none
         }
         
         if let certificatesInfo = dictionary["certificate"] as? [String: Any] {
@@ -67,8 +65,6 @@ public class UserCourseEnrollment : NSObject {
         self.certificateUrl = certificateURL
         if let mode = mode {
             self.type = EnrollmentMode(rawValue: mode) ?? .none
-        } else {
-            self.type = .none
         }
     }
     

--- a/Source/ValuePropComponentView.swift
+++ b/Source/ValuePropComponentView.swift
@@ -116,7 +116,7 @@ class ValuePropComponentView: UIView {
         container.addSubview(upgradeButton)
         addSubview(container)
         
-        guard let course = course, let courseSku = UpgradeSKUManager.shared.purchaseID(for: course) else { return }
+        guard let course = course, let courseSku = UpgradeSKUManager.shared.courseSku(for: course) else { return }
         PaymentManager.shared.productPrice(courseSku) { [weak self] price in
             if let price = price {
                 self?.upgradeButton.setPrice(price)

--- a/Source/ValuePropComponentView.swift
+++ b/Source/ValuePropComponentView.swift
@@ -116,8 +116,8 @@ class ValuePropComponentView: UIView {
         container.addSubview(upgradeButton)
         addSubview(container)
         
-        guard let course = course, let coursePurchaseID = CoursePurchaseIDManager.shared.purchaseID(for: course) else { return }
-        PaymentManager.shared.productPrice(coursePurchaseID) { [weak self] price in
+        guard let course = course, let courseSku = UpgradeSKUManager.shared.purchaseID(for: course) else { return }
+        PaymentManager.shared.productPrice(courseSku) { [weak self] price in
             if let price = price {
                 self?.upgradeButton.setPrice(price)
             }

--- a/Source/ValuePropComponentView.swift
+++ b/Source/ValuePropComponentView.swift
@@ -69,10 +69,10 @@ class ValuePropComponentView: UIView {
         return OEXMutableTextStyle(weight: .normal, size: .small, color: environment.styles.neutralXXDark())
     }()
 
+    private lazy var course: OEXCourse? = environment.dataManager.enrollmentManager.enrolledCourseWithID(courseID: courseID)?.course
+    
     private lazy var pacing: String = {
-        let course = environment.dataManager.enrollmentManager.enrolledCourseWithID(courseID: courseID)?.course
         let selfPaced = course?.isSelfPaced ?? false
-
         return selfPaced ? "self" : "instructor"
     }()
 
@@ -115,8 +115,9 @@ class ValuePropComponentView: UIView {
         container.addSubview(infoMessagesView)
         container.addSubview(upgradeButton)
         addSubview(container)
-
-        PaymentManager.shared.productPrice(TestInAppPurchaseID) { [weak self] price in
+        
+        guard let course = course, let coursePurchaseID = CoursePurchaseIDManager.shared.purchaseID(for: course) else { return }
+        PaymentManager.shared.productPrice(coursePurchaseID) { [weak self] price in
             if let price = price {
                 self?.upgradeButton.setPrice(price)
             }

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -147,7 +147,7 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
                 }
                 
                 break
-            case .error(let purchaseError):
+            case .error:
                 self?.enableAppTouches()
                 self?.upgradeButton.stopAnimating()
                 

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -72,7 +72,8 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
         
         configureView()
         
-        PaymentManager.shared.productPrice(TestInAppPurchaseID) { [weak self] price in
+        guard let coursePurchaseID = CoursePurchaseIDManager.shared.purchaseID(for: course) else { return }
+        PaymentManager.shared.productPrice(coursePurchaseID) { [weak self] price in
             if let price = price {
                 self?.upgradeButton.setPrice(price)
             }
@@ -126,10 +127,12 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
     }
     
     private func upgradeCourse() {
+        guard let coursePurchaseID = CoursePurchaseIDManager.shared.purchaseID(for: course) else { return }
+        
         disableAppTouchs()
         
         let pacing = course.isSelfPaced ? "self" : "instructor"
-        environment.analytics.trackUpgradeNow(with: course.course_id ?? "", blockID: TestInAppPurchaseID, pacing: pacing)
+        environment.analytics.trackUpgradeNow(with: course.course_id ?? "", blockID: coursePurchaseID, pacing: pacing)
         
         CourseUpgradeHandler.shared.upgradeCourse(course, environment: environment) { [weak self] status in
             switch status {
@@ -144,7 +147,7 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
                 }
                 
                 break
-            case .error:
+            case .error(let purchaseError):
                 self?.enableAppTouches()
                 self?.upgradeButton.stopAnimating()
                 

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -132,11 +132,6 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
         environment.analytics.trackUpgradeNow(with: course.course_id ?? "", blockID: TestInAppPurchaseID, pacing: pacing)
         
         CourseUpgradeHandler.shared.upgradeCourse(course, environment: environment) { [weak self] status in
-            guard let topController = UIApplication.shared.topMostController() else {
-                self?.enableAppTouches()
-                return
-            }
-            
             switch status {
             case .payment:
                 self?.upgradeButton.stopAnimating()
@@ -144,20 +139,17 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
             case .complete:
                 self?.enableAppTouches()
                 self?.upgradeButton.isHidden = true
-                let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.successAlertTitle, message: Strings.CourseUpgrade.successAlertMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
-                alertController.addButton(withTitle: Strings.CourseUpgrade.successAlertContinue, style: .cancel) { action in
-                    // TODO: continue button handling
+                self?.dismiss(animated: true) {
+                    CourseUpgradeCompletion.shared.handleCompletion(state: .success(self?.course.course_id ?? "", nil))
                 }
+                
                 break
             case .error:
                 self?.enableAppTouches()
                 self?.upgradeButton.stopAnimating()
-                let alertController = UIAlertController().showAlert(withTitle: Strings.CourseUpgrade.failureAlertTitle, message: Strings.CourseUpgrade.failureAlertMessage, cancelButtonTitle: nil, onViewController: topController) { _, _, _ in }
-                alertController.addButton(withTitle: Strings.CourseUpgrade.failureAlertGetHelp) { action in
-                    // TODO: Add option to send email
-                }
-                alertController.addButton(withTitle: Strings.close, style: .default) { action in
-                    // TODO: Close button handling
+                
+                self?.dismiss(animated: true) {
+                    CourseUpgradeCompletion.shared.handleCompletion(state: .error)
                 }
                 break
             default:

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -119,8 +119,8 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
         }
         
         upgradeButton.snp.makeConstraints { make in
-            make.leading.equalTo(valuePropTableView)
-            make.trailing.equalTo(valuePropTableView)
+            make.leading.equalTo(view).offset(StandardHorizontalMargin)
+            make.trailing.equalTo(view).inset(StandardHorizontalMargin)
             make.bottom.equalTo(safeBottom).inset(StandardVerticalMargin)
             make.height.equalTo(CourseUpgradeButtonView.height)
         }

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -72,7 +72,7 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
         
         configureView()
         
-        guard let courseSku = UpgradeSKUManager.shared.purchaseID(for: course) else { return }
+        guard let courseSku = UpgradeSKUManager.shared.courseSku(for: course) else { return }
         PaymentManager.shared.productPrice(courseSku) { [weak self] price in
             if let price = price {
                 self?.upgradeButton.setPrice(price)
@@ -127,7 +127,7 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
     }
     
     private func upgradeCourse() {
-        guard let courseSku = UpgradeSKUManager.shared.purchaseID(for: course) else { return }
+        guard let courseSku = UpgradeSKUManager.shared.courseSku(for: course) else { return }
         
         disableAppTouchs()
         

--- a/Source/ValuePropDetailViewController.swift
+++ b/Source/ValuePropDetailViewController.swift
@@ -72,8 +72,8 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
         
         configureView()
         
-        guard let coursePurchaseID = CoursePurchaseIDManager.shared.purchaseID(for: course) else { return }
-        PaymentManager.shared.productPrice(coursePurchaseID) { [weak self] price in
+        guard let courseSku = UpgradeSKUManager.shared.purchaseID(for: course) else { return }
+        PaymentManager.shared.productPrice(courseSku) { [weak self] price in
             if let price = price {
                 self?.upgradeButton.setPrice(price)
             }
@@ -127,12 +127,12 @@ class ValuePropDetailViewController: UIViewController, InterfaceOrientationOverr
     }
     
     private func upgradeCourse() {
-        guard let coursePurchaseID = CoursePurchaseIDManager.shared.purchaseID(for: course) else { return }
+        guard let courseSku = UpgradeSKUManager.shared.purchaseID(for: course) else { return }
         
         disableAppTouchs()
         
         let pacing = course.isSelfPaced ? "self" : "instructor"
-        environment.analytics.trackUpgradeNow(with: course.course_id ?? "", blockID: coursePurchaseID, pacing: pacing)
+        environment.analytics.trackUpgradeNow(with: course.course_id ?? "", blockID: courseSku, pacing: pacing)
         
         CourseUpgradeHandler.shared.upgradeCourse(course, environment: environment) { [weak self] status in
             switch status {

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -195,7 +195,7 @@
 		5F59B40026AFF5B000D6CA3E /* ProfileOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F59B3FF26AFF5B000D6CA3E /* ProfileOptionsViewController.swift */; };
 		5F5FC00B269DA8C500F92B8F /* ValuePropMessagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5FC00A269DA8C500F92B8F /* ValuePropMessagesView.swift */; };
 		5F5FC00D269DA9F800F92B8F /* CourseUpgradeButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5FC00C269DA9F800F92B8F /* CourseUpgradeButtonView.swift */; };
-		5F6919E02773090F007F00AD /* CoursePurchaseIDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6919DF2773090F007F00AD /* CoursePurchaseIDManager.swift */; };
+		5F6919E02773090F007F00AD /* UpgradeSKUManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6919DF2773090F007F00AD /* UpgradeSKUManager.swift */; };
 		5F6AD05B27467898007686C2 /* ProfileOptions.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5F6AD05927467898007686C2 /* ProfileOptions.strings */; };
 		5F6F2B60255AABA400AA3708 /* Inter-SemiBoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5F6F2B56255AABA200AA3708 /* Inter-SemiBoldItalic.ttf */; };
 		5F6F2B61255AABA400AA3708 /* Inter-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5F6F2B57255AABA300AA3708 /* Inter-ExtraBold.ttf */; };
@@ -1268,7 +1268,7 @@
 		5F64839D274CEB5B00DB38E0 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/ProfileOptions.strings"; sourceTree = "<group>"; };
 		5F64839E274CEB5E00DB38E0 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/ProfileOptions.strings; sourceTree = "<group>"; };
 		5F64839F274CEB6000DB38E0 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/ProfileOptions.strings; sourceTree = "<group>"; };
-		5F6919DF2773090F007F00AD /* CoursePurchaseIDManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePurchaseIDManager.swift; sourceTree = "<group>"; };
+		5F6919DF2773090F007F00AD /* UpgradeSKUManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradeSKUManager.swift; sourceTree = "<group>"; };
 		5F6AD05A27467898007686C2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ProfileOptions.strings; sourceTree = "<group>"; };
 		5F6F2B56255AABA200AA3708 /* Inter-SemiBoldItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-SemiBoldItalic.ttf"; sourceTree = "<group>"; };
 		5F6F2B57255AABA300AA3708 /* Inter-ExtraBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-ExtraBold.ttf"; sourceTree = "<group>"; };
@@ -2580,7 +2580,7 @@
 				E0357C4626CA59120041947A /* CourseUpgradeHandler.swift */,
 				E0357C4826CB80BC0041947A /* CourseUpgradeAPI.swift */,
 				5F45030D276B4B290054D266 /* CourseUpgradeCompletion.swift */,
-				5F6919DF2773090F007F00AD /* CoursePurchaseIDManager.swift */,
+				5F6919DF2773090F007F00AD /* UpgradeSKUManager.swift */,
 			);
 			name = Payment;
 			sourceTree = "<group>";
@@ -5215,7 +5215,7 @@
 				E0A2461F1D5DA12A0066C766 /* AppStoreConfig.swift in Sources */,
 				7778F0981ABB1A6C00B4CDA0 /* NSError+OEXKnownErrors.m in Sources */,
 				224F1F532067B4E0009B3639 /* CustomSlider.swift in Sources */,
-				5F6919E02773090F007F00AD /* CoursePurchaseIDManager.swift in Sources */,
+				5F6919E02773090F007F00AD /* UpgradeSKUManager.swift in Sources */,
 				223972E11FE92BB500B2BBEC /* EnrolledTabBarViewController.swift in Sources */,
 				B4B6D6041A949EFC000F44E8 /* OEXRegistrationRestriction.m in Sources */,
 				77BFD86A1BB9E15B001D7BE5 /* Strings.swift in Sources */,

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		5F59B40026AFF5B000D6CA3E /* ProfileOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F59B3FF26AFF5B000D6CA3E /* ProfileOptionsViewController.swift */; };
 		5F5FC00B269DA8C500F92B8F /* ValuePropMessagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5FC00A269DA8C500F92B8F /* ValuePropMessagesView.swift */; };
 		5F5FC00D269DA9F800F92B8F /* CourseUpgradeButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5FC00C269DA9F800F92B8F /* CourseUpgradeButtonView.swift */; };
+		5F6919E02773090F007F00AD /* CoursePurchaseIDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6919DF2773090F007F00AD /* CoursePurchaseIDManager.swift */; };
 		5F6AD05B27467898007686C2 /* ProfileOptions.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5F6AD05927467898007686C2 /* ProfileOptions.strings */; };
 		5F6F2B60255AABA400AA3708 /* Inter-SemiBoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5F6F2B56255AABA200AA3708 /* Inter-SemiBoldItalic.ttf */; };
 		5F6F2B61255AABA400AA3708 /* Inter-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5F6F2B57255AABA300AA3708 /* Inter-ExtraBold.ttf */; };
@@ -1267,6 +1268,7 @@
 		5F64839D274CEB5B00DB38E0 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/ProfileOptions.strings"; sourceTree = "<group>"; };
 		5F64839E274CEB5E00DB38E0 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/ProfileOptions.strings; sourceTree = "<group>"; };
 		5F64839F274CEB6000DB38E0 /* vi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = vi; path = vi.lproj/ProfileOptions.strings; sourceTree = "<group>"; };
+		5F6919DF2773090F007F00AD /* CoursePurchaseIDManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePurchaseIDManager.swift; sourceTree = "<group>"; };
 		5F6AD05A27467898007686C2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ProfileOptions.strings; sourceTree = "<group>"; };
 		5F6F2B56255AABA200AA3708 /* Inter-SemiBoldItalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-SemiBoldItalic.ttf"; sourceTree = "<group>"; };
 		5F6F2B57255AABA300AA3708 /* Inter-ExtraBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-ExtraBold.ttf"; sourceTree = "<group>"; };
@@ -2578,6 +2580,7 @@
 				E0357C4626CA59120041947A /* CourseUpgradeHandler.swift */,
 				E0357C4826CB80BC0041947A /* CourseUpgradeAPI.swift */,
 				5F45030D276B4B290054D266 /* CourseUpgradeCompletion.swift */,
+				5F6919DF2773090F007F00AD /* CoursePurchaseIDManager.swift */,
 			);
 			name = Payment;
 			sourceTree = "<group>";
@@ -5212,6 +5215,7 @@
 				E0A2461F1D5DA12A0066C766 /* AppStoreConfig.swift in Sources */,
 				7778F0981ABB1A6C00B4CDA0 /* NSError+OEXKnownErrors.m in Sources */,
 				224F1F532067B4E0009B3639 /* CustomSlider.swift in Sources */,
+				5F6919E02773090F007F00AD /* CoursePurchaseIDManager.swift in Sources */,
 				223972E11FE92BB500B2BBEC /* EnrolledTabBarViewController.swift in Sources */,
 				B4B6D6041A949EFC000F44E8 /* OEXRegistrationRestriction.m in Sources */,
 				77BFD86A1BB9E15B001D7BE5 /* Strings.swift in Sources */,

--- a/edX.xcodeproj/project.pbxproj
+++ b/edX.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		5F2C5A19242C99EE00FBF986 /* CollectionPaginationManipulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2C5A18242C99EE00FBF986 /* CollectionPaginationManipulator.swift */; };
 		5F371470260B3BC9004937DA /* Observeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F37146F260B3BC9004937DA /* Observeable.swift */; };
 		5F3A619A265796A7005329A4 /* CalendarSyncConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3A6199265796A7005329A4 /* CalendarSyncConfig.swift */; };
+		5F45030E276B4B290054D266 /* CourseUpgradeCompletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F45030D276B4B290054D266 /* CourseUpgradeCompletion.swift */; };
 		5F46A7CC24ADFFA300347EFC /* CourseDateViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F46A7C724ADFFA200347EFC /* CourseDateViewCell.swift */; };
 		5F46A7CE24ADFFA300347EFC /* TimelinePoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F46A7C924ADFFA200347EFC /* TimelinePoint.swift */; };
 		5F46A7CF24ADFFA300347EFC /* Timeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F46A7CB24ADFFA300347EFC /* Timeline.swift */; };
@@ -1246,6 +1247,7 @@
 		5F2C5A18242C99EE00FBF986 /* CollectionPaginationManipulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionPaginationManipulator.swift; sourceTree = "<group>"; };
 		5F37146F260B3BC9004937DA /* Observeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observeable.swift; sourceTree = "<group>"; };
 		5F3A6199265796A7005329A4 /* CalendarSyncConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSyncConfig.swift; sourceTree = "<group>"; };
+		5F45030D276B4B290054D266 /* CourseUpgradeCompletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseUpgradeCompletion.swift; sourceTree = "<group>"; };
 		5F46A7C724ADFFA200347EFC /* CourseDateViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseDateViewCell.swift; sourceTree = "<group>"; };
 		5F46A7C924ADFFA200347EFC /* TimelinePoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimelinePoint.swift; sourceTree = "<group>"; };
 		5F46A7CB24ADFFA300347EFC /* Timeline.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Timeline.swift; sourceTree = "<group>"; };
@@ -2575,6 +2577,7 @@
 				5F54D99C26B9228500F1EA71 /* PaymentManager.swift */,
 				E0357C4626CA59120041947A /* CourseUpgradeHandler.swift */,
 				E0357C4826CB80BC0041947A /* CourseUpgradeAPI.swift */,
+				5F45030D276B4B290054D266 /* CourseUpgradeCompletion.swift */,
 			);
 			name = Payment;
 			sourceTree = "<group>";
@@ -5469,6 +5472,7 @@
 				B78823A51FC6F59A00F9CD61 /* RegistrationFormFieldView.swift in Sources */,
 				77DC295E1ABC9D4400FAD22C /* NSObject+OEXReplaceNull.m in Sources */,
 				B4B6D6031A949EFC000F44E8 /* OEXRegistrationOption.m in Sources */,
+				5F45030E276B4B290054D266 /* CourseUpgradeCompletion.swift in Sources */,
 				223895D01F25CF76005B9C15 /* SwipeActionButton.swift in Sources */,
 				B78823B01FC80CBB00F9CD61 /* RegistrationFieldControllerFactory.swift in Sources */,
 				5D43B1871B0C1F9200448B52 /* PostsViewController.swift in Sources */,


### PR DESCRIPTION
### Description

[LEARNER-8668](https://openedx.atlassian.net/browse/LEARNER-8668)

After successfully purchasing a course, when the modal dismisses, the VP banner or button is no longer visible because the user should have a verified seat in the course

The trigger for this is a successful purchase (not tied to the "Continue" button of the Success alert)

### How to test this PR

- [x] Make purchase on a course
- [x] Upgrade banner should be gone after successful purchase on `My Courses` screen
