### PR TITLE
refactor: remove username and email from identify

### DIFF
--- a/Source/FullStoryAnalyticsTracker.swift
+++ b/Source/FullStoryAnalyticsTracker.swift
@@ -16,10 +16,8 @@ class FullStoryAnalyticsTracker: NSObject, OEXAnalyticsTracker {
     }
     
     func identifyUser(_ user: OEXUserDetails?) {
-        guard let userID = user?.userId?.stringValue, let email = user?.email, let username = user?.username else { return }
+        guard let userID = user?.userId?.stringValue else { return }
         let traits: [String: String] = [
-            "email": email,
-            "username": username,
             "displayName": userID
         ]
         

--- a/Source/FullStoryAnalyticsTracker.swift
+++ b/Source/FullStoryAnalyticsTracker.swift
@@ -17,11 +17,8 @@ class FullStoryAnalyticsTracker: NSObject, OEXAnalyticsTracker {
     
     func identifyUser(_ user: OEXUserDetails?) {
         guard let userID = user?.userId?.stringValue else { return }
-        let traits: [String: String] = [
-            "displayName": userID
-        ]
         
-        FS.identify(userID, userVars: traits)
+        FS.identify(userID, userVars: ["displayName": userID])
     }
     
     func clearIdentifiedUser() {


### PR DESCRIPTION
Removing username and email from the identify call as per the web team. 
